### PR TITLE
ci: eks: Private networking and spot instances

### DIFF
--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Add nodegroup
         run: |
-          ./eksctl create nodegroup --cluster ${{ env.clusterName }} --nodes 2
+          ./eksctl create nodegroup --cluster ${{ env.clusterName }} --nodes 2 --node-private-networking --spot --managed
 
       - name: Enable Relay
         run: |


### PR DESCRIPTION
Reduces the cost and does not use public IPv4 addresses

Signed-off-by: Thomas Graf <thomas@cilium.io>