### PR TITLE
clustermesh: Start using clustermesh-apiserver:1.9.2

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -73,14 +73,6 @@ jobs:
 
           cmd/cilium/cilium clustermesh connect --context kind-cluster1 --destination-context kind-cluster2
 
-          # Workaround: Restart cilium to work around fsnotify bug
-          kubectl --context kind-cluster1 -n kube-system delete pod -l k8s-app=cilium
-          kubectl --context kind-cluster2 -n kube-system delete pod -l k8s-app=cilium
-
-          # Wait for Cilium to come back up
-          cmd/cilium/cilium status --context kind-cluster1 --wait
-          cmd/cilium/cilium status --context kind-cluster2 --wait
-
           # Wait for cluster connections to be estblished
           cmd/cilium/cilium clustermesh status --context kind-cluster1 --wait
           cmd/cilium/cilium clustermesh status --context kind-cluster2 --wait

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -56,7 +56,7 @@ const (
 	ClusterMeshDeploymentName       = "clustermesh-apiserver"
 	ClusterMeshServiceAccountName   = "clustermesh-apiserver"
 	ClusterMeshClusterRoleName      = "clustermesh-apiserver"
-	ClusterMeshApiserverImage       = "quay.io/cilium/clustermesh-apiserver:latest"
+	ClusterMeshApiserverImage       = "quay.io/cilium/clustermesh-apiserver:" + Version
 	ClusterMeshServiceName          = "clustermesh-apiserver"
 	ClusterMeshSecretName           = "cilium-clustermesh" // Secret which contains the clustermesh configuration
 	ClusterMeshServerSecretName     = "clustermesh-apiserver-server-certs"


### PR DESCRIPTION
With the 1.9.2 release, all known issues have been resolved. It also
allows to remove the workaround that has been in place so far.

Signed-off-by: Thomas Graf <thomas@cilium.io>