### PR TITLE
install: Add missing "get" op for customresourcedefinitions

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -96,7 +96,7 @@ var ciliumClusterRole = &rbacv1.ClusterRole{
 		{
 			APIGroups: []string{"apiextensions.k8s.io"},
 			Resources: []string{"customresourcedefinitions"},
-			Verbs:     []string{"create", "list", "watch", "update"},
+			Verbs:     []string{"get", "create", "list", "watch", "update"},
 		},
 		{
 			APIGroups: []string{"cilium.io"},


### PR DESCRIPTION
Cilium Agent has the "get" operation registered in its ClusterRole for
CRDs. It was missing in the install step.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
