### PR TITLE
add make targets to build release binaries for Linux and MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# release tarballs
+/release

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ GIT_BRANCH = $(shell which git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEA
 GIT_HASH = $(shell which git >/dev/null 2>&1 && git rev-parse --short HEAD)
 
 TEST_TIMEOUT ?= 5s
+RELEASE_UID ?= $(shell id -u)
+RELEASE_GID ?= $(shell id -g)
 
 $(TARGET):
 	$(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) \
@@ -18,12 +20,47 @@ $(TARGET):
 		-o $(TARGET) \
 		./cmd/cilium
 
+release:
+	docker run \
+		--env "RELEASE_UID=$(RELEASE_UID)" \
+		--env "RELEASE_GID=$(RELEASE_GID)" \
+		--rm \
+		--workdir /cilium \
+		--volume `pwd`:/cilium docker.io/library/golang:1.15.7-alpine3.13 \
+		sh -c "apk add --no-cache make && make local-release"
+
+local-release: clean
+	for OS in darwin linux; do \
+		EXT=; \
+		ARCHS=; \
+		case $$OS in \
+			darwin) \
+				ARCHS='amd64'; \
+				;; \
+			linux) \
+				ARCHS='386 amd64 arm arm64'; \
+				;; \
+		esac; \
+		for ARCH in $$ARCHS; do \
+			echo Building release binary for $$OS/$$ARCH...; \
+			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
+			env GOOS=$$OS GOARCH=$$ARCH $(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/cilium-cli/internal/cli/cmd.Version=${VERSION}'" -o release/$$OS/$$ARCH/$(TARGET)$$EXT ./cmd/cilium; \
+			tar -czf release/$(TARGET)-$$OS-$$ARCH.tar.gz -C release/$$OS/$$ARCH $(TARGET)$$EXT; \
+			(cd release && sha256sum $(TARGET)-$$OS-$$ARCH.tar.gz > $(TARGET)-$$OS-$$ARCH.tar.gz.sha256sum); \
+		done; \
+		rm -r release/$$OS; \
+	done; \
+	if [ $$(id -u) -eq 0 -a -n "$$RELEASE_UID" -a -n "$$RELEASE_GID" ]; then \
+		chown -R "$$RELEASE_UID:$$RELEASE_GID" release; \
+	fi
+
 install: $(TARGET)
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -f $(TARGET)
+	rm -rf ./release
 
 test:
 	go test -timeout=$(TEST_TIMEOUT) -race -cover $$(go list ./...)
@@ -50,4 +87,4 @@ staticcheck:
 vet:
 	go vet $$(go list ./...)
 
-.PHONY: $(TARGET) install clean test bench check gofmt ineffassign lint staticcheck vet
+.PHONY: $(TARGET) release local-release install clean test bench check gofmt ineffassign lint staticcheck vet


### PR DESCRIPTION
This allows building release binaries for the following platforms:

  - darwin/amd64
  - linux/386
  - linux/amd64
  - linux/arm
  - linux/arm64

Unfortunately, Windows is not supported yet due to syslog usage by the cilium logger.

This PR is based on how it's done for the Hubble CLI.

NOTE: ~This PR depends on #62~