### PR TITLE
install: fix cluster name autodetection with dots

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -42,7 +42,7 @@ var (
 		},
 	}
 
-	clusterNameValidation = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])$`)
+	clusterNameValidation = regexp.MustCompile(`^[a-z0-9]([-.a-z0-9]*[a-z0-9])$`)
 )
 
 func (p InstallParameters) checkDisabled(name string) bool {
@@ -149,11 +149,6 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		if k.params.DatapathMode != "" {
 			k.Log("🔮 Auto-detected datapath mode: %s", k.params.DatapathMode)
 		}
-	}
-
-	if strings.Contains(k.params.ClusterName, ".") {
-		k.Log("❌ Cluster name %q cannot contain dots", k.params.ClusterName)
-		return fmt.Errorf("invalid cluster name, dots are not allowed")
 	}
 
 	if !clusterNameValidation.MatchString(k.params.ClusterName) {


### PR DESCRIPTION
Previously, dots were disallowed in cluster names per commit
46db7b821ad9 ("install: Reject cluster names with dots"). This was due
to the fact that the Hubble server certificate would otherwise include
the dots which would lead to an unexpected commonName in the
certificate, making Relay unable to authenticate the Hubble servers.
This was fixed in commit 942d4325208c ("hubble: support clusters with
dots in their name").

Update the cluster name autodetection to allow cluster names with dots.
This e.g. allows to seamlessly use `cilium install` (i.e. without
setting `--cluster-name`) on clusters created by `eksctl` which by
default uses the naming scheme `<cluster-name>.<region>.eksctl.io`.