### PR TITLE
Allow specifying agent and operator image via CLI options

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/install"
 
 	"github.com/spf13/cobra"
@@ -69,6 +70,8 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().BoolVar(&params.Encryption, "encryption", false, "Enable encryption of all workloads traffic")
 	cmd.Flags().BoolVar(&params.NodeEncryption, "node-encryption", false, "Enable encryption of all node to node traffic")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Set ConfigMap entries (key=value)")
+	cmd.Flags().StringVar(&params.AgentImage, "agent-image", defaults.AgentImage, "Image path to use for Cilium agent")
+	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", defaults.OperatorImage, "Image path to use for Cilium operator")
 
 	cmd.Flags().StringVar(&params.Azure.ResourceGroupName, "azure-resource-group", "", "Azure resource group name the cluster is in")
 	cmd.Flags().StringVar(&params.Azure.TenantID, "azure-tenant-id", "", "Azure tenant ID")

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium-cli/defaults"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/go-openapi/strfmt"
 	"gopkg.in/check.v1"
@@ -165,43 +167,43 @@ func (b *StatusSuite) TestStatus(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(collector, check.Not(check.IsNil))
 
-	client.setDaemonSet("kube-system", ciliumDaemonSetName, "k8s-app=cilium", 10, 10, 10, 0)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 10, 10, 0)
 	status, err := collector.Status(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Not(check.IsNil))
-	c.Assert(status.PodState[ciliumDaemonSetName].Desired, check.Equals, 10)
-	c.Assert(status.PodState[ciliumDaemonSetName].Ready, check.Equals, 10)
-	c.Assert(status.PodState[ciliumDaemonSetName].Available, check.Equals, 10)
-	c.Assert(status.PodState[ciliumDaemonSetName].Unavailable, check.Equals, 0)
-	c.Assert(status.PhaseCount[ciliumDaemonSetName][string(corev1.PodRunning)], check.Equals, 10)
-	c.Assert(status.PhaseCount[ciliumDaemonSetName][string(corev1.PodFailed)], check.Equals, 0)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Desired, check.Equals, 10)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Ready, check.Equals, 10)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Available, check.Equals, 10)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Unavailable, check.Equals, 0)
+	c.Assert(status.PhaseCount[defaults.AgentDaemonSetName][string(corev1.PodRunning)], check.Equals, 10)
+	c.Assert(status.PhaseCount[defaults.AgentDaemonSetName][string(corev1.PodFailed)], check.Equals, 0)
 	c.Assert(len(status.CiliumStatus), check.Equals, 10)
 
 	client.reset()
-	client.setDaemonSet("kube-system", ciliumDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
 	status, err = collector.Status(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Not(check.IsNil))
-	c.Assert(status.PodState[ciliumDaemonSetName].Desired, check.Equals, 10)
-	c.Assert(status.PodState[ciliumDaemonSetName].Ready, check.Equals, 5)
-	c.Assert(status.PodState[ciliumDaemonSetName].Available, check.Equals, 5)
-	c.Assert(status.PodState[ciliumDaemonSetName].Unavailable, check.Equals, 5)
-	c.Assert(status.PhaseCount[ciliumDaemonSetName][string(corev1.PodRunning)], check.Equals, 5)
-	c.Assert(status.PhaseCount[ciliumDaemonSetName][string(corev1.PodFailed)], check.Equals, 5)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Desired, check.Equals, 10)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Ready, check.Equals, 5)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Available, check.Equals, 5)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Unavailable, check.Equals, 5)
+	c.Assert(status.PhaseCount[defaults.AgentDaemonSetName][string(corev1.PodRunning)], check.Equals, 5)
+	c.Assert(status.PhaseCount[defaults.AgentDaemonSetName][string(corev1.PodFailed)], check.Equals, 5)
 	c.Assert(len(status.CiliumStatus), check.Equals, 5)
 
 	client.reset()
-	client.setDaemonSet("kube-system", ciliumDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
 	delete(client.status, "cilium-2")
 	status, err = collector.Status(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Not(check.IsNil))
-	c.Assert(status.PodState[ciliumDaemonSetName].Desired, check.Equals, 10)
-	c.Assert(status.PodState[ciliumDaemonSetName].Ready, check.Equals, 5)
-	c.Assert(status.PodState[ciliumDaemonSetName].Available, check.Equals, 5)
-	c.Assert(status.PodState[ciliumDaemonSetName].Unavailable, check.Equals, 5)
-	c.Assert(status.PhaseCount[ciliumDaemonSetName][string(corev1.PodRunning)], check.Equals, 5)
-	c.Assert(status.PhaseCount[ciliumDaemonSetName][string(corev1.PodFailed)], check.Equals, 5)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Desired, check.Equals, 10)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Ready, check.Equals, 5)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Available, check.Equals, 5)
+	c.Assert(status.PodState[defaults.AgentDaemonSetName].Unavailable, check.Equals, 5)
+	c.Assert(status.PhaseCount[defaults.AgentDaemonSetName][string(corev1.PodRunning)], check.Equals, 5)
+	c.Assert(status.PhaseCount[defaults.AgentDaemonSetName][string(corev1.PodFailed)], check.Equals, 5)
 	c.Assert(len(status.CiliumStatus), check.Equals, 5)
 	c.Assert(status.CiliumStatus["cilium-2"], check.IsNil)
 }
@@ -214,7 +216,7 @@ func (b *StatusSuite) TestFormat(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(collector, check.Not(check.IsNil))
 
-	client.setDaemonSet("kube-system", ciliumDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
 	delete(client.status, "cilium-2")
 
 	client.addPod("kube-system", "cilium-operator-1", "k8s-app=cilium-operator", []corev1.Container{{Image: "cilium-operator:1.9"}}, corev1.PodStatus{Phase: corev1.PodRunning})

--- a/status/status.go
+++ b/status/status.go
@@ -279,9 +279,9 @@ func (s *Status) Format() string {
 	w := tabwriter.NewWriter(&buf, 0, 0, 4, ' ', 0)
 
 	fmt.Fprintf(w, Yellow+"    /¯¯\\\n")
-	fmt.Fprintf(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\tCilium:\t"+s.statusSummary(ciliumDaemonSetName)+"\n")
-	fmt.Fprintf(w, Cyan+" \\__"+Red+"/¯¯\\"+Green+"__/"+Reset+"\tOperator:\t"+s.statusSummary(operatorDeploymentName)+"\n")
-	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tHubble:\t"+s.statusSummary(relayDeploymentName)+"\n")
+	fmt.Fprintf(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\tCilium:\t"+s.statusSummary(defaults.AgentDaemonSetName)+"\n")
+	fmt.Fprintf(w, Cyan+" \\__"+Red+"/¯¯\\"+Green+"__/"+Reset+"\tOperator:\t"+s.statusSummary(defaults.OperatorDeploymentName)+"\n")
+	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tHubble:\t"+s.statusSummary(defaults.RelayDeploymentName)+"\n")
 	fmt.Fprintf(w, Green+" \\__"+Blue+"/¯¯\\"+Magenta+"__/"+Reset+"\tClusterMesh:\t"+s.statusSummary(defaults.ClusterMeshDeploymentName)+"\n")
 	fmt.Fprintf(w, Blue+"    \\__/\n"+Reset)
 	fmt.Fprintf(w, "\n")


### PR DESCRIPTION
Everything is already set up to take a custom agent and/or operator
image and the Hubble relay image can already be specified as a CLI
options. Thus, wire up the `--agent-image` and `--operator-image` options
for the `install` sub-command. This makes it very easy to install a
custom locally built development image in a cluster, e.g.:
    
    $ cilium install \
      --agent-image quay.io/tklauser/cilium \
      --operator-image quay.io/tklauser/operator-aws \
      --version latest

The second commit contains a small cleanup to re-use the constants from the `defaults` package for the `DaemonSet`/`Deployment` names.