### PR TITLE
internal/k8s: fix cluster name autodetection for eksctl created clusters

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -327,7 +327,7 @@ func (c *Client) AutodetectFlavor(ctx context.Context) (f Flavor, err error) {
 	}
 
 	// When creating a cluster with kind create cluster --name foo,
-	// the context and clustername are kind-foo.
+	// the context and cluster name are kind-foo.
 	if strings.HasPrefix(c.ClusterName(), "kind-") || strings.HasPrefix(c.ContextName(), "kind-") {
 		f.Kind = KindKind
 		return
@@ -335,6 +335,14 @@ func (c *Client) AutodetectFlavor(ctx context.Context) (f Flavor, err error) {
 
 	if strings.HasPrefix(c.ClusterName(), "gke_") {
 		f.Kind = KindGKE
+		return
+	}
+
+	// When creating a cluster with eksctl create cluster --name foo,
+	// the cluster name is foo.<region>.eksctl.io
+	if strings.HasSuffix(c.ClusterName(), ".eksctl.io") {
+		f.ClusterName = strings.ReplaceAll(c.ClusterName(), ".", "-")
+		f.Kind = KindEKS
 		return
 	}
 


### PR DESCRIPTION
Clusters created using `eksctl create cluster--name foo` will have their
cluster name set to `foo.<region>.eksctl.io`. This will break cluster
name autodetection due to the fact that currently, dots are not allowed
in cluster names (see cilium/cilium-cli#71). Thus, replace dots by
hyphens for the purpose of the Cilium CLI.

This will allow to seamlessly use `cilium install` (i.e. without setting
`--cluster-name` explicitly) on `eksctl`-created clusters.