### PR TITLE
internal/cli/cmd: fix operator image autodetection

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/install"
 
 	"github.com/spf13/cobra"
@@ -70,8 +69,8 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().BoolVar(&params.Encryption, "encryption", false, "Enable encryption of all workloads traffic")
 	cmd.Flags().BoolVar(&params.NodeEncryption, "node-encryption", false, "Enable encryption of all node to node traffic")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Set ConfigMap entries (key=value)")
-	cmd.Flags().StringVar(&params.AgentImage, "agent-image", defaults.AgentImage, "Image path to use for Cilium agent")
-	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", defaults.OperatorImage, "Image path to use for Cilium operator")
+	cmd.Flags().StringVar(&params.AgentImage, "agent-image", "", "Image path to use for Cilium agent")
+	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", "", "Image path to use for Cilium operator")
 
 	cmd.Flags().StringVar(&params.Azure.ResourceGroupName, "azure-resource-group", "", "Azure resource group name the cluster is in")
 	cmd.Flags().StringVar(&params.Azure.TenantID, "azure-tenant-id", "", "Azure tenant ID")


### PR DESCRIPTION
Commit a855451c7e7a ("internal/cli/cmd: allow specifying agent and
operator image via CLI parameters") broke the operator image
autodetection for AWS and Azure which leads to `operator-generic` being
deployed rather than `operator-{aws.azure}`.

This is due to the fact that `utils.BuildImagePath` will only set the
provided cloud-specific image path if the OperatorImage parameter is
empty. Fix this by making the default CLI option value empty, so the
autodetection will kick in as long as the option is not specified.

Fixes: a855451c7e7a ("internal/cli/cmd: allow specifying agent and operator image via CLI parameters")