### PR TITLE
cmd: only setup the kubernetes client for commands that require it

### DIFF
--- a/cmd/cilium/main.go
+++ b/cmd/cilium/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,15 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/cilium/cilium-cli/internal/cli/cmd"
 )
 
 func main() {
-	cmd.NewDefaultCiliumCommand().Execute()
+	if err := cmd.NewDefaultCiliumCommand().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -59,6 +59,8 @@ cilium hubble enable
 
 # Perform a connectivity test
 cilium connectivity test`,
+		SilenceErrors: true, // this is being handled in main, no need to duplicate error messages
+		SilenceUsage:  true, // avoid showing help when usage is correct but an error occured
 	}
 
 	cmd.AddCommand(


### PR DESCRIPTION
Ever since I added completion for the cilium CLI to my default shell
config, I was bugged by this message when opening a new terminal
session and having no kubectl config:

    Unable to create Kubernetes client: invalid configuration: no configuration has been provided, try setting KUBERNETES_

It turns out that initializing the kubernetes client is setup in the
root command as a persistent pre-run.

As we can see, for commands that do not require the client the be setup,
such as `help`, `completion` or `version`, it doesn't make sense to try
to setup the client. In fact, when setting up the client fails, it would
even prevent the command from running. This is particularly annoying
when trying to run "help".

This commit addresses this problem by treating the root command and the
`completion`, `help` and `version` commands as special cases and return
early in the persistent pre-run function to avoid trying to setup the
kubernetes client.