### PR TITLE
install: Fix typo in resource quota

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -1295,7 +1295,7 @@ func (k *K8sInstaller) deployResourceQuotas(ctx context.Context) error {
 					{
 						ScopeName: corev1.ResourceQuotaScopePriorityClass,
 						Operator:  corev1.ScopeSelectorOpIn,
-						Values:    []string{"system-node-critical"},
+						Values:    []string{"system-cluster-critical"},
 					},
 				},
 			},


### PR DESCRIPTION
This resulted in the pod quota for the operator to be also applied to
the agent DaemonSet.

Signed-off-by: Thomas Graf <thomas@cilium.io>