### PR TITLE
release: create release binaries for darwin/arm64 (aka Apple silicon)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ local-release: clean
 		ARCHS=; \
 		case $$OS in \
 			darwin) \
-				ARCHS='amd64'; \
+				ARCHS='amd64 arm64'; \
 				;; \
 			linux) \
 				ARCHS='386 amd64 arm arm64'; \


### PR DESCRIPTION
Go 1.16 adds macOS ARM64 support so let's build release binaries for Apple silicon.