### PR TITLE
connectivity: Relax flow requirement for world connection termination

### DIFF
--- a/connectivity/test_world.go
+++ b/connectivity/test_world.go
@@ -44,7 +44,7 @@ func (p *connectivityTestPodToWorld) Run(ctx context.Context, c TestContext) {
 			{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.TCP(0, 443), filters.SYN()), Expect: true, Msg: "SYN"},
 			{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.SYNACK()), Expect: true, Msg: "SYN-ACK"},
 			{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.TCP(0, 443), filters.Or(filters.FIN(), filters.RST())), Expect: true, Msg: "FIN or RST"},
-			{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.FIN()), Expect: true, Msg: "FIN-ACK"},
+			{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.Or(filters.FIN(), filters.RST())), Expect: true, Msg: "FIN or RST"},
 		})
 
 		run.End()


### PR DESCRIPTION
Termination of the connection with a mutual RST is valid as well:
```
Feb 19 09:24:01.459: 10.0.1.46:41144 -> 172.217.4.142:443 from-endpoint FORWARDED (TCP Flags: ACK, RST)
Feb 19 09:24:01.459: 10.0.1.46:41144 -> 172.217.4.142:443 to-stack FORWARDED (TCP Flags: ACK, RST)
```

Fixes: #88

Signed-off-by: Thomas Graf <thomas@cilium.io>