### PR TITLE
ci: aks: Relax timeout of 15m to 30m

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   installation-and-connectivitiy:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The cluster delete can take a long time sometimes so allow for it to
complete

Signed-off-by: Thomas Graf <thomas@cilium.io>