### PR TITLE
 connectivity: Add liberal flow filter and descriptions

### DIFF
--- a/connectivity/check.go
+++ b/connectivity/check.go
@@ -334,7 +334,7 @@ func (t *TestRun) settleFlows(ctx context.Context) error {
 
 // ValidateFlows retrieves the flow pods of the specified pod and validates
 // that all filters find a match. On failure, t.Failure() is called.
-func (t *TestRun) ValidateFlows(ctx context.Context, pod string, filter []FilterPair) {
+func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, filter []FilterPair) {
 	hubbleClient := t.context.HubbleClient()
 	if hubbleClient == nil {
 		return
@@ -347,7 +347,7 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod string, filter []Filter
 	flows, ok := t.flows[pod]
 	if !ok {
 		var err error
-		flows, err = getFlows(ctx, hubbleClient, t.started.Add(-2*time.Second), pod)
+		flows, err = getFlows(ctx, hubbleClient, t.started.Add(-2*time.Second), pod, podIP)
 		if err != nil {
 			t.context.Log("Unable to retrieve flows of pod %s: %s", pod, err)
 			t.Failure("Unable to retrieve flows of pod %q: %s", pod, err)
@@ -370,7 +370,7 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod string, filter []Filter
 			if p.Expect {
 				msgSuffix = "not found"
 			}
-			t.Failure(fmt.Sprintf("%s %s for pod %s", p.Msg, msgSuffix, pod))
+			t.Failure(fmt.Sprintf("%s %s %s for pod %s", p.Msg, p.Filter.String(), msgSuffix, pod))
 		} else {
 			msgSuffix := "not found"
 			if p.Expect {
@@ -533,7 +533,7 @@ type flowsSet struct {
 	flows []*observer.GetFlowsResponse
 }
 
-func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since time.Time, pod string) (*flowsSet, error) {
+func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since time.Time, pod, podIP string) (*flowsSet, error) {
 	set := &flowsSet{}
 
 	if hubbleClient == nil {
@@ -545,8 +545,13 @@ func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since t
 		return nil, fmt.Errorf("invalid since value %s: %s", since, err)
 	}
 
+	// The filter is liberal, it includes any flow that:
+	// - source or destination IP matches pod IP
+	// - source or destination pod name matches pod name
 	filter := []*flow.FlowFilter{
+		{SourceIp: []string{podIP}},
 		{SourcePod: []string{pod}},
+		{DestinationIp: []string{podIP}},
 		{DestinationPod: []string{pod}},
 	}
 
@@ -581,13 +586,13 @@ func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since t
 	}
 }
 
-func (f *flowsSet) Contains(fn filters.FlowFilterFunc) bool {
+func (f *flowsSet) Contains(filter filters.FlowFilterImplementation) bool {
 	if f == nil {
 		return false
 	}
 
 	for _, res := range f.flows {
-		if fn(res.GetFlow()) {
+		if filter.Match(res.GetFlow()) {
 			return true
 		}
 	}
@@ -596,7 +601,7 @@ func (f *flowsSet) Contains(fn filters.FlowFilterFunc) bool {
 }
 
 type FilterPair struct {
-	Filter filters.FlowFilterFunc
+	Filter filters.FlowFilterImplementation
 	Msg    string
 	Expect bool
 }

--- a/connectivity/filters/filters.go
+++ b/connectivity/filters/filters.go
@@ -15,6 +15,9 @@
 package filters
 
 import (
+	"fmt"
+	"strings"
+
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 )
 
@@ -22,164 +25,294 @@ import (
 // true if the condition is true.
 type FlowFilterFunc func(flow *flowpb.Flow) bool
 
-// And returns true if all FlowFilterFunc return true
-func And(funcs ...FlowFilterFunc) FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		for _, f := range funcs {
-			if !f(flow) {
-				return false
-			}
+type FlowFilterImplementation interface {
+	Match(flow *flowpb.Flow) bool
+	String() string
+}
+
+type andFilter struct {
+	filters []FlowFilterImplementation
+}
+
+func (a *andFilter) Match(flow *flowpb.Flow) bool {
+	for _, f := range a.filters {
+		if !f.Match(flow) {
+			return false
 		}
-		return true
+	}
+	return true
+}
+
+func (a *andFilter) String() string {
+	var s []string
+	for _, f := range a.filters {
+		s = append(s, f.String())
+	}
+	return "and(" + strings.Join(s, ",") + ")"
+}
+
+// And returns true if all filters return true
+func And(filters ...FlowFilterImplementation) FlowFilterImplementation {
+	return &andFilter{
+		filters: filters,
 	}
 }
 
-// Or returns true if any FlowFilterFunc return true
-func Or(funcs ...FlowFilterFunc) FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		for _, f := range funcs {
-			if f(flow) {
-				return true
-			}
+type orFilter struct {
+	filters []FlowFilterImplementation
+}
+
+func (o *orFilter) Match(flow *flowpb.Flow) bool {
+	for _, f := range o.filters {
+		if f.Match(flow) {
+			return true
 		}
-		return false
 	}
+	return false
+}
+
+func (o *orFilter) String() string {
+	var s []string
+	for _, f := range o.filters {
+		s = append(s, f.String())
+	}
+	return "or(" + strings.Join(s, ",") + ")"
+}
+
+// Or returns true if any FlowFilterImplementation return true
+func Or(filters ...FlowFilterImplementation) FlowFilterImplementation {
+	return &orFilter{filters: filters}
+}
+
+type dropFilter struct{}
+
+func (d *dropFilter) Match(flow *flowpb.Flow) bool {
+	return flow.GetDropReasonDesc() != flowpb.DropReason_DROP_REASON_UNKNOWN
+}
+
+func (d *dropFilter) String() string {
+	return "drop"
 }
 
 // Drop matches on drops
-func Drop() FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		return flow.GetDropReasonDesc() != flowpb.DropReason_DROP_REASON_UNKNOWN
+func Drop() FlowFilterImplementation {
+	return &dropFilter{}
+}
+
+type icmpFilter struct {
+	typ uint32
+}
+
+func (i *icmpFilter) Match(flow *flowpb.Flow) bool {
+	l4 := flow.GetL4()
+	if l4 == nil {
+		return false
 	}
+
+	icmp := l4.GetICMPv4()
+	if icmp == nil {
+		return false
+	}
+
+	if icmp.Type != i.typ {
+		return false
+	}
+
+	return true
+}
+
+func (i *icmpFilter) String() string {
+	return fmt.Sprintf("icmp(%d)", i.typ)
 }
 
 // ICMP matches on ICMP messages of the specified type
-func ICMP(typ uint32) FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		l4 := flow.GetL4()
-		if l4 == nil {
-			return false
-		}
+func ICMP(typ uint32) FlowFilterImplementation {
+	return &icmpFilter{typ: typ}
+}
 
-		icmp := l4.GetICMPv4()
-		if icmp == nil {
-			return false
-		}
+type udpFilter struct {
+	srcPort int
+	dstPort int
+}
 
-		if icmp.Type != typ {
-			return false
-		}
-
-		return true
+func (u *udpFilter) Match(flow *flowpb.Flow) bool {
+	l4 := flow.GetL4()
+	if l4 == nil {
+		return false
 	}
+
+	udp := l4.GetUDP()
+	if udp == nil {
+		return false
+	}
+
+	if u.srcPort != 0 && udp.SourcePort != uint32(u.srcPort) {
+		return false
+	}
+
+	if u.dstPort != 0 && udp.DestinationPort != uint32(u.dstPort) {
+		return false
+	}
+
+	return true
+}
+
+func (u *udpFilter) String() string {
+	var s []string
+	if u.srcPort != 0 {
+		s = append(s, fmt.Sprintf("srcPort=%d", u.srcPort))
+	}
+	if u.dstPort != 0 {
+		s = append(s, fmt.Sprintf("dstPort=%d", u.dstPort))
+	}
+	return "udp(" + strings.Join(s, ",") + ")"
 }
 
 // UDP matches on UDP packets with the specified source and destination ports
-func UDP(srcPort, dstPort int) FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		l4 := flow.GetL4()
-		if l4 == nil {
-			return false
-		}
+func UDP(srcPort, dstPort int) FlowFilterImplementation {
+	return &udpFilter{srcPort: srcPort, dstPort: dstPort}
+}
 
-		udp := l4.GetUDP()
-		if udp == nil {
-			return false
-		}
+type tcpFlagsFilter struct {
+	syn, ack, fin, rst bool
+}
 
-		if srcPort != 0 && udp.SourcePort != uint32(srcPort) {
-			return false
-		}
-
-		if dstPort != 0 && udp.DestinationPort != uint32(dstPort) {
-			return false
-		}
-
-		return true
+func (t *tcpFlagsFilter) Match(flow *flowpb.Flow) bool {
+	l4 := flow.GetL4()
+	if l4 == nil {
+		return false
 	}
+
+	tcp := l4.GetTCP()
+	if tcp == nil || tcp.Flags == nil {
+		return false
+	}
+
+	if tcp.Flags.SYN != t.syn || tcp.Flags.ACK != t.ack || tcp.Flags.FIN != t.fin || tcp.Flags.RST != t.rst {
+		return false
+	}
+
+	return true
+}
+
+func (t *tcpFlagsFilter) String() string {
+	var s []string
+	if t.syn {
+		s = append(s, "syn")
+	}
+	if t.ack {
+		s = append(s, "ack")
+	}
+	if t.fin {
+		s = append(s, "fin")
+	}
+	if t.rst {
+		s = append(s, "rst")
+	}
+	return "tcpflags(" + strings.Join(s, ",") + ")"
 }
 
 // TCPFlags matches on TCP packets with the specified TCP flags
-func TCPFlags(syn, ack, fin, rst bool) FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		l4 := flow.GetL4()
-		if l4 == nil {
-			return false
-		}
-
-		tcp := l4.GetTCP()
-		if tcp == nil || tcp.Flags == nil {
-			return false
-		}
-
-		if tcp.Flags.SYN != syn || tcp.Flags.ACK != ack || tcp.Flags.FIN != fin || tcp.Flags.RST != rst {
-			return false
-		}
-
-		return true
-	}
+func TCPFlags(syn, ack, fin, rst bool) FlowFilterImplementation {
+	return &tcpFlagsFilter{syn: syn, ack: ack, fin: fin, rst: rst}
 }
 
 // FIN matches on TCP packets with FIN+ACK flags
-func FIN() FlowFilterFunc {
+func FIN() FlowFilterImplementation {
 	return TCPFlags(false, true, true, false)
 }
 
 // RST matches on TCP packets with RST+ACK flags
-func RST() FlowFilterFunc {
+func RST() FlowFilterImplementation {
 	return TCPFlags(false, true, false, true)
 }
 
 // SYNACK matches on TCP packets with SYN+ACK flags
-func SYNACK() FlowFilterFunc {
+func SYNACK() FlowFilterImplementation {
 	return TCPFlags(true, true, false, false)
 }
 
 // SYN matches on TCP packets with SYN flag
-func SYN() FlowFilterFunc {
+func SYN() FlowFilterImplementation {
 	return TCPFlags(true, false, false, false)
 }
 
-// IP matches on IP packets with specified source and destination IP
-func IP(srcIP, dstIP string) FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		ip := flow.GetIP()
-		if ip == nil {
-			return false
-		}
-		if srcIP != "" && ip.Source != srcIP {
-			return false
-		}
+type ipFilter struct {
+	srcIP string
+	dstIP string
+}
 
-		if dstIP != "" && ip.Destination != dstIP {
-			return false
-		}
-
-		return true
+func (i *ipFilter) Match(flow *flowpb.Flow) bool {
+	ip := flow.GetIP()
+	if ip == nil {
+		return false
 	}
+	if i.srcIP != "" && ip.Source != i.srcIP {
+		return false
+	}
+
+	if i.dstIP != "" && ip.Destination != i.dstIP {
+		return false
+	}
+
+	return true
+}
+
+func (i *ipFilter) String() string {
+	var s []string
+	if i.srcIP != "" {
+		s = append(s, "src="+i.srcIP)
+	}
+	if i.dstIP != "" {
+		s = append(s, "dst="+i.dstIP)
+	}
+	return "ip(" + strings.Join(s, ",") + ")"
+}
+
+// IP matches on IP packets with specified source and destination IP
+func IP(srcIP, dstIP string) FlowFilterImplementation {
+	return &ipFilter{srcIP: srcIP, dstIP: dstIP}
+}
+
+type tcpFilter struct {
+	srcPort int
+	dstPort int
+}
+
+func (t *tcpFilter) Match(flow *flowpb.Flow) bool {
+	l4 := flow.GetL4()
+	if l4 == nil {
+		return false
+	}
+
+	tcp := l4.GetTCP()
+	if tcp == nil {
+		return false
+	}
+
+	if t.srcPort != 0 && tcp.SourcePort != uint32(t.srcPort) {
+		return false
+	}
+
+	if t.dstPort != 0 && tcp.DestinationPort != uint32(t.dstPort) {
+		return false
+	}
+
+	return true
+}
+
+func (t *tcpFilter) String() string {
+	var s []string
+	if t.srcPort != 0 {
+		s = append(s, fmt.Sprintf("srcPort=%d", t.srcPort))
+	}
+	if t.dstPort != 0 {
+		s = append(s, fmt.Sprintf("dstPort=%d", t.dstPort))
+	}
+	return "tcp(" + strings.Join(s, ",") + ")"
 }
 
 // TCP matches on TCP packets with the specified source and destination ports
-func TCP(srcPort, dstPort int) FlowFilterFunc {
-	return func(flow *flowpb.Flow) bool {
-		l4 := flow.GetL4()
-		if l4 == nil {
-			return false
-		}
-
-		tcp := l4.GetTCP()
-		if tcp == nil {
-			return false
-		}
-
-		if srcPort != 0 && tcp.SourcePort != uint32(srcPort) {
-			return false
-		}
-
-		if dstPort != 0 && tcp.DestinationPort != uint32(dstPort) {
-			return false
-		}
-
-		return true
-	}
+func TCP(srcPort, dstPort int) FlowFilterImplementation {
+	return &tcpFilter{srcPort: srcPort, dstPort: dstPort}
 }

--- a/connectivity/test_host.go
+++ b/connectivity/test_host.go
@@ -50,7 +50,7 @@ func (p *connectivityTestPodToHost) Run(ctx context.Context, c TestContext) {
 				run.Failure("ping command failed: %s", err)
 			}
 
-			run.ValidateFlows(ctx, client.Name(), []FilterPair{
+			run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, []FilterPair{
 				{Filter: filters.Drop(), Expect: false, Msg: "Found drop"},
 				{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, hostIP), filters.ICMP(8)), Expect: true, Msg: "ICMP request"},
 				{Filter: filters.And(filters.IP(hostIP, client.Pod.Status.PodIP), filters.ICMP(0)), Expect: true, Msg: "ICMP response"},

--- a/connectivity/test_pod.go
+++ b/connectivity/test_pod.go
@@ -41,14 +41,14 @@ func (p *connectivityTestPodToPod) Run(ctx context.Context, c TestContext) {
 			tcpRequest := filters.TCP(0, 8080)                                         // request to port 8080
 			tcpResponse := filters.TCP(8080, 0)                                        // response from port 8080
 
-			run.ValidateFlows(ctx, client.Name(), []FilterPair{
+			run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, []FilterPair{
 				{Filter: filters.Drop(), Expect: false, Msg: "Drop"},
 				{Filter: filters.RST(), Expect: false, Msg: "RST"},
 				{Filter: filters.And(echoToClient, tcpResponse, filters.SYNACK()), Expect: true, Msg: "SYN-ACK"},
 				{Filter: filters.And(echoToClient, tcpResponse, filters.FIN()), Expect: true, Msg: "FIN-ACK"},
 			})
 
-			run.ValidateFlows(ctx, echo.Name(), []FilterPair{
+			run.ValidateFlows(ctx, echo.Name(), echo.Pod.Status.PodIP, []FilterPair{
 				{Filter: filters.Drop(), Expect: false, Msg: "Drop"},
 				{Filter: filters.RST(), Expect: false, Msg: "RST"},
 				{Filter: filters.And(clientToEcho, tcpRequest, filters.SYN()), Expect: true, Msg: "SYN"},

--- a/connectivity/test_service.go
+++ b/connectivity/test_service.go
@@ -75,7 +75,7 @@ func testConnetivityToServiceDefinition(ctx context.Context, c TestContext, name
 			}...)
 		}
 
-		run.ValidateFlows(ctx, client.Name(), flowRequirements)
+		run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, flowRequirements)
 
 		run.End()
 	}

--- a/connectivity/test_world.go
+++ b/connectivity/test_world.go
@@ -37,7 +37,7 @@ func (p *connectivityTestPodToWorld) Run(ctx context.Context, c TestContext) {
 			run.Failure("curl connectivity check command failed: %s", err)
 		}
 
-		run.ValidateFlows(ctx, client.Name(), []FilterPair{
+		run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, []FilterPair{
 			{Filter: filters.Drop(), Expect: false, Msg: "Drop"},
 			{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.UDP(0, 53)), Expect: true, Msg: "DNS request"},
 			{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.UDP(53, 0)), Expect: true, Msg: "DNS response"},


### PR DESCRIPTION
Matches on pod IPs instead of just pod names in case the pod name association is not reliable. Also describes flow filters to assist in troubleshooting

```
❌ SYN-ACK and(ip(dst=10.52.2.87),tcp(srcPort=443),tcpflags(syn,ack)) not found for pod cilium-test/client-6c46bff775-sq4mm
```

Related: #102