### PR TITLE
ci: Give EKS tests 45 minutes to run

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   installation-and-connectivitiy:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   installation-and-connectivitiy:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Tests typically take ~25min to run but sometimes exceeds 30min. Give EKS
tests 45min to complete.

Signed-off-by: Thomas Graf <thomas@cilium.io>