### PR TITLE
Bump Go to 1.16.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.0
+        go-version: 1.16.2
 
     - name: Build
       run: make

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ release:
 		--env "RELEASE_GID=$(RELEASE_GID)" \
 		--rm \
 		--workdir /cilium \
-		--volume `pwd`:/cilium docker.io/library/golang:1.16.0-alpine3.13 \
+		--volume `pwd`:/cilium docker.io/library/golang:1.16.2-alpine3.13 \
 		sh -c "apk add --no-cache make && make local-release"
 
 local-release: clean


### PR DESCRIPTION
Release notes: https://golang.org/doc/devel/release.html#go1.16.minor