### PR TITLE
VM support fixes

### DIFF
--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -76,7 +76,7 @@ func (k *K8sClusterMesh) createClusterMeshAdminCertificate(ctx context.Context) 
 			"localhost",
 			"127.0.0.1",
 		},
-		CN: "ClusterMesh Admin",
+		CN: "root",
 	}
 
 	signConf := &config.Signing{
@@ -112,7 +112,7 @@ func (k *K8sClusterMesh) createClusterMeshClientCertificate(ctx context.Context)
 		Names:      []csr.Name{{C: "US", ST: "San Francisco", L: "CA"}},
 		KeyRequest: csr.NewKeyRequest(),
 		Hosts:      []string{""},
-		CN:         "ClusterMesh Client",
+		CN:         "remote",
 	}
 
 	signConf := &config.Signing{

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -46,6 +46,7 @@ import (
 const (
 	configNameClusterID   = "cluster-id"
 	configNameClusterName = "cluster-name"
+	configNameTunnel      = "tunnel"
 
 	caSuffix   = ".etcd-client-ca.crt"
 	keySuffix  = ".etcd-client.key"
@@ -591,6 +592,7 @@ type accessInformation struct {
 	ClientKey            []byte
 	ExternalWorkloadCert []byte
 	ExternalWorkloadKey  []byte
+	Tunnel               string
 }
 
 func (ai *accessInformation) etcdConfiguration() string {
@@ -676,6 +678,7 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 		ExternalWorkloadKey:  externalWorkloadKey,
 		ExternalWorkloadCert: externalWorkloadCert,
 		ServiceIPs:           []string{},
+		Tunnel:               cm.Data[configNameTunnel],
 	}
 
 	switch {
@@ -1454,6 +1457,10 @@ func (k *K8sClusterMesh) WriteExternalWorkloadInstallScript(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	if ai.Tunnel != "" && ai.Tunnel != "vxlan" {
+		return fmt.Errorf("Cilium datapath not using vxlan, please install Cilium with '--config tunnel=vxlan'")
+	}
+
 	clusterAddr := fmt.Sprintf("%s:%d", ai.ServiceIPs[0], ai.ServicePort)
 	k.Log("✅ Using clustermesh-apiserver service address: %s", clusterAddr)
 

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -570,13 +570,15 @@ func (k *K8sClusterMesh) Enable(ctx context.Context) error {
 }
 
 type accessInformation struct {
-	ServiceIPs  []string
-	ServicePort int
-	ClusterID   string
-	ClusterName string
-	CA          []byte
-	ClientCert  []byte
-	ClientKey   []byte
+	ServiceIPs           []string
+	ServicePort          int
+	ClusterID            string
+	ClusterName          string
+	CA                   []byte
+	ClientCert           []byte
+	ClientKey            []byte
+	ExternalWorkloadCert []byte
+	ExternalWorkloadKey  []byte
 }
 
 func (ai *accessInformation) etcdConfiguration() string {
@@ -638,13 +640,30 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshClientSecretName, defaults.ClusterMeshClientSecretCertName)
 	}
 
+	externalWorkloadSecret, err := client.GetSecret(ctx, k.params.Namespace, defaults.ClusterMeshExternalWorkloadSecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get secret %q to access clustermesh service: %s", defaults.ClusterMeshExternalWorkloadSecretName, err)
+	}
+
+	externalWorkloadKey, ok := externalWorkloadSecret.Data[defaults.ClusterMeshExternalWorkloadSecretKeyName]
+	if !ok {
+		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshExternalWorkloadSecretName, defaults.ClusterMeshExternalWorkloadSecretKeyName)
+	}
+
+	externalWorkloadCert, ok := externalWorkloadSecret.Data[defaults.ClusterMeshExternalWorkloadSecretCertName]
+	if !ok {
+		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshExternalWorkloadSecretName, defaults.ClusterMeshExternalWorkloadSecretCertName)
+	}
+
 	ai := &accessInformation{
-		ClusterID:   clusterID,
-		ClusterName: clusterName,
-		CA:          caCert,
-		ClientKey:   clientKey,
-		ClientCert:  clientCert,
-		ServiceIPs:  []string{},
+		ClusterID:            clusterID,
+		ClusterName:          clusterName,
+		CA:                   caCert,
+		ClientKey:            clientKey,
+		ClientCert:           clientCert,
+		ExternalWorkloadKey:  externalWorkloadKey,
+		ExternalWorkloadCert: externalWorkloadCert,
+		ServiceIPs:           []string{},
 	}
 
 	switch {

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -662,7 +662,18 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 		}
 
 	case svc.Spec.Type == corev1.ServiceTypeClusterIP:
-		return nil, fmt.Errorf("not able to derive service IPs for type ClusterIP, please specify IPs manually")
+		if len(svc.Spec.Ports) == 0 {
+			return nil, fmt.Errorf("port of service could not be derived, service has no ports")
+		}
+		if svc.Spec.Ports[0].Port == 0 {
+			return nil, fmt.Errorf("port is not set in service")
+		}
+		ai.ServicePort = int(svc.Spec.Ports[0].Port)
+
+		if svc.Spec.ClusterIP == "" {
+			return nil, fmt.Errorf("IP of service could not be derived, service has no ClusterIP")
+		}
+		ai.ServiceIPs = append(ai.ServiceIPs, svc.Spec.ClusterIP)
 
 	case svc.Spec.Type == corev1.ServiceTypeNodePort:
 		if len(svc.Spec.Ports) == 0 {

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1455,7 +1455,7 @@ func (k *K8sClusterMesh) WriteExternalWorkloadInstallScript(ctx context.Context,
 		return err
 	}
 	if daemonSet == nil {
-		return fmt.Errorf("DaemomSet %s is not available", defaults.AgentDaemonSetName)
+		return fmt.Errorf("DaemonSet %s is not available", defaults.AgentDaemonSetName)
 	}
 	k.Log("✅ Using image from Cilium DaemonSet: %s", daemonSet.Spec.Template.Spec.Containers[0].Image)
 
@@ -1464,7 +1464,7 @@ func (k *K8sClusterMesh) WriteExternalWorkloadInstallScript(ctx context.Context,
 		return err
 	}
 	if ai.Tunnel != "" && ai.Tunnel != "vxlan" {
-		return fmt.Errorf("Cilium datapath not using vxlan, please install Cilium with '--config tunnel=vxlan'")
+		return fmt.Errorf("datapath not using vxlan, please install Cilium with '--config tunnel=vxlan'")
 	}
 
 	clusterAddr := fmt.Sprintf("%s:%d", ai.ServiceIPs[0], ai.ServicePort)

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -57,21 +57,24 @@ const (
 	RelayClientSecretCertName = "tls.crt"
 	RelayClientSecretKeyName  = "tls.key"
 
-	ClusterMeshDeploymentName       = "clustermesh-apiserver"
-	ClusterMeshServiceAccountName   = "clustermesh-apiserver"
-	ClusterMeshClusterRoleName      = "clustermesh-apiserver"
-	ClusterMeshApiserverImage       = "quay.io/cilium/clustermesh-apiserver:" + Version
-	ClusterMeshServiceName          = "clustermesh-apiserver"
-	ClusterMeshSecretName           = "cilium-clustermesh" // Secret which contains the clustermesh configuration
-	ClusterMeshServerSecretName     = "clustermesh-apiserver-server-certs"
-	ClusterMeshServerSecretCertName = "tls.crt"
-	ClusterMeshServerSecretKeyName  = "tls.key"
-	ClusterMeshAdminSecretName      = "clustermesh-apiserver-admin-certs"
-	ClusterMeshAdminSecretCertName  = "tls.crt"
-	ClusterMeshAdminSecretKeyName   = "tls.key"
-	ClusterMeshClientSecretName     = "clustermesh-apiserver-client-certs"
-	ClusterMeshClientSecretCertName = "tls.crt"
-	ClusterMeshClientSecretKeyName  = "tls.key"
+	ClusterMeshDeploymentName                 = "clustermesh-apiserver"
+	ClusterMeshServiceAccountName             = "clustermesh-apiserver"
+	ClusterMeshClusterRoleName                = "clustermesh-apiserver"
+	ClusterMeshApiserverImage                 = "quay.io/cilium/clustermesh-apiserver:" + Version
+	ClusterMeshServiceName                    = "clustermesh-apiserver"
+	ClusterMeshSecretName                     = "cilium-clustermesh" // Secret which contains the clustermesh configuration
+	ClusterMeshServerSecretName               = "clustermesh-apiserver-server-certs"
+	ClusterMeshServerSecretCertName           = "tls.crt"
+	ClusterMeshServerSecretKeyName            = "tls.key"
+	ClusterMeshAdminSecretName                = "clustermesh-apiserver-admin-certs"
+	ClusterMeshAdminSecretCertName            = "tls.crt"
+	ClusterMeshAdminSecretKeyName             = "tls.key"
+	ClusterMeshClientSecretName               = "clustermesh-apiserver-client-certs"
+	ClusterMeshClientSecretCertName           = "tls.crt"
+	ClusterMeshClientSecretKeyName            = "tls.key"
+	ClusterMeshExternalWorkloadSecretName     = "clustermesh-apiserver-external-workload-certs"
+	ClusterMeshExternalWorkloadSecretCertName = "tls.crt"
+	ClusterMeshExternalWorkloadSecretKeyName  = "tls.key"
 
 	ConnectivityCheckNamespace = "cilium-test"
 

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -130,6 +130,11 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 
 	if k.params.DatapathMode == "" {
 		switch f.Kind {
+		case k8s.KindKind:
+			k.params.DatapathMode = DatapathTunnel
+			k.Log("ℹ️  kube-proxy-replacement disabled")
+			k.params.KubeProxyReplacement = "disabled"
+
 		case k8s.KindMinikube:
 			k.params.DatapathMode = DatapathTunnel
 		case k8s.KindEKS:

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -403,3 +403,19 @@ func (c *Client) ListCiliumEndpoints(ctx context.Context, namespace string, opti
 func (c *Client) ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error) {
 	return c.Clientset.CoreV1().Nodes().List(ctx, options)
 }
+
+func (c *Client) ListCiliumExternalWorkloads(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error) {
+	return c.CiliumClientset.CiliumV2().CiliumExternalWorkloads().List(ctx, opts)
+}
+
+func (c *Client) GetCiliumExternalWorkload(ctx context.Context, name string, opts metav1.GetOptions) (*ciliumv2.CiliumExternalWorkload, error) {
+	return c.CiliumClientset.CiliumV2().CiliumExternalWorkloads().Get(ctx, name, opts)
+}
+
+func (c *Client) CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2.CiliumExternalWorkload, opts metav1.CreateOptions) (*ciliumv2.CiliumExternalWorkload, error) {
+	return c.CiliumClientset.CiliumV2().CiliumExternalWorkloads().Create(ctx, cew, opts)
+}
+
+func (c *Client) DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.CiliumClientset.CiliumV2().CiliumExternalWorkloads().Delete(ctx, name, opts)
+}

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -103,6 +104,8 @@ retry:
 	return s, err
 }
 
+var ErrClusterMeshStatusNotAvailable = errors.New("ClusterMesh status is not available")
+
 func (k *K8sStatusCollector) clusterMeshConnectivity(ctx context.Context, ciliumPod string) (*ClusterMeshAgentConnectivityStatus, error) {
 	c := &ClusterMeshAgentConnectivityStatus{
 		Clusters: map[string]*models.RemoteCluster{},
@@ -114,7 +117,7 @@ func (k *K8sStatusCollector) clusterMeshConnectivity(ctx context.Context, cilium
 	}
 
 	if status.ClusterMesh == nil {
-		return nil, fmt.Errorf("ClusterMesh status is not available")
+		return nil, ErrClusterMeshStatusNotAvailable
 	}
 
 	c.GlobalServices = status.ClusterMesh.NumGlobalServices

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -164,7 +164,7 @@ func (k *K8sStatusCollector) daemonSetStatus(ctx context.Context, status *Status
 	}
 
 	if daemonSet == nil {
-		return fmt.Errorf("DaemomSet %s is not available", name)
+		return fmt.Errorf("DaemonSet %s is not available", name)
 	}
 
 	stateCount := PodStateCount{Type: "DaemonSet"}


### PR DESCRIPTION
Various changes to allow external workloads to be used when installing Cilium with the Cilium CLI tool:
- Relax clustermesh validation on "enable"
- Change default service type to NodePort on port 32379
- Set etcd client Common Names to the corresponding user names
- Add external-workload certs
- Auto-detect datapath mode for Kind

These changes are required to run the updated GSG at https://github.com/cilium/cilium/pull/15320.