### PR TITLE
install: Use GKE node init for flavor GKE

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -1247,7 +1247,6 @@ func (k *K8sInstaller) generateConfigMap() *corev1.ConfigMap {
 		m.Data["tunnel"] = "disabled"
 		m.Data["enable-endpoint-routes"] = "true"
 		m.Data["enable-local-node-route"] = "false"
-		m.Data["gke-node-init-script"] = nodeInitStartupScriptGKE
 
 	case DatapathAzure:
 		m.Data["tunnel"] = "disabled"
@@ -1256,6 +1255,11 @@ func (k *K8sInstaller) generateConfigMap() *corev1.ConfigMap {
 		m.Data["enable-local-node-route"] = "false"
 		m.Data["masquerade"] = "false"
 		m.Data["enable-bpf-masquerade"] = "false"
+	}
+
+	switch k.flavor.Kind {
+	case k8s.KindGKE:
+		m.Data["gke-node-init-script"] = nodeInitStartupScriptGKE
 	}
 
 	if k.params.Encryption {


### PR DESCRIPTION
Instead of including the GKE node init on datapath GKE, include it on
flavor GKE as it is also needed if a user runs with
`--datapath-mode=tunnel` on GKE.

Signed-off-by: Thomas Graf <thomas@cilium.io>