### PR TITLE
Fix pod-to-pod test for IPv6 deployments

### DIFF
--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -16,6 +16,8 @@ package tests
 
 import (
 	"context"
+	"net"
+	"strconv"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/connectivity/filters"
@@ -30,9 +32,10 @@ func (t *PodToPod) Name() string {
 func (t *PodToPod) Run(ctx context.Context, c check.TestContext) {
 	for _, client := range c.ClientPods() {
 		for _, echo := range c.EchoPods() {
+			destination := net.JoinHostPort(echo.Pod.Status.PodIP, strconv.Itoa(8080))
 			run := check.NewTestRun(t.Name(), c, client, echo)
 
-			_, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, curlCommand(echo.Pod.Status.PodIP+":8080"))
+			_, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, curlCommand(destination))
 			if err != nil {
 				run.Failure("curl connectivity check command failed: %s", err)
 			}


### PR DESCRIPTION
The original code constructed the `curlCommand()` argument as the concatenated string `echo.Pod.Status.PodIP+":8080"` (i.e. pod IP + port 8080).

This works for IPv4, but does not satisfy the IPv6 case in which `curl` requires that the host address is enclosed in square brackets (e.g. `[2001:db8::abcd]:8080`). In a v6-first-dual-stack or v6-only environment, this causes false-negative test results like the following (addresses have been replaced):

```
---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-pod] Testing cilium-test/client-58dfdc5f6-fkgxg -> cilium-test/echo-other-node-588bf78fbb-jfbbd...
---------------------------------------------------------------------------------------------------------------------
❌ curl connectivity check command failed: error in stream: command terminated with exit code 3
❌ [pod-to-pod] cilium-test/client-58dfdc5f6-fkgxg (2001:db8:0:0:3::1234) -> cilium-test/echo-other-node-588bf78fbb-jfbbd (2001:db8:0:0:4::abcd)
```

The exit code 3 (URL malformed) can be verified by exec'ing into the pod and running `curl`:

```
/ # curl 2001:db8:0:0:4::abcd:8080
curl: (3) URL using bad/illegal format or missing URL
```

I noticed that the pod-to-service test was not failing in a similar manner. This was because that test uses `net.JoinHostPort()` rather than string concatenation, and this does result in a properly bracketed IPv6 address.
This PR alters the pod-to-pod test to use the same approach as the pod-to-service test, fixing the IPv6 case.

Open questions: Should an IPv6 test be introduced into CI? It appears that this could be done with KIND so long as it is single-stack v6 (no dual-stack support in KIND at this time).