### PR TITLE
install: Disable hubble by default

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -87,15 +87,19 @@ const (
 	FlowRetryInterval = 500 * time.Millisecond
 )
 
-var OperatorLabels = map[string]string{
-	"io.cilium/app": "operator",
-	"name":          "cilium-operator",
-}
+var (
+	OperatorLabels = map[string]string{
+		"io.cilium/app": "operator",
+		"name":          "cilium-operator",
+	}
 
-var RelayDeploymentLabels = map[string]string{
-	"k8s-app": "hubble-relay",
-}
+	RelayDeploymentLabels = map[string]string{
+		"k8s-app": "hubble-relay",
+	}
 
-var ClusterMeshDeploymentLabels = map[string]string{
-	"k8s-app": "clustermesh-apiserver",
-}
+	ClusterMeshDeploymentLabels = map[string]string{
+		"k8s-app": "clustermesh-apiserver",
+	}
+
+	CiliumPodSelector = "k8s-app=cilium"
+)

--- a/install/install.go
+++ b/install/install.go
@@ -1197,17 +1197,7 @@ func (k *K8sInstaller) generateConfigMap() *corev1.ConfigMap {
 			"enable-well-known-identities":        "false",
 			"enable-remote-node-identity":         "true",
 			"operator-api-serve-addr":             "127.0.0.1:9234",
-			// Enable Hubble gRPC service.
-			"enable-hubble": "true",
-			// UNIX domain socket for Hubble server to listen to.
-			"hubble-socket-path": defaults.HubbleSocketPath,
-			// An additional address for Hubble server to listen to (e.g. ":4244").
-			"hubble-listen-address":      ":4244",
-			"hubble-disable-tls":         "false",
-			"hubble-tls-cert-file":       "/var/lib/cilium/tls/hubble/server.crt",
-			"hubble-tls-key-file":        "/var/lib/cilium/tls/hubble/server.key",
-			"hubble-tls-client-ca-files": "/var/lib/cilium/tls/hubble/client-ca.crt",
-			"disable-cnp-status-updates": "true",
+			"disable-cnp-status-updates":          "true",
 		},
 	}
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -216,6 +216,10 @@ func (c *Client) DeletePod(ctx context.Context, namespace, name string, opts met
 	return c.Clientset.CoreV1().Pods(namespace).Delete(ctx, name, opts)
 }
 
+func (c *Client) DeletePodCollection(ctx context.Context, namespace string, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return c.Clientset.CoreV1().Pods(namespace).DeleteCollection(ctx, opts, listOpts)
+}
+
 func (c *Client) ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error) {
 	return c.Clientset.CoreV1().Pods(namespace).List(ctx, options)
 }


### PR DESCRIPTION
It has become trivial to enable and disable hubble with ``cilium hubble
enable``.  Disable it by default in the install to minimize the memory
footprint of the default install.

Signed-off-by: Thomas Graf <thomas@cilium.io>