### PR TITLE
connectivity: Add filter for ICMPv6, match ICMPv6 in pod-to-host test

### DIFF
--- a/connectivity/filters/filters.go
+++ b/connectivity/filters/filters.go
@@ -136,6 +136,37 @@ func ICMP(typ uint32) FlowFilterImplementation {
 	return &icmpFilter{typ: typ}
 }
 
+type icmpv6Filter struct {
+	typ uint32
+}
+
+func (i *icmpv6Filter) Match(flow *flowpb.Flow) bool {
+	l4 := flow.GetL4()
+	if l4 == nil {
+		return false
+	}
+
+	icmpv6 := l4.GetICMPv6()
+	if icmpv6 == nil {
+		return false
+	}
+
+	if icmpv6.Type != i.typ {
+		return false
+	}
+
+	return true
+}
+
+func (i *icmpv6Filter) String() string {
+	return fmt.Sprintf("icmpv6(%d)", i.typ)
+}
+
+// ICMPv6 matches on ICMPv6 messages of the specified type
+func ICMPv6(typ uint32) FlowFilterImplementation {
+	return &icmpv6Filter{typ: typ}
+}
+
 type udpFilter struct {
 	srcPort int
 	dstPort int

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -53,8 +53,8 @@ func (t *PodToHost) Run(ctx context.Context, c check.TestContext) {
 
 			run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, []filters.Pair{
 				{Filter: filters.Drop(), Expect: false, Msg: "Found drop"},
-				{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, hostIP), filters.ICMP(8)), Expect: true, Msg: "ICMP request"},
-				{Filter: filters.And(filters.IP(hostIP, client.Pod.Status.PodIP), filters.ICMP(0)), Expect: true, Msg: "ICMP response"},
+				{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, hostIP), filters.Or(filters.ICMP(8), filters.ICMPv6(128))), Expect: true, Msg: "ICMP request"},
+				{Filter: filters.And(filters.IP(hostIP, client.Pod.Status.PodIP), filters.Or(filters.ICMP(0), filters.ICMPv6(129))), Expect: true, Msg: "ICMP response"},
 			})
 
 			run.End()


### PR DESCRIPTION
The pod-to-host test fails in IPv6 (or v6-first-dualstack) clusters when Hubble is enabled, because the test checks for ICMP(v4) codes 8 and 0 (echo request, echo reply) but the logged flows have ICMPv6 codes 128 (echo) and 129 (reply).

Add a filter for ICMPv6 mimicking the existing ICMPv4 filter, and use `filters.Or()` to make the pod-to-host test IP-version-agnostic.