### PR TITLE
CI: disable fail-fast behavior in cleanup step

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -80,6 +80,7 @@ jobs:
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
           az aks delete --yes --name ${{ env.clusterName }} --resource-group cilium-ci
+        shell: bash {0}
 
       - name: Upload Artifacts
         if: ${{ always() }}

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -76,6 +76,7 @@ jobs:
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
           ./eksctl delete cluster --name ${{ env.clusterName }}
+        shell: bash {0}
 
       - name: Upload Artifacts
         if: ${{ always() }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -76,6 +76,7 @@ jobs:
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
           ./eksctl delete cluster --name ${{ env.clusterName }}
+        shell: bash {0}
 
       - name: Upload Artifacts
         if: ${{ always() }}

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -85,6 +85,7 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
+        shell: bash {0}
 
       - name: Upload Artifacts
         if: ${{ always() }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -118,6 +118,7 @@ jobs:
           python cilium-sysdump.zip --output cilium-sysdump-out
           gcloud container clusters delete --quiet ${{ env.clusterName1 }} --zone ${{ env.zone }}
           gcloud container clusters delete --quiet ${{ env.clusterName2 }} --zone ${{ env.zone }}
+        shell: bash {0}
 
       - name: Upload Artifacts
         if: ${{ always() }}


### PR DESCRIPTION
By default shell scripts in jobs.<job_id>.steps[*].run have fail-fast
behavior, potentially leading to commands in the cleanup step not being
executed. In the worst case this could lead to cloud resources not being
cleaned up, e.g. when `cilium status` fails with non-zero exit status,
the remaining commands will not be run.

Fix this by specifying `shell: bash {0}` for the cleanup step, which
will opt out of the fail-fast behavior.

For details see:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

For an example see https://github.com/cilium/cilium-cli/runs/2205848981?check_suite_focus=true, where `cilium status` exited with non-zero status due to clustermesh errors, leading to the successive steps in cleanup (i.e. cluster teardown) not being run.