### PR TITLE
tests: Add initial policy testing support

### DIFF
--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -1,0 +1,185 @@
+// Copyright 2020-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CiliumNetworkPolicy implements ConnectivityTest interface so that
+// policies can be applied between tests and policy apply failures can
+// be reported like any other test results.
+type CiliumNetworkPolicy struct {
+	Title  string
+	Policy string
+}
+
+// Name returns the absolute name of the policy
+func (p *CiliumNetworkPolicy) Name() string {
+	return p.Title
+}
+
+// Run applies the policy, use nil policy to delete all policies
+func (p *CiliumNetworkPolicy) Run(ctx context.Context, c TestContext) {
+	failures := c.ApplyPolicyYaml(ctx, p.Policy)
+	c.Report(TestResult{
+		Name:     p.Name(),
+		Failures: failures,
+		Warnings: 0,
+	})
+}
+
+type WithPolicy struct {
+	err  error
+	cnps []*ciliumv2.CiliumNetworkPolicy
+}
+
+func (wp *WithPolicy) Parse(policy string) {
+	wp.cnps, wp.err = ParsePolicyYaml(policy)
+}
+
+// Apply returns the number of failures and a cancel function that deletes the applied policies
+func (wp *WithPolicy) Apply(ctx context.Context, c TestContext) (failures int, cancel func()) {
+	if wp.err != nil {
+		return 1, func() {}
+	}
+
+	for _, cnp := range wp.cnps {
+		failures += c.ApplyCNP(ctx, cnp)
+	}
+	return failures, func() {
+		for _, cnp := range wp.cnps {
+			c.DeleteCNP(ctx, cnp)
+		}
+	}
+}
+
+// Run applies the policy, use empty policy to delete all policies
+func (k *K8sConnectivityCheck) ApplyPolicyYaml(ctx context.Context, policy string) int {
+	if policy == "" {
+		// Delete all policies
+		return k.ApplyCNP(ctx, nil)
+	}
+	failures := 0
+	cnps, err := ParsePolicyYaml(policy)
+	if err != nil {
+		k.Log("❌ %s", err)
+		failures++
+	} else {
+		for _, cnp := range cnps {
+			failures += k.ApplyCNP(ctx, cnp)
+		}
+	}
+	return failures
+}
+
+// ParsePolicyYaml decodes policy yaml into a slice of CiliumNetworkPolicies
+func ParsePolicyYaml(policy string) (cnps []*ciliumv2.CiliumNetworkPolicy, err error) {
+	if policy == "" {
+		return nil, nil
+	}
+	yamls := strings.Split(policy, "---")
+	for _, yaml := range yamls {
+		if yaml == "\n" || yaml == "" {
+			continue
+		}
+		obj, groupVersionKind, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(yaml), nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("Resource decode error (%s) in: %s", err, yaml)
+		}
+		switch groupVersionKind.Kind {
+		case "CiliumNetworkPolicy":
+			cnp, ok := obj.(*ciliumv2.CiliumNetworkPolicy)
+			if !ok {
+				return nil, fmt.Errorf("Object cast to CiliumNetworkPolicy failed: %s", yaml)
+			}
+			cnps = append(cnps, cnp)
+		default:
+			return nil, fmt.Errorf("Unknown policy type '%s' in: %s", groupVersionKind.Kind, yaml)
+		}
+	}
+	return cnps, nil
+}
+
+// DeleteCNP deletes a CNP
+func (k *K8sConnectivityCheck) DeleteCNP(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy) {
+	name := cnp.Namespace + "/" + cnp.Name
+	if err := k.deleteCNP(ctx, cnp); err != nil {
+		k.Log("❌ [%s] policy delete failed: %s", name, err)
+	}
+	delete(k.policies, name)
+}
+
+// ApplyCNP returns the number of failures
+func (k *K8sConnectivityCheck) ApplyCNP(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy) int {
+	failures := 0
+	if cnp == nil {
+		k.Header("🔌 Deleting all previously applied policies...")
+		for _, cnp := range k.policies {
+			k.DeleteCNP(ctx, cnp)
+		}
+	} else {
+		name := cnp.Namespace + "/" + cnp.Name
+		k.Header("🔌 [%s] Applying CiliumNetworkPolicy...", name)
+		k8sCNP, err := k.updateOrCreateCNP(ctx, cnp)
+		if err == nil {
+			k.Log("✅ [%s] CiliumNetworkPolicy applied", name)
+			k.policies[name] = k8sCNP
+		} else {
+			k.Log("❌ policy apply failed: %s", err)
+			failures++
+		}
+	}
+	return failures
+}
+
+func (k *K8sConnectivityCheck) updateOrCreateCNP(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy) (*ciliumv2.CiliumNetworkPolicy, error) {
+        k8sCNP, err := k.clients.src.GetCiliumNetworkPolicy(ctx, cnp.Namespace, cnp.Name, metav1.GetOptions{})
+        if err == nil {
+                k8sCNP.ObjectMeta.Labels = cnp.ObjectMeta.Labels
+                k8sCNP.Spec = cnp.Spec
+                k8sCNP.Specs = cnp.Specs
+                k8sCNP.Status = ciliumv2.CiliumNetworkPolicyStatus{}
+                return k.clients.src.UpdateCiliumNetworkPolicy(ctx, k8sCNP, metav1.UpdateOptions{})
+        }
+        return k.clients.src.CreateCiliumNetworkPolicy(ctx, cnp, metav1.CreateOptions{})
+}
+
+func (k *K8sConnectivityCheck) deleteCNP(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy) error {
+        return k.clients.src.DeleteCiliumNetworkPolicy(ctx, cnp.Namespace, cnp.Name, metav1.DeleteOptions{})
+}
+
+func (k *K8sConnectivityCheck) updateOrCreateCCNP(ctx context.Context, ccnp *ciliumv2.CiliumClusterwideNetworkPolicy) (*ciliumv2.CiliumClusterwideNetworkPolicy, error) {
+        k8sCCNP, err := k.clients.src.GetCiliumClusterwideNetworkPolicy(ctx, ccnp.Name, metav1.GetOptions{})
+        if err == nil {
+                k8sCCNP.ObjectMeta.Labels = ccnp.ObjectMeta.Labels
+                k8sCCNP.Spec = ccnp.Spec
+                k8sCCNP.Specs = ccnp.Specs
+                k8sCCNP.Status = ciliumv2.CiliumNetworkPolicyStatus{}
+                return k.clients.src.UpdateCiliumClusterwideNetworkPolicy(ctx, k8sCCNP, metav1.UpdateOptions{})
+        }
+        return k.clients.src.CreateCiliumClusterwideNetworkPolicy(ctx, ccnp, metav1.CreateOptions{})
+}
+
+func (k *K8sConnectivityCheck) deleteCCNP(ctx context.Context, ccnp *ciliumv2.CiliumNetworkPolicy) error {
+        return k.clients.src.DeleteCiliumClusterwideNetworkPolicy(ctx, ccnp.Name, metav1.DeleteOptions{})
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -423,3 +423,43 @@ func (c *Client) CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2
 func (c *Client) DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.CiliumClientset.CiliumV2().CiliumExternalWorkloads().Delete(ctx, name, opts)
 }
+
+func (c *Client) ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(namespace).List(ctx, opts)
+}
+
+func (c *Client) GetCiliumNetworkPolicy(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*ciliumv2.CiliumNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(namespace).Get(ctx, name, opts)
+}
+
+func (c *Client) CreateCiliumNetworkPolicy(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy, opts metav1.CreateOptions) (*ciliumv2.CiliumNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace).Create(ctx, cnp, opts)
+}
+
+func (c *Client) UpdateCiliumNetworkPolicy(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy, opts metav1.UpdateOptions) (*ciliumv2.CiliumNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace).Update(ctx, cnp, opts)
+}
+
+func (c *Client) DeleteCiliumNetworkPolicy(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(namespace).Delete(ctx, name, opts)
+}
+
+func (c *Client) ListCiliumClusterwideNetworkPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumClusterwideNetworkPolicyList, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().List(ctx, opts)
+}
+
+func (c *Client) GetCiliumClusterwideNetworkPolicy(ctx context.Context, name string, opts metav1.GetOptions) (*ciliumv2.CiliumClusterwideNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Get(ctx, name, opts)
+}
+
+func (c *Client) CreateCiliumClusterwideNetworkPolicy(ctx context.Context, ccnp *ciliumv2.CiliumClusterwideNetworkPolicy, opts metav1.CreateOptions) (*ciliumv2.CiliumClusterwideNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Create(ctx, ccnp, opts)
+}
+
+func (c *Client) UpdateCiliumClusterwideNetworkPolicy(ctx context.Context, ccnp *ciliumv2.CiliumClusterwideNetworkPolicy, opts metav1.UpdateOptions) (*ciliumv2.CiliumClusterwideNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Update(ctx, ccnp, opts)
+}
+
+func (c *Client) DeleteCiliumClusterwideNetworkPolicy(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Delete(ctx, name, opts)
+}


### PR DESCRIPTION
Policy can be installed and removed as a test step between other
tests, or applied to a single test with `WithPolicy()`. Go syntax for
WithPolicy() use requires scoping address-of operator, which is not
ideal.

Policy is expressed as yaml and must specify the namespace in which
the policy is to be applied.

Expected failures are not handled yet, so they will be reported as
test failures. The initial test cases that are expected to fail
contain the string "SHOULD-FAIL".

Design considerations:
 - Currently policies are expressed as stand-alone yaml, parsed in to CiliumNetworkPolicies. Policies need to specify in which namespace they apply and this must match the namespace in which the tests are executed. This, however, is a configurable parameter, and may need to be overridden after the yamls have been parsed
 - Yaml can consist of multiple policies, so composing more complex policy cases should be possible by composing sets of policies from smaller yamls, or even fragments of yamls (composing different versions of a policy from fragments that are not valid policies by themselves)
 - Templating could be added if parts, such as names, namespaces, labels, port numbers, header values, etc. will need to be provided programmatically. Hopefully we do not need to compose policies purely in Go, as I find text (yaml) to be more readable
 - More complicated policy tests may require use of multiple namespaces, but the current test setup with a single configurable test namespace seems ill-suited for that
 - Only pod-to-pod test has been extended with the `.WithPolicy()` treatment
 - Only CiliumNetworkPolicies (CNPs) are currently supported, should support also CiliumClusterwideNetworkPolicies (CCNPs) and the k8s NetworkPolicies

Infrastructure TODOs:
- [ ] Finalize policy apply/delete infra within the test suite (i.e., between or with the tests)
- [ ] Add support for different expected test outcomes (currently drops are never expected)
  - [ ] Allow the same test case be run against different policies with different expected outcomes
- [ ] Add support for CiliumClusterwideNetworkPolicies
- [ ] Add support for k8s NetworkPolicies
    
Policy test cases needed (Once the infra is in place adding these should not need any new Go code):
 - [x] L3 policy
 - [x] L3/L4 policy
 - [ ] CIDR
 - [ ] HTTP (adds use of Envoy)
 - [ ] Kafka (adds use of proxylib with Envoy)
 - [ ] FQDN (adds use of DNS proxy)
 - [ ] L3-dependent L7 with HTTP
 - [ ] L3-dependent L7 with FQDN with HTTP


Signed-off-by: Jarno Rajahalme <jarno@covalent.io>