### PR TITLE
CI: combine build and install in a single step

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -19,10 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build cilium CLI binary
-        run: make
-
-      - name: Install cilium CLI binary
+      - name: Build and install cilium CLI binary
         run: sudo make install
 
       - name: Azure Login

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -20,10 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build cilium CLI binary
-        run: make
-
-      - name: Install cilium CLI binary
+      - name: Build and install cilium CLI binary
         run: sudo make install
 
       - name: Install eksctl

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -20,10 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build cilium CLI binary
-        run: make
-
-      - name: Install cilium CLI binary
+      - name: Build and install cilium CLI binary
         run: sudo make install
 
       - name: Install eksctl

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -22,10 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build cilium CLI binary
-        run: make
-
-      - name: Install cilium CLI binary
+      - name: Build and install cilium CLI binary
         run: sudo make install
 
       - name: Set up gcloud

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -20,10 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build cilium CLI binary
-        run: make
-
-      - name: Install cilium CLI binary
+      - name: Build and install cilium CLI binary
         run: sudo make install
 
       - name: Set up gcloud

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -22,10 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build cilium CLI binary
-        run: make
-
-      - name: Install cilium CLI binary
+      - name: Build and install cilium CLI binary
         run: sudo make install
 
       - name: Create kind cluster

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -21,10 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build cilium CLI binary
-        run: make
-
-      - name: Install cilium CLI binary
+      - name: Build and install cilium CLI binary
         run: sudo make install
 
       - name: Set up gcloud


### PR DESCRIPTION
The Cilium CLI binary is currently always re-built during `make install`
because the command is executed with `sudo` and thus the build cache of
the root user is used. But the earlier `make` command populating the
cache was run as a normal user.

Fix this by only running `sudo make install` which will also build the
binary due to the respective Makefile target dependency.

This reduces the GitHub actions jobs by about ~50s.