### PR TITLE
add ca.crt to TLS Secrets

### DIFF
--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,8 +57,8 @@ func (k *K8sClusterMesh) createClusterMeshServerCertificate(ctx context.Context)
 	}
 
 	data := map[string][]byte{
-		defaults.ClusterMeshServerSecretCertName: cert,
-		defaults.ClusterMeshServerSecretKeyName:  key,
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -95,8 +96,8 @@ func (k *K8sClusterMesh) createClusterMeshAdminCertificate(ctx context.Context) 
 	}
 
 	data := map[string][]byte{
-		defaults.ClusterMeshAdminSecretCertName: cert,
-		defaults.ClusterMeshAdminSecretKeyName:  key,
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshAdminSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -131,8 +132,8 @@ func (k *K8sClusterMesh) createClusterMeshClientCertificate(ctx context.Context)
 	}
 
 	data := map[string][]byte{
-		defaults.ClusterMeshClientSecretCertName: cert,
-		defaults.ClusterMeshClientSecretKeyName:  key,
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -167,8 +168,8 @@ func (k *K8sClusterMesh) createClusterMeshExternalWorkloadCertificate(ctx contex
 	}
 
 	data := map[string][]byte{
-		defaults.ClusterMeshExternalWorkloadSecretCertName: cert,
-		defaults.ClusterMeshExternalWorkloadSecretKeyName:  key,
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshExternalWorkloadSecretName, k.params.Namespace, data), metav1.CreateOptions{})

--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -60,7 +60,7 @@ func (k *K8sClusterMesh) createClusterMeshServerCertificate(ctx context.Context)
 		defaults.ClusterMeshServerSecretKeyName:  key,
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewSecret(defaults.ClusterMeshServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.ClusterMeshServerSecretName, err)
 	}
@@ -99,7 +99,7 @@ func (k *K8sClusterMesh) createClusterMeshAdminCertificate(ctx context.Context) 
 		defaults.ClusterMeshAdminSecretKeyName:  key,
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewSecret(defaults.ClusterMeshAdminSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshAdminSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.ClusterMeshAdminSecretName, err)
 	}
@@ -135,7 +135,7 @@ func (k *K8sClusterMesh) createClusterMeshClientCertificate(ctx context.Context)
 		defaults.ClusterMeshClientSecretKeyName:  key,
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewSecret(defaults.ClusterMeshClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.ClusterMeshClientSecretName, err)
 	}
@@ -171,7 +171,7 @@ func (k *K8sClusterMesh) createClusterMeshExternalWorkloadCertificate(ctx contex
 		defaults.ClusterMeshExternalWorkloadSecretKeyName:  key,
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewSecret(defaults.ClusterMeshExternalWorkloadSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshExternalWorkloadSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.ClusterMeshExternalWorkloadSecretName, err)
 	}

--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -57,8 +57,9 @@ func (k *K8sClusterMesh) createClusterMeshServerCertificate(ctx context.Context)
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:       cert,
-		corev1.TLSPrivateKeyKey: key,
+		corev1.TLSCertKey:         cert,
+		corev1.TLSPrivateKeyKey:   key,
+		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -96,8 +97,9 @@ func (k *K8sClusterMesh) createClusterMeshAdminCertificate(ctx context.Context) 
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:       cert,
-		corev1.TLSPrivateKeyKey: key,
+		corev1.TLSCertKey:         cert,
+		corev1.TLSPrivateKeyKey:   key,
+		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshAdminSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -132,8 +134,9 @@ func (k *K8sClusterMesh) createClusterMeshClientCertificate(ctx context.Context)
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:       cert,
-		corev1.TLSPrivateKeyKey: key,
+		corev1.TLSCertKey:         cert,
+		corev1.TLSPrivateKeyKey:   key,
+		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -168,8 +171,9 @@ func (k *K8sClusterMesh) createClusterMeshExternalWorkloadCertificate(ctx contex
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:       cert,
-		corev1.TLSPrivateKeyKey: key,
+		corev1.TLSCertKey:         cert,
+		corev1.TLSPrivateKeyKey:   key,
+		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshExternalWorkloadSecretName, k.params.Namespace, data), metav1.CreateOptions{})

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -655,14 +655,14 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 		return nil, fmt.Errorf("unable to get secret %q to access clustermesh service: %s", defaults.ClusterMeshClientSecretName, err)
 	}
 
-	clientKey, ok := meshSecret.Data[defaults.ClusterMeshClientSecretKeyName]
+	clientKey, ok := meshSecret.Data[corev1.TLSPrivateKeyKey]
 	if !ok {
-		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshClientSecretName, defaults.ClusterMeshClientSecretKeyName)
+		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshClientSecretName, corev1.TLSPrivateKeyKey)
 	}
 
-	clientCert, ok := meshSecret.Data[defaults.ClusterMeshClientSecretCertName]
+	clientCert, ok := meshSecret.Data[corev1.TLSCertKey]
 	if !ok {
-		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshClientSecretName, defaults.ClusterMeshClientSecretCertName)
+		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshClientSecretName, corev1.TLSCertKey)
 	}
 
 	externalWorkloadSecret, err := client.GetSecret(ctx, k.params.Namespace, defaults.ClusterMeshExternalWorkloadSecretName, metav1.GetOptions{})
@@ -670,14 +670,14 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 		return nil, fmt.Errorf("unable to get secret %q to access clustermesh service: %s", defaults.ClusterMeshExternalWorkloadSecretName, err)
 	}
 
-	externalWorkloadKey, ok := externalWorkloadSecret.Data[defaults.ClusterMeshExternalWorkloadSecretKeyName]
+	externalWorkloadKey, ok := externalWorkloadSecret.Data[corev1.TLSPrivateKeyKey]
 	if !ok {
-		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshExternalWorkloadSecretName, defaults.ClusterMeshExternalWorkloadSecretKeyName)
+		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshExternalWorkloadSecretName, corev1.TLSPrivateKeyKey)
 	}
 
-	externalWorkloadCert, ok := externalWorkloadSecret.Data[defaults.ClusterMeshExternalWorkloadSecretCertName]
+	externalWorkloadCert, ok := externalWorkloadSecret.Data[corev1.TLSCertKey]
 	if !ok {
-		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshExternalWorkloadSecretName, defaults.ClusterMeshExternalWorkloadSecretCertName)
+		return nil, fmt.Errorf("secret %q does not contain key %q", defaults.ClusterMeshExternalWorkloadSecretName, corev1.TLSCertKey)
 	}
 
 	ai := &accessInformation{

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -37,10 +37,8 @@ const (
 	OperatorImageAWS           = "quay.io/cilium/operator-aws"
 	OperatorImageAzure         = "quay.io/cilium/operator-azure"
 
-	HubbleSocketPath           = "/var/run/cilium/hubble.sock"
-	HubbleServerSecretName     = "hubble-server-certs"
-	HubbleServerSecretCertName = "tls.crt"
-	HubbleServerSecretKeyName  = "tls.key"
+	HubbleSocketPath       = "/var/run/cilium/hubble.sock"
+	HubbleServerSecretName = "hubble-server-certs"
 
 	RelayDeploymentName       = "hubble-relay"
 	RelayClusterRoleName      = "hubble-relay"
@@ -53,11 +51,7 @@ const (
 	RelayServicePlaintextPort = 80
 	RelayServiceTLSPort       = 443
 	RelayServerSecretName     = "hubble-relay-server-certs"
-	RelayServerSecretCertName = "tls.crt"
-	RelayServerSecretKeyName  = "tls.key"
 	RelayClientSecretName     = "hubble-relay-client-certs"
-	RelayClientSecretCertName = "tls.crt"
-	RelayClientSecretKeyName  = "tls.key"
 
 	HubbleUIServiceName        = "hubble-ui"
 	HubbleUIClusterRoleName    = "hubble-ui"
@@ -65,24 +59,16 @@ const (
 	HubbleUIConfigMapName      = "hubble-ui-envoy"
 	HubbleUIDeploymentName     = "hubble-ui"
 
-	ClusterMeshDeploymentName                 = "clustermesh-apiserver"
-	ClusterMeshServiceAccountName             = "clustermesh-apiserver"
-	ClusterMeshClusterRoleName                = "clustermesh-apiserver"
-	ClusterMeshApiserverImage                 = "quay.io/cilium/clustermesh-apiserver:" + Version
-	ClusterMeshServiceName                    = "clustermesh-apiserver"
-	ClusterMeshSecretName                     = "cilium-clustermesh" // Secret which contains the clustermesh configuration
-	ClusterMeshServerSecretName               = "clustermesh-apiserver-server-certs"
-	ClusterMeshServerSecretCertName           = "tls.crt"
-	ClusterMeshServerSecretKeyName            = "tls.key"
-	ClusterMeshAdminSecretName                = "clustermesh-apiserver-admin-certs"
-	ClusterMeshAdminSecretCertName            = "tls.crt"
-	ClusterMeshAdminSecretKeyName             = "tls.key"
-	ClusterMeshClientSecretName               = "clustermesh-apiserver-client-certs"
-	ClusterMeshClientSecretCertName           = "tls.crt"
-	ClusterMeshClientSecretKeyName            = "tls.key"
-	ClusterMeshExternalWorkloadSecretName     = "clustermesh-apiserver-external-workload-certs"
-	ClusterMeshExternalWorkloadSecretCertName = "tls.crt"
-	ClusterMeshExternalWorkloadSecretKeyName  = "tls.key"
+	ClusterMeshDeploymentName             = "clustermesh-apiserver"
+	ClusterMeshServiceAccountName         = "clustermesh-apiserver"
+	ClusterMeshClusterRoleName            = "clustermesh-apiserver"
+	ClusterMeshApiserverImage             = "quay.io/cilium/clustermesh-apiserver:" + Version
+	ClusterMeshServiceName                = "clustermesh-apiserver"
+	ClusterMeshSecretName                 = "cilium-clustermesh" // Secret which contains the clustermesh configuration
+	ClusterMeshServerSecretName           = "clustermesh-apiserver-server-certs"
+	ClusterMeshAdminSecretName            = "clustermesh-apiserver-admin-certs"
+	ClusterMeshClientSecretName           = "clustermesh-apiserver-client-certs"
+	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-certs"
 
 	ConnectivityCheckNamespace = "cilium-test"
 

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -364,8 +364,9 @@ func (k *K8sHubble) createRelayServerCertificate(ctx context.Context) error {
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:       cert,
-		corev1.TLSPrivateKeyKey: key,
+		corev1.TLSCertKey:         cert,
+		corev1.TLSPrivateKeyKey:   key,
+		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.RelayServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -400,8 +401,9 @@ func (k *K8sHubble) createRelayClientCertificate(ctx context.Context) error {
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:       cert,
-		corev1.TLSPrivateKeyKey: key,
+		corev1.TLSCertKey:         cert,
+		corev1.TLSPrivateKeyKey:   key,
+		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.RelayClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -368,7 +368,7 @@ func (k *K8sHubble) createRelayServerCertificate(ctx context.Context) error {
 		defaults.RelayServerSecretKeyName:  key,
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewSecret(defaults.RelayServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.RelayServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.RelayServerSecretName, err)
 	}
@@ -404,7 +404,7 @@ func (k *K8sHubble) createRelayClientCertificate(ctx context.Context) error {
 		defaults.RelayClientSecretKeyName:  key,
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewSecret(defaults.RelayClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.RelayClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.RelayClientSecretName, err)
 	}

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -195,15 +195,6 @@ func (k *K8sHubble) generateRelayDeployment() *appsv1.Deployment {
 														Key:  corev1.TLSPrivateKeyKey,
 														Path: "client.key",
 													},
-												},
-											},
-										},
-										{
-											Secret: &corev1.SecretProjection{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: defaults.CASecretName,
-												},
-												Items: []corev1.KeyToPath{
 													{
 														Key:  defaults.CASecretCertName,
 														Path: "hubble-server-ca.crt",
@@ -215,15 +206,6 @@ func (k *K8sHubble) generateRelayDeployment() *appsv1.Deployment {
 								},
 							},
 						},
-						//{{- if .Values.hubble.relay.tls.server.enabled }}
-						//          - secret:
-						//              name: hubble-relay-server-certs
-						//              items:
-						//                - key: tls.crt
-						//                  path: server.crt
-						//                - key: tls.key
-						//                  path: server.key
-						//{{- end }}
 					},
 				},
 			},

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -188,11 +188,11 @@ func (k *K8sHubble) generateRelayDeployment() *appsv1.Deployment {
 												},
 												Items: []corev1.KeyToPath{
 													{
-														Key:  defaults.RelayClientSecretCertName,
+														Key:  corev1.TLSCertKey,
 														Path: "client.crt",
 													},
 													{
-														Key:  defaults.RelayClientSecretKeyName,
+														Key:  corev1.TLSPrivateKeyKey,
 														Path: "client.key",
 													},
 												},
@@ -364,8 +364,8 @@ func (k *K8sHubble) createRelayServerCertificate(ctx context.Context) error {
 	}
 
 	data := map[string][]byte{
-		defaults.RelayServerSecretCertName: cert,
-		defaults.RelayServerSecretKeyName:  key,
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.RelayServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
@@ -400,8 +400,8 @@ func (k *K8sHubble) createRelayClientCertificate(ctx context.Context) error {
 	}
 
 	data := map[string][]byte{
-		defaults.RelayClientSecretCertName: cert,
-		defaults.RelayClientSecretKeyName:  key,
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.RelayClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})

--- a/install/certs.go
+++ b/install/certs.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,8 +54,8 @@ func (k *K8sInstaller) createHubbleServerCertificate(ctx context.Context) error 
 	}
 
 	data := map[string][]byte{
-		defaults.HubbleServerSecretCertName: cert,
-		defaults.HubbleServerSecretKeyName:  key,
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.HubbleServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})

--- a/install/certs.go
+++ b/install/certs.go
@@ -57,7 +57,7 @@ func (k *K8sInstaller) createHubbleServerCertificate(ctx context.Context) error 
 		defaults.HubbleServerSecretKeyName:  key,
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewSecret(defaults.HubbleServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.HubbleServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.HubbleServerSecretName, err)
 	}

--- a/install/certs.go
+++ b/install/certs.go
@@ -54,8 +54,9 @@ func (k *K8sInstaller) createHubbleServerCertificate(ctx context.Context) error 
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:       cert,
-		corev1.TLSPrivateKeyKey: key,
+		corev1.TLSCertKey:        cert,
+		corev1.TLSPrivateKeyKey:  key,
+		defaults.CASecretKeyName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.HubbleServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})

--- a/install/install.go
+++ b/install/install.go
@@ -611,11 +611,11 @@ func (k *K8sInstaller) generateAgentDaemonSet() *appsv1.DaemonSet {
 												},
 												Items: []corev1.KeyToPath{
 													{
-														Key:  defaults.HubbleServerSecretCertName,
+														Key:  corev1.TLSCertKey,
 														Path: "server.crt",
 													},
 													{
-														Key:  defaults.HubbleServerSecretKeyName,
+														Key:  corev1.TLSPrivateKeyKey,
 														Path: "server.key",
 													},
 												},

--- a/install/install.go
+++ b/install/install.go
@@ -618,15 +618,6 @@ func (k *K8sInstaller) generateAgentDaemonSet() *appsv1.DaemonSet {
 														Key:  corev1.TLSPrivateKeyKey,
 														Path: "server.key",
 													},
-												},
-											},
-										},
-										{
-											Secret: &corev1.SecretProjection{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: defaults.CASecretName,
-												},
-												Items: []corev1.KeyToPath{
 													{
 														Key:  defaults.CASecretCertName,
 														Path: "client-ca.crt",

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -143,3 +143,13 @@ func (c *CertManager) GenerateCertificate(profile string, certReq *csr.Certifica
 	}
 	return certBytes, keyBytes, nil
 }
+
+// CACertBytes return the CA public certificate bytes, or nil when it is not
+// set.
+func (c *CertManager) CACertBytes() []byte {
+	// NOTE: return a copy just to avoid the caller modifiying our CA
+	// certificate.
+	crt := make([]byte, len(c.caCert))
+	copy(crt, c.caCert)
+	return crt
+}

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -18,6 +18,7 @@ import (
 	//appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+
 	//"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	//"k8s.io/apimachinery/pkg/util/intstr"
@@ -59,5 +60,18 @@ func NewSecret(name, namespace string, data map[string][]byte) *corev1.Secret {
 		},
 		Data: data,
 		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+// NewTLSSecret return a Secret of the type kubernetes.io/tls. Note that for
+// this kind of Secret, both tls.key and tls.crt are required in data.
+func NewTLSSecret(name, namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+		Type: corev1.SecretTypeTLS,
 	}
 }


### PR DESCRIPTION
This PR ensure that all the Secrets containing a TLS keypair are of `kubernetes.io/tls` type. This brings consistency with respect to how we generate certificates [with certgen](https://github.com/cilium/certgen/blob/d9f612a4775d85632acfa9653cade50e1cd2af50/internal/generate/generate.go#L147) and [Helm](https://github.com/cilium/cilium/blob/de8b14eb7816b773ec757ef0847dcfff56d507d2/install/kubernetes/cilium/templates/hubble-server-secret.yaml#L10).

Besides honoring the required `tls.key` and `tls.crt` keys, we also consistently add `ca.crt` to theses Secrets (see https://github.com/cilium/cilium/pull/15443 for context).

Finally, use the newly added `ca.crt` for both Hubble and Relay. This allow compatibility with [cert-manager](https://cert-manager.io/).

After this PR we could consider a `--generate-certificates=false` flag preventing certificate generation from the CLI. Users could then use cert-manager go generate the TLS Secrets since the deployments are using the TLS Secrets in a compatible way.