### PR TITLE
clustermesh: Add search domains to VM support DNS config

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1419,6 +1419,8 @@ for ((i = 0 ; i < 24; i++)); do
     echo "Waiting for kube-dns service to come available..."
 done
 
+namespace=$(cilium endpoint get -l reserved:host -o jsonpath='{$[0].status.identity.labels}' | tr -d "[]\"" | tr "," "\n" | grep io.kubernetes.pod.namespace | cut -d= -f2)
+
 if [ -n "$kubedns" ] ; then
     if grep "nameserver $kubedns" /etc/resolv.conf ; then
 	echo "kube-dns IP $kubedns already in /etc/resolv.conf"
@@ -1431,6 +1433,7 @@ if [ -n "$kubedns" ] ; then
 # This file is installed by Cilium to use kube dns server from a non-k8s node.
 [Resolve]
 DNS=$kubedns
+Domains=${namespace}.svc.cluster.local svc.cluster.local cluster.local
 EOF
 	    ${SUDO} systemctl daemon-reload
 	    ${SUDO} systemctl reenable systemd-resolved.service
@@ -1439,7 +1442,7 @@ EOF
 	else
 	    echo "Adding kube-dns IP $kubedns to /etc/resolv.conf"
 	    ${SUDO} cp /etc/resolv.conf /etc/resolv.conf.orig
-	    resolvconf="nameserver $kubedns\n$(cat /etc/resolv.conf)\n"
+	    resolvconf="nameserver $kubedns\n$(cat /etc/resolv.conf)\nsearch ${namespace}.svc.cluster.local svc.cluster.local cluster.local\n"
 	    printf "$resolvconf" | ${SUDO} tee /etc/resolv.conf
 	fi
     fi


### PR DESCRIPTION
Add the search domains for '\<namespace\>.svc.cluster.local',
'svc.cluster.local', and 'cluster.local' in addition to the kube DNS
server to the VM's DNS configuration. This allows VM to use names
local to its namespace without specifying the fully qualified name.
\<namespace\> is derived from VMs cilium state at runtime so that
the install script works for VMs in different namespaces.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>