### PR TITLE
Add test for pod to external workload connectivity

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -12,7 +12,7 @@ env:
   clusterName: cilium-cli-ci-${{ github.run_number }}
 
 jobs:
-  installation-and-connectivitiy:
+  installation-and-connectivity:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -13,7 +13,7 @@ env:
   region: us-east-2
 
 jobs:
-  installation-and-connectivitiy:
+  installation-and-connectivity:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -13,7 +13,7 @@ env:
   region: us-east-2
 
 jobs:
-  installation-and-connectivitiy:
+  installation-and-connectivity:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   installation-and-connectivity:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -84,6 +84,10 @@ jobs:
       - name: Ping clustermesh-apiserver from external workload
         run: |
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "ping -c 3 \$(cilium service list get -o jsonpath='{[?(@.spec.flags.name==\"clustermesh-apiserver\")].spec.backend-addresses[0].ip}')"
+
+      - name: Connectivity test
+        run: |
+          cilium connectivity test
 
       - name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -72,13 +72,10 @@ jobs:
       - name: Install cilium on external workload
         run: |
           cilium clustermesh vm install install-external-workload.sh
-          gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "hostname"
           gcloud compute scp install-external-workload.sh ${{ env.vmName }}:~/ --zone ${{ env.zone }}
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "~/install-external-workload.sh"
-          sleep 10s
+          sleep 5s
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
-          kubectl get cew --all-namespaces -o wide
-          kubectl get cep --all-namespaces -o wide
 
       - name: Verify cluster DNS on external workload
         run: |

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -13,7 +13,7 @@ env:
   zone: us-west2-a
 
 jobs:
-  installation-and-connectivitiy:
+  installation-and-connectivity:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -15,7 +15,7 @@ env:
   LOG_TIME: 30m
 
 jobs:
-  installation-and-connectivitiy:
+  installation-and-connectivity:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -14,7 +14,7 @@ env:
   zone: us-west2-a
 
 jobs:
-  installation-and-connectivitiy:
+  installation-and-connectivity:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -49,6 +49,7 @@ func Run(ctx context.Context, k *check.K8sConnectivityCheck) error {
 		&tests.PodToLocalNodePort{},
 		&tests.PodToWorld{},
 		&tests.PodToHost{},
+		&tests.PodToExternalWorkload{},
 
 		// Then test with an allow-all policy
 		(&check.PolicyContext{}).WithPolicy(allowAllPolicyYAML),
@@ -59,6 +60,7 @@ func Run(ctx context.Context, k *check.K8sConnectivityCheck) error {
 		&tests.PodToLocalNodePort{Variant: "-allow-all"},
 		&tests.PodToWorld{Variant: "-allow-all"},
 		&tests.PodToHost{Variant: "-allow-all"},
+		&tests.PodToExternalWorkload{Variant: "-allow-all"},
 		// By itself this should fail, but allow-all policy is in effect so this succeeds
 		(&tests.PodToPod{Variant: "-client-egress-only-dns-with-allow-all"}).WithPolicy(clientEgressOnlyDNSPolicyYAML),
 		(&check.PolicyContext{}).WithPolicy(""), // delete all applied policies

--- a/connectivity/tests/externalworkload.go
+++ b/connectivity/tests/externalworkload.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+)
+
+type PodToExternalWorkload struct {
+	check.PolicyContext
+	Variant string
+}
+
+func (t *PodToExternalWorkload) WithPolicy(yaml string) check.ConnectivityTest {
+	return t.WithPolicyRunner(t, yaml)
+}
+
+func (t *PodToExternalWorkload) Name() string {
+	return "pod-to-external-workload" + t.Variant
+}
+
+func (t *PodToExternalWorkload) Run(ctx context.Context, c check.TestContext) {
+	for _, src := range c.ClientPods() {
+		for _, dst := range c.ExternalWorkloads() {
+			run := check.NewTestRun(t, c, src, dst, 0) // 0 port number for ICMP
+			cmd := []string{"ping", "-w", "3", "-c", "1", dst.ExternalWorkload.Status.IP}
+
+			stdout, stderr, err := src.K8sClient.ExecInPodWithStderr(ctx, src.Pod.Namespace, src.Pod.Name, "", cmd)
+			run.LogResult(cmd, err, stdout, stderr)
+			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
+				Protocol: check.ICMP,
+			})
+			run.ValidateFlows(ctx, src.Name(), src.Pod.Status.PodIP, egressFlowRequirements)
+			ingressFlowRequirements := run.GetIngressRequirements(check.FlowParameters{
+				Protocol: check.ICMP,
+			})
+			if ingressFlowRequirements != nil {
+				run.ValidateFlows(ctx, dst.Name(), dst.ExternalWorkload.Status.IP, ingressFlowRequirements)
+			}
+			run.End()
+		}
+	}
+}

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -46,7 +46,7 @@ func (t *PodToService) Run(ctx context.Context, c check.TestContext) {
 			}
 		}
 
-		testConnetivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
+		testConnectivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
 	}
 
 }
@@ -78,7 +78,7 @@ func (t *PodToNodePort) Run(ctx context.Context, c check.TestContext) {
 			}
 		}
 
-		testConnetivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
+		testConnectivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
 	}
 }
 
@@ -111,7 +111,7 @@ func (t *PodToLocalNodePort) Run(ctx context.Context, c check.TestContext) {
 			}
 		}
 
-		testConnetivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
+		testConnectivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
 	}
 }
 
@@ -123,7 +123,7 @@ type serviceDefinition struct {
 
 type serviceDefinitionMap map[string]serviceDefinition
 
-func testConnetivityToServiceDefinition(ctx context.Context, c check.TestContext, t check.ConnectivityTest, client check.PodContext, def serviceDefinitionMap) {
+func testConnectivityToServiceDefinition(ctx context.Context, c check.TestContext, t check.ConnectivityTest, client check.PodContext, def serviceDefinitionMap) {
 	for peer, definition := range def {
 		destination := net.JoinHostPort(peer, strconv.Itoa(definition.port))
 		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{


### PR DESCRIPTION
Test ping connectivity from all pods to external workloads.

"Screenshot" of successful `cilium connectivity test` run with Hubble enabled (note the last test `pod-to-external-workload`):

```
tklauser@orbital:~ % cilium connectivity test
⌛ [gke_cilium-dev_europe-west6-a_test-tklauser-15653] Waiting for deployments [client echo-same-node] to become ready...
⌛ [gke_cilium-dev_europe-west6-a_test-tklauser-15653] Waiting for deployments [echo-other-node] to become ready...
⌛ [gke_cilium-dev_europe-west6-a_test-tklauser-15653] Waiting for CiliumEndpoint for pod cilium-test/client-77bd7f48dd-xmkrk to appear...
⌛ [gke_cilium-dev_europe-west6-a_test-tklauser-15653] Waiting for CiliumEndpoint for pod cilium-test/echo-other-node-86774f89b9-w2v2c to appear...
⌛ [gke_cilium-dev_europe-west6-a_test-tklauser-15653] Waiting for CiliumEndpoint for pod cilium-test/echo-same-node-f789dd8f7-bcm6l to appear...
⌛ [gke_cilium-dev_europe-west6-a_test-tklauser-15653] Waiting for service echo-other-node to become ready...
⌛ [gke_cilium-dev_europe-west6-a_test-tklauser-15653] Waiting for service echo-same-node to become ready...
🔭 Enabling Hubble telescope...
ℹ️  Hubble is OK, flows: 8192/8192

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-pod] Testing cilium-test/client-77bd7f48dd-xmkrk -> cilium-test/echo-other-node-86774f89b9-w2v2c...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-pod] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> cilium-test/echo-other-node-86774f89b9-w2v2c (10.12.1.145)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-pod] Testing cilium-test/client-77bd7f48dd-xmkrk -> cilium-test/echo-same-node-f789dd8f7-bcm6l...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-pod] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> cilium-test/echo-same-node-f789dd8f7-bcm6l (10.12.0.200)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-service] Testing cilium-test/client-77bd7f48dd-xmkrk -> echo-other-node:8080 (ClusterIP)...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-service] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> echo-other-node:8080 (ClusterIP) (echo-other-node:8080)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-service] Testing cilium-test/client-77bd7f48dd-xmkrk -> echo-same-node:8080 (ClusterIP)...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-service] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> echo-same-node:8080 (ClusterIP) (echo-same-node:8080)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-nodeport] Testing cilium-test/client-77bd7f48dd-xmkrk -> 10.172.15.218:30083 (NodePort)...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-nodeport] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> 10.172.15.218:30083 (NodePort) (10.172.15.218:30083)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-local-nodeport] Testing cilium-test/client-77bd7f48dd-xmkrk -> 10.172.15.220:31749 (NodePort)...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-local-nodeport] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> 10.172.15.220:31749 (NodePort) (10.172.15.220:31749)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-world] Testing cilium-test/client-77bd7f48dd-xmkrk -> https://google.com...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-world] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> https://google.com (https://google.com)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-host] Testing cilium-test/client-77bd7f48dd-xmkrk -> 10.172.15.220...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-host] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> 10.172.15.220 (10.172.15.220)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-host] Testing cilium-test/client-77bd7f48dd-xmkrk -> 10.172.15.218...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-host] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> 10.172.15.218 (10.172.15.218)

---------------------------------------------------------------------------------------------------------------------
🔌 [pod-to-external-workload] Testing cilium-test/client-77bd7f48dd-xmkrk -> 10.172.15.217...
---------------------------------------------------------------------------------------------------------------------
✅ [pod-to-external-workload] cilium-test/client-77bd7f48dd-xmkrk (10.12.0.52) -> 10.172.15.217 (10.172.15.217)

---------------------------------------------------------------------------------------------------------------------
📋 Test Report
---------------------------------------------------------------------------------------------------------------------
✅ 10/10 tests successful (0 warnings)
```