### PR TITLE
Add a restart flag to config set

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type K8sConfig struct {
 
 type Parameters struct {
 	Namespace string
+	Restart   bool
 	Writer    io.Writer
 }
 

--- a/internal/cli/cmd/config.go
+++ b/internal/cli/cmd/config.go
@@ -84,7 +84,13 @@ func newCmdConfigSet() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
+	cmd.Flags().StringVarP(
+		&params.Namespace,
+		"namespace",
+		"n",
+		"kube-system",
+		"Namespace Cilium is running in",
+	)
 
 	return cmd
 }
@@ -108,7 +114,13 @@ func newCmdConfigDelete() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
+	cmd.Flags().StringVarP(
+		&params.Namespace,
+		"namespace",
+		"n",
+		"kube-system",
+		"Namespace Cilium is running in",
+	)
 
 	return cmd
 }


### PR DESCRIPTION
After setting config map changes, Cilium pods need to be restarted for the changes to take effect.
Currently, this is a manual step. Add a new flag with default set to `true`. 
