### PR TITLE
install: rollback installation on failure

### DIFF
--- a/install/encryption.go
+++ b/install/encryption.go
@@ -61,6 +61,11 @@ func (k *K8sInstaller) createEncryptionSecret(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to create encryption secret %s/%s: %w", k.params.Namespace, defaults.HubbleServerSecretName, err)
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteSecret(ctx, k.params.Namespace, defaults.EncryptionSecretName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s Secret: %w", defaults.EncryptionSecretName, err)
+		}
+	})
 
 	return nil
 }

--- a/install/install.go
+++ b/install/install.go
@@ -1002,10 +1002,11 @@ type k8sInstallerImplementation interface {
 }
 
 type K8sInstaller struct {
-	client      k8sInstallerImplementation
-	params      InstallParameters
-	flavor      k8s.Flavor
-	certManager *certs.CertManager
+	client        k8sInstallerImplementation
+	params        InstallParameters
+	flavor        k8s.Flavor
+	certManager   *certs.CertManager
+	rollbackSteps []rollbackStep
 }
 
 const (
@@ -1051,6 +1052,8 @@ type InstallParameters struct {
 	ConfigOverwrites     []string
 	configOverwrites     map[string]string
 }
+
+type rollbackStep func(context.Context)
 
 func (p *InstallParameters) validate() error {
 	p.configOverwrites = map[string]string{}
@@ -1331,7 +1334,7 @@ func (k *K8sInstaller) generateConfigMap() (*corev1.ConfigMap, error) {
 	}
 
 	for key, value := range k.params.configOverwrites {
-		k.Log("ℹ️  Manual overwrite in ConfigMap: %s=%s", key, value)
+		k.Log("ℹ️ Manual overwrite in ConfigMap: %s=%s", key, value)
 		m.Data[key] = value
 	}
 
@@ -1388,6 +1391,11 @@ func (k *K8sInstaller) deployResourceQuotas(ctx context.Context) error {
 	if _, err := k.client.CreateResourceQuota(ctx, k.params.Namespace, ciliumResourceQuota, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteResourceQuota(ctx, k.params.Namespace, defaults.AgentResourceQuota, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ResourceQuota: %w", defaults.AgentResourceQuota, err)
+		}
+	})
 
 	operatorResourceQuota := &corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1413,6 +1421,11 @@ func (k *K8sInstaller) deployResourceQuotas(ctx context.Context) error {
 	if _, err := k.client.CreateResourceQuota(ctx, k.params.Namespace, operatorResourceQuota, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteResourceQuota(ctx, k.params.Namespace, defaults.OperatorResourceQuota, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ResourceQuota: %w", defaults.OperatorResourceQuota, err)
+		}
+	})
 
 	return nil
 }
@@ -1516,27 +1529,57 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 	if _, err := k.client.CreateServiceAccount(ctx, k.params.Namespace, k8s.NewServiceAccount(defaults.AgentServiceAccountName), metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteServiceAccount(ctx, k.params.Namespace, defaults.AgentServiceAccountName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ServiceAccount: %w", defaults.AgentServiceAccountName, err)
+		}
+	})
 
 	if _, err := k.client.CreateServiceAccount(ctx, k.params.Namespace, k8s.NewServiceAccount(defaults.OperatorServiceAccountName), metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteServiceAccount(ctx, k.params.Namespace, defaults.OperatorServiceAccountName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ServiceAccount: %w", defaults.OperatorServiceAccountName, err)
+		}
+	})
 
 	k.Log("🚀 Creating Cluster roles...")
 	if _, err := k.client.CreateClusterRole(ctx, ciliumClusterRole, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteClusterRole(ctx, defaults.AgentClusterRoleName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ClusterRole: %w", defaults.AgentClusterRoleName, err)
+		}
+	})
 
 	if _, err := k.client.CreateClusterRoleBinding(ctx, k8s.NewClusterRoleBinding(defaults.AgentClusterRoleName, k.params.Namespace, defaults.AgentServiceAccountName), metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteClusterRoleBinding(ctx, defaults.AgentClusterRoleName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ClusterRoleBinding: %w", defaults.AgentClusterRoleName, err)
+		}
+	})
 
 	if _, err := k.client.CreateClusterRole(ctx, operatorClusterRole, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteClusterRole(ctx, defaults.OperatorClusterRoleName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ClusterRole: %w", defaults.OperatorClusterRoleName, err)
+		}
+	})
 
 	if _, err := k.client.CreateClusterRoleBinding(ctx, k8s.NewClusterRoleBinding(defaults.OperatorClusterRoleName, k.params.Namespace, defaults.OperatorServiceAccountName), metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteClusterRoleBinding(ctx, defaults.OperatorClusterRoleName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ClusterRoleBinding: %w", defaults.OperatorClusterRoleName, err)
+		}
+	})
 
 	if k.params.Encryption == encryptionIPsec {
 		if err := k.createEncryptionSecret(ctx); err != nil {
@@ -1553,6 +1596,11 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 	if _, err := k.client.CreateConfigMap(ctx, k.params.Namespace, configMap, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteConfigMap(ctx, k.params.Namespace, defaults.ConfigMapName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s ConfigMap: %w", defaults.ConfigMapName, err)
+		}
+	})
 
 	switch k.flavor.Kind {
 	case k8s.KindGKE:
@@ -1560,17 +1608,32 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 		if _, err := k.client.CreateDaemonSet(ctx, k.params.Namespace, k.generateGKEInitDaemonSet(), metav1.CreateOptions{}); err != nil {
 			return err
 		}
+		k.pushRollbackStep(func(ctx context.Context) {
+			if err := k.client.DeleteDaemonSet(ctx, k.params.Namespace, gkeInitName, metav1.DeleteOptions{}); err != nil {
+				k.Log("Cannot delete %s DaemonSet: %w", gkeInitName, err)
+			}
+		})
 	}
 
 	k.Log("🚀 Creating Agent DaemonSet...")
 	if _, err := k.client.CreateDaemonSet(ctx, k.params.Namespace, k.generateAgentDaemonSet(), metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteDaemonSet(ctx, k.params.Namespace, defaults.AgentDaemonSetName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s DaemonSet: %w", defaults.AgentDaemonSetName, err)
+		}
+	})
 
 	k.Log("🚀 Creating Operator Deployment...")
 	if _, err := k.client.CreateDeployment(ctx, k.params.Namespace, k.generateOperatorDeployment(), metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	k.pushRollbackStep(func(ctx context.Context) {
+		if err := k.client.DeleteDaemonSet(ctx, k.params.Namespace, defaults.OperatorDeploymentName, metav1.DeleteOptions{}); err != nil {
+			k.Log("Cannot delete %s Deployment: %w", defaults.OperatorDeploymentName, err)
+		}
+	})
 
 	if k.params.Wait {
 		k.Log("⌛ Waiting for Cilium to be installed...")
@@ -1600,4 +1663,18 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (k *K8sInstaller) pushRollbackStep(step rollbackStep) {
+	// Prepend the step to the steps slice so that, in case rollback is
+	// performed, steps are rolled back in the reverse order
+	k.rollbackSteps = append([]rollbackStep{step}, k.rollbackSteps...)
+}
+
+func (k *K8sInstaller) RollbackInstallation(ctx context.Context) {
+	k.Log("↩️ Rolling back installation...")
+
+	for _, r := range k.rollbackSteps {
+		r(ctx)
+	}
 }

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -49,7 +49,9 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 			}
 			cmd.SilenceUsage = true
 			if err := installer.Install(context.Background()); err != nil {
-				fatalf("Unable to install Cilium:  %s", err)
+				installer.RollbackInstallation(context.Background())
+
+				fatalf("Unable to install Cilium: %s", err)
 			}
 			return nil
 		},


### PR DESCRIPTION
When the `cilium install` command fails, all Kubernetes object already
created by the installer are not automatically deleted. This causes
subsequent installation attempts to fail as some objects already exist:

    $ cilium install
    🔮 Auto-detected Kubernetes kind: GKE
    🔮 Auto-detected cluster name: gke-cilium-dev-europe-west4-a-jibi-cluster
    🔮 Auto-detected IPAM mode: kubernetes
    🔮 Auto-detected datapath mode: gke
    ✅ Detected GKE native routing CIDR: 10.32.0.0/14
    🚀 Creating Resource quotas...
    Error: Unable to install Cilium:  resourcequotas "cilium-resource-quota" already exists

This commit introduces additional logic to delete, in case the
installation fails, all the objects created during the installation
process:

    $ cilium install --config install-no-conntrack-iptables-rules=true
    ..
    ↩️ Rolling back installation...
    Error: Unable to install Cilium: cannot generate ConfigMap: --install-no-conntrack-iptables-rules cannot be enabled on Google GKE

    $ cilium install
    ..
    ⌛ Waiting for Cilium to be installed...

Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>