### PR TITLE
BGP support

### DIFF
--- a/install/bgp.go
+++ b/install/bgp.go
@@ -1,0 +1,19 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+func (k *K8sInstaller) bgpEnabled() bool {
+	return k.params.configOverwrites["bgp-announce-lb-ip"] == "true"
+}

--- a/install/install.go
+++ b/install/install.go
@@ -150,6 +150,12 @@ var operatorClusterRole = &rbacv1.ClusterRole{
 			Verbs: []string{"get", "list", "watch"},
 		},
 		{
+
+			APIGroups: []string{""},
+			Resources: []string{"services/status"}, // to perform LB IP allocation for BGP
+			Verbs:     []string{"update"},
+		},
+		{
 			APIGroups: []string{"cilium.io"},
 			Resources: []string{
 				"ciliumnetworkpolicies",

--- a/install/install.go
+++ b/install/install.go
@@ -726,6 +726,26 @@ func (k *K8sInstaller) generateAgentDaemonSet() *appsv1.DaemonSet {
 	ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, auxVolumes...)
 	ds.Spec.Template.Spec.Containers[0].VolumeMounts = append(ds.Spec.Template.Spec.Containers[0].VolumeMounts, auxVolumeMounts...)
 
+	if k.bgpEnabled() {
+		ds.Spec.Template.Spec.Containers[0].VolumeMounts = append(ds.Spec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "bgp-config-path",
+				ReadOnly:  true,
+				MountPath: "/var/lib/cilium/bgp",
+			},
+		)
+		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: "bgp-config-path",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "bgp-config",
+					},
+				},
+			},
+		})
+	}
+
 	return ds
 }
 
@@ -911,6 +931,26 @@ func (k *K8sInstaller) generateOperatorDeployment() *appsv1.Deployment {
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "AZURE_CLIENT_SECRET",
 			Value: k.params.Azure.ClientSecret,
+		})
+	}
+
+	if k.bgpEnabled() {
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "bgp-config-path",
+				ReadOnly:  true,
+				MountPath: "/var/lib/cilium/bgp",
+			},
+		)
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: "bgp-config-path",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "bgp-config",
+					},
+				},
+			},
 		})
 	}
 


### PR DESCRIPTION
Following the Helm changes in https://github.com/cilium/cilium/pull/15340, update the CLI accordingly.

See commit msgs.

- install: Add update ability for services/status in Operator
- install: Update Agent and Operator resources for BGP
