### PR TITLE
tests: Add policy testing support

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -19,6 +19,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
       - name: Build and install cilium CLI binary
         run: sudo make install
 

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -20,6 +20,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
       - name: Build and install cilium CLI binary
         run: sudo make install
 

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -20,6 +20,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
       - name: Build and install cilium CLI binary
         run: sudo make install
 

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -22,6 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
       - name: Build and install cilium CLI binary
         run: sudo make install
 

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -20,6 +20,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
       - name: Build and install cilium CLI binary
         run: sudo make install
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -22,6 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
       - name: Build and install cilium CLI binary
         run: sudo make install
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -75,15 +75,28 @@ jobs:
 
       - name: Install Cilium with Encryption
         run: |
-          cilium install --encryption
+          cilium install --encryption --kube-proxy-replacement=probe
+
+      - name: Enable Relay
+        run: |
+          cilium hubble enable
+
+          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
 
       - name: Status
         run: |
           cilium status --wait
 
+      - name: Relay Port Forward
+        run: |
+          pkill -f "kubectl port-forward.*hubble-relay" || true
+          sleep 1s
+          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          sleep 5s
+
       - name: Connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --force-deploy -v
 
       - name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -21,6 +21,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
       - name: Build and install cilium CLI binary
         run: sudo make install
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+
       - name: Generate the artifacts
         run: make release
       - name: Create Release

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -254,9 +254,6 @@ type TestContext interface {
 	// AllFlows returns true if all flows should be shown
 	AllFlows() bool
 
-	// FlowSettleSleepDuration is the duration to wait before collecting flows
-	FlowSettleSleepDuration() time.Duration
-
 	// PostTestSleepDuration is the duration to sleep after each test
 	PostTestSleepDuration() time.Duration
 
@@ -294,9 +291,6 @@ type TestRun struct {
 
 	// warnings is the number of warnings encountered in this test run
 	warnings int
-
-	// flowsSettled is true once flows have been given time to settle so they can be collected
-	flowsSettled bool
 }
 
 // NewTestRun creates a new test run
@@ -372,21 +366,6 @@ func (t *TestRun) printFlows(pod string, f *flowsSet, r FlowRequirementResults) 
 		//lint:ignore SA1019 Summary is deprecated but there is no real alternative yet
 		t.context.Log("%s%s: %s -> %s %s %s (%s)", flowPrefix, ts, src, dst, hubprinter.GetFlowType(f), f.Verdict.String(), f.Summary)
 	}
-}
-
-func (t *TestRun) settleFlows(ctx context.Context) error {
-	if t.flowsSettled {
-		return nil
-	}
-
-	select {
-	case <-time.After(t.context.FlowSettleSleepDuration()):
-	case <-ctx.Done():
-		return fmt.Errorf("flow settling interrupted: %w", ctx.Err())
-	}
-
-	t.flowsSettled = true
-	return nil
 }
 
 type MatchMap map[int]bool
@@ -475,10 +454,6 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, req filt
 		return
 	}
 
-	if err := t.settleFlows(ctx); err != nil {
-		return
-	}
-
 	w := utils.NewWaitObserver(ctx, utils.WaitParameters{
 		Timeout:       defaults.FlowWaitTimeout,
 		RetryInterval: defaults.FlowRetryInterval,
@@ -486,8 +461,6 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, req filt
 			t.context.Log("⌛ Waiting (%s) for flows: %s", wait, err)
 		}})
 	defer w.Cancel()
-
-	var err error
 
 retry:
 	flows, err := getFlows(ctx, hubbleClient, t.started.Add(-2*time.Second), pod, podIP)
@@ -770,20 +743,19 @@ const (
 )
 
 type Parameters struct {
-	CiliumNamespace         string
-	TestNamespace           string
-	SingleNode              bool
-	PrintFlows              bool
-	ForceDeploy             bool
-	Hubble                  bool
-	HubbleServer            string
-	MultiCluster            string
-	Tests                   []string
-	PostTestSleepDuration   time.Duration
-	FlowSettleSleepDuration time.Duration
-	FlowValidation          string
-	AllFlows                bool
-	Writer                  io.Writer
+	CiliumNamespace       string
+	TestNamespace         string
+	SingleNode            bool
+	PrintFlows            bool
+	ForceDeploy           bool
+	Hubble                bool
+	HubbleServer          string
+	MultiCluster          string
+	Tests                 []string
+	PostTestSleepDuration time.Duration
+	FlowValidation        string
+	AllFlows              bool
+	Writer                io.Writer
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {
@@ -1242,10 +1214,6 @@ func (k *K8sConnectivityCheck) ClientPods() map[string]PodContext {
 
 func (k *K8sConnectivityCheck) EchoServices() map[string]ServiceContext {
 	return k.echoServices
-}
-
-func (k *K8sConnectivityCheck) FlowSettleSleepDuration() time.Duration {
-	return k.params.FlowSettleSleepDuration
 }
 
 func (k *K8sConnectivityCheck) PostTestSleepDuration() time.Duration {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -43,7 +43,8 @@ import (
 )
 
 const (
-	ClientDeploymentName = "client"
+	ClientDeploymentName  = "client"
+	Client2DeploymentName = "client2"
 
 	echoSameNodeDeploymentName  = "echo-same-node"
 	echoOtherNodeDeploymentName = "echo-other-node"
@@ -80,6 +81,7 @@ type deploymentParameters struct {
 	Command        []string
 	Affinity       *corev1.Affinity
 	ReadinessProbe *corev1.Probe
+	Labels         map[string]string
 }
 
 func newDeployment(p deploymentParameters) *appsv1.Deployment {
@@ -87,7 +89,7 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 		p.Replicas = 1
 	}
 	replicas32 := int32(p.Replicas)
-	return &appsv1.Deployment{
+	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: p.Name,
 			Labels: map[string]string{
@@ -132,6 +134,12 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 			},
 		},
 	}
+
+	for k, v := range p.Labels {
+		dep.Spec.Template.ObjectMeta.Labels[k] = v
+	}
+
+	return dep
 }
 
 func newLocalReadinessProbe(port int, path string) *corev1.Probe {
@@ -202,6 +210,12 @@ func (p PodContext) Address() string {
 	return p.Pod.Status.PodIP
 }
 
+// HasLabel checks if given label exists and value matches
+func (p PodContext) HasLabel(name, value string) bool {
+	v, ok := p.Pod.Labels[name]
+	return ok && v == value
+}
+
 // ServiceContext is a service acting as a peer in a connectivity test
 type ServiceContext struct {
 	// Service  is the Kubernetes service resource
@@ -216,6 +230,12 @@ func (s ServiceContext) Name() string {
 // Address returns the network address of the service
 func (s ServiceContext) Address() string {
 	return s.Service.Name
+}
+
+// HasLabel checks if given label exists and value matches
+func (s ServiceContext) HasLabel(name, value string) bool {
+	v, ok := s.Service.Labels[name]
+	return ok && v == value
 }
 
 // NetworkEndpointContext is a network endpoint acting as a peer in a connectivity test
@@ -238,6 +258,11 @@ func (n NetworkEndpointContext) Name() string {
 // Address it the network address of the network endpoint
 func (n NetworkEndpointContext) Address() string {
 	return n.Peer
+}
+
+// HasLabel checks if given label exists and value matches
+func (n NetworkEndpointContext) HasLabel(name, value string) bool {
+	return false
 }
 
 // TestContext is the context a test uses to interact with the test framework
@@ -304,11 +329,11 @@ type TestRun struct {
 	// context is the test context of the framework
 	context TestContext
 
-	// src is the peer used as the source (client)
-	src TestPeer
+	// Src is the peer used as the source (client)
+	Src TestPeer
 
-	// dst is the peer used as the destination (server)
-	dst TestPeer
+	// Dst is the peer used as the destination (server)
+	Dst TestPeer
 
 	// expectedEgress is the expected test result for egress from the source pod
 	expectedEgress Result
@@ -339,8 +364,8 @@ func NewTestRun(t ConnectivityTest, c TestContext, src, dst TestPeer) *TestRun {
 		name:        t.Name(),
 		verboseName: fmt.Sprintf("%s: %s -> %s", t.Name(), src.Name(), dst.Name()),
 		context:     c,
-		src:         src,
-		dst:         dst,
+		Src:         src,
+		Dst:         dst,
 		started:     time.Now(),
 		flows:       map[string]*flowsSet{},
 		flowResults: map[string]FlowRequirementResults{},
@@ -565,8 +590,8 @@ type FlowParameters struct {
 
 func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequirement {
 	var egress *filters.FlowSetRequirement
-	srcIP := t.src.Address()
-	dstIP := t.dst.Address()
+	srcIP := t.Src.Address()
+	dstIP := t.Dst.Address()
 
 	if dstIP != "" && net.ParseIP(dstIP) == nil {
 		// dstIP is not an IP address, assume it is a domain name
@@ -583,12 +608,20 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 
 		switch t.expectedEgress {
 		case ResultOK:
-			egress = &filters.FlowSetRequirement{
-				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
-				Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
-				Except: []filters.FlowRequirement{
-					{Filter: filters.Drop(), Msg: "Drop"},
-				},
+			if t.expectedIngress != ResultOK {
+				// If ingress drops we may get the drop flows also for egress, tolerate that
+				egress = &filters.FlowSetRequirement{
+					First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+					Last:  filters.FlowRequirement{Filter: filters.Or(filters.And(ipResponse, icmpResponse), filters.And(ipRequest, filters.Drop())), Msg: "ICMP response or request drop", SkipOnAggregation: true},
+				}
+			} else {
+				egress = &filters.FlowSetRequirement{
+					First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+					Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
+					Except: []filters.FlowRequirement{
+						{Filter: filters.Drop(), Msg: "Drop"},
+					},
+				}
 			}
 		case ResultDrop:
 			egress = &filters.FlowSetRequirement{
@@ -599,7 +632,7 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 				},
 			}
 		default:
-			t.Failure("Invalid expected egress result %s", t.expectedEgress.String())
+			t.Failure("Invalid expected ICMP egress result %s", t.expectedEgress.String())
 		}
 	case TCP:
 		tcpRequest := filters.TCP(0, p.DstPort)
@@ -648,7 +681,7 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 				},
 			}
 		default:
-			t.Failure("Invalid expected egress result %s", t.expectedEgress.String())
+			t.Failure("Invalid expected TCP egress result %s", t.expectedEgress.String())
 		}
 	case UDP:
 		t.Failure("UDP egress flow matching not implemented yet")
@@ -672,8 +705,8 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 }
 
 func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequirement {
-	srcIP := t.src.Address()
-	dstIP := t.dst.Address()
+	srcIP := t.Src.Address()
+	dstIP := t.Dst.Address()
 
 	var ingress *filters.FlowSetRequirement
 
@@ -694,7 +727,29 @@ func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequi
 
 	switch p.Protocol {
 	case ICMP:
-		t.Failure("ICMP ingress flow matching not implemented yet")
+		icmpRequest := filters.Or(filters.ICMP(8), filters.ICMPv6(128))
+		icmpResponse := filters.Or(filters.ICMP(0), filters.ICMPv6(129))
+
+		switch t.expectedIngress {
+		case ResultOK:
+			ingress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+				Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.Drop(), Msg: "Drop"},
+				},
+			}
+		case ResultDrop:
+			ingress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest, filters.Drop()), Msg: "Drop"},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response"},
+				},
+			}
+		default:
+			t.Failure("Invalid expected ICMP ingress result %s", t.expectedEgress.String())
+		}
 	case TCP:
 		switch t.expectedIngress {
 		case ResultOK:
@@ -714,7 +769,7 @@ func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequi
 			// Nothing, used when expecting a drop in egress so that packet does not show up at ingress
 		default:
 			// Ingress drops not supported yet
-			t.Failure("Invalid expected ingress result %s", t.expectedIngress.String())
+			t.Failure("Invalid expected TCP ingress result %s", t.expectedIngress.String())
 		}
 	case UDP:
 		t.Failure("UDP ingress flow matching not implemented yet")
@@ -804,8 +859,8 @@ func (t *TestRun) End() {
 
 	t.context.Log("%s [%s] %s (%s) -> %s (%s)",
 		prefix, t.name,
-		t.src.Name(), t.src.Address(),
-		t.dst.Name(), t.dst.Address())
+		t.Src.Name(), t.Src.Address(),
+		t.Dst.Name(), t.Dst.Address())
 
 	if duration := t.context.PostTestSleepDuration(); duration != time.Duration(0) {
 		time.Sleep(duration)
@@ -827,6 +882,9 @@ type TestPeer interface {
 	// Address must return the network address of the peer. This can be a
 	// DNS name or an IP address.
 	Address() string
+
+	// HasLabel checks if given label exists and value matches
+	HasLabel(name, value string) bool
 }
 
 // ConnectivityTest is the interface to implement for all connectivity tests
@@ -1120,6 +1178,7 @@ func (k *K8sConnectivityCheck) deleteDeployments(ctx context.Context, client k8s
 	client.DeleteDeployment(ctx, k.params.TestNamespace, echoSameNodeDeploymentName, metav1.DeleteOptions{})
 	client.DeleteDeployment(ctx, k.params.TestNamespace, echoOtherNodeDeploymentName, metav1.DeleteOptions{})
 	client.DeleteDeployment(ctx, k.params.TestNamespace, ClientDeploymentName, metav1.DeleteOptions{})
+	client.DeleteDeployment(ctx, k.params.TestNamespace, Client2DeploymentName, metav1.DeleteOptions{})
 	client.DeleteService(ctx, k.params.TestNamespace, echoSameNodeDeploymentName, metav1.DeleteOptions{})
 	client.DeleteService(ctx, k.params.TestNamespace, echoOtherNodeDeploymentName, metav1.DeleteOptions{})
 	client.DeleteNamespace(ctx, k.params.TestNamespace, metav1.DeleteOptions{})
@@ -1137,7 +1196,7 @@ func (k *K8sConnectivityCheck) deleteDeployments(ctx context.Context, client k8s
 }
 
 func (k *K8sConnectivityCheck) deploymentList() (srcList []string, dstList []string) {
-	srcList = []string{ClientDeploymentName, echoSameNodeDeploymentName}
+	srcList = []string{ClientDeploymentName, Client2DeploymentName, echoSameNodeDeploymentName}
 
 	if k.params.MultiCluster != "" || !k.params.SingleNode {
 		dstList = append(dstList, echoOtherNodeDeploymentName)
@@ -1279,10 +1338,11 @@ func (k *K8sConnectivityCheck) deploy(ctx context.Context) error {
 	if err != nil {
 		k.Log("✨ [%s] Deploying same-node deployment...", k.clients.src.ClusterName())
 		echoDeployment := newDeployment(deploymentParameters{
-			Name:  echoSameNodeDeploymentName,
-			Kind:  kindEchoName,
-			Port:  8080,
-			Image: "quay.io/cilium/json-mock:1.2",
+			Name:   echoSameNodeDeploymentName,
+			Kind:   kindEchoName,
+			Port:   8080,
+			Image:  "quay.io/cilium/json-mock:1.2",
+			Labels: map[string]string{"other": "echo"},
 			Affinity: &corev1.Affinity{
 				PodAffinity: &corev1.PodAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -1319,6 +1379,24 @@ func (k *K8sConnectivityCheck) deploy(ctx context.Context) error {
 		_, err = k.clients.src.CreateDeployment(ctx, k.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to create deployment %s: %s", ClientDeploymentName, err)
+		}
+	}
+
+	// 2nd client with label other=client
+	_, err = k.clients.src.GetDeployment(ctx, k.params.TestNamespace, Client2DeploymentName, metav1.GetOptions{})
+	if err != nil {
+		k.Log("✨ [%s] Deploying client2 deployment...", k.clients.src.ClusterName())
+		clientDeployment := newDeployment(deploymentParameters{
+			Name:    Client2DeploymentName,
+			Kind:    kindClientName,
+			Port:    8080,
+			Image:   "quay.io/cilium/alpine-curl:1.1",
+			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
+			Labels:  map[string]string{"other": "client"},
+		})
+		_, err = k.clients.src.CreateDeployment(ctx, k.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create deployment %s: %s", Client2DeploymentName, err)
 		}
 	}
 
@@ -1426,7 +1504,7 @@ func (k *K8sConnectivityCheck) waitForService(ctx context.Context, client k8sCon
 	}
 
 retry:
-	if _, _, err := client.ExecInPodWithStderr(ctx, clientPod.Pod.Namespace, clientPod.Pod.Name, ClientDeploymentName, []string{"nslookup", service}); err != nil {
+	if _, _, err := client.ExecInPodWithStderr(ctx, clientPod.Pod.Namespace, clientPod.Pod.Name, clientPod.Pod.Labels["name"], []string{"nslookup", service}); err != nil {
 		select {
 		case <-time.After(time.Second):
 		case <-ctx.Done():

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -1171,7 +1171,7 @@ func (p Parameters) testEnabled(test string) bool {
 			numAllow++
 		}
 
-		if p == test {
+		if strings.HasPrefix(test, p) {
 			return result
 		}
 	}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -151,6 +151,7 @@ func newLocalReadinessProbe(port int, path string) *corev1.Probe {
 }
 
 type k8sConnectivityImplementation interface {
+	GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error)
 	GetService(ctx context.Context, namespace, service string, opts metav1.GetOptions) (*corev1.Service, error)
 	CreateService(ctx context.Context, namespace string, service *corev1.Service, opts metav1.CreateOptions) (*corev1.Service, error)
 	DeleteService(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
@@ -253,6 +254,10 @@ type TestContext interface {
 
 	// AllFlows returns true if all flows should be shown
 	AllFlows() bool
+
+	// FlowAggregation returns true if flow aggregation is enabled in any
+	// of the clusters
+	FlowAggregation() bool
 
 	// PostTestSleepDuration is the duration to sleep after each test
 	PostTestSleepDuration() time.Duration
@@ -438,18 +443,23 @@ func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, po
 	}
 
 	for _, f := range req.Middle {
+		if f.SkipOnAggregation && t.context.FlowAggregation() {
+			continue
+		}
 		match(true, f)
 	}
 
-	if index, match, lastFlow := match(true, req.Last); !match {
-		r.NeedMoreFlows = true
-	} else {
-		r.LastMatch = index
+	if !(req.Last.SkipOnAggregation && t.context.FlowAggregation()) {
+		if index, match, lastFlow := match(true, req.Last); !match {
+			r.NeedMoreFlows = true
+		} else {
+			r.LastMatch = index
 
-		if lastFlow != nil {
-			flowTimestamp, err := ptypes.Timestamp(lastFlow.Time)
-			if err == nil {
-				r.LastMatchTimestamp = flowTimestamp
+			if lastFlow != nil {
+				flowTimestamp, err := ptypes.Timestamp(lastFlow.Time)
+				if err == nil {
+					r.LastMatchTimestamp = flowTimestamp
+				}
 			}
 		}
 	}
@@ -622,6 +632,7 @@ type K8sConnectivityCheck struct {
 	echoServices       map[string]ServiceContext
 	results            TestResults
 	lastFlowTimestamps map[string]time.Time
+	flowAggregation    bool
 }
 
 func NewK8sConnectivityCheck(client k8sConnectivityImplementation, p Parameters) (*K8sConnectivityCheck, error) {
@@ -889,10 +900,27 @@ func (d *deploymentClients) clients() []k8sConnectivityImplementation {
 	return []k8sConnectivityImplementation{d.src}
 }
 
+func (k *K8sConnectivityCheck) logAggregationMode(ctx context.Context, client k8sConnectivityImplementation) (string, error) {
+	cm, err := client.GetConfigMap(ctx, k.params.CiliumNamespace, defaults.ConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve ConfigMap %q: %w", defaults.ConfigMapName, err)
+	}
+
+	if cm.Data == nil {
+		return "", fmt.Errorf("ConfigMap %q does not contain any configuration", defaults.ConfigMapName)
+	}
+
+	return cm.Data[defaults.ConfigMapKeyMonitorAggregation], nil
+}
+
 func (k *K8sConnectivityCheck) initClients(ctx context.Context) (*deploymentClients, error) {
 	c := &deploymentClients{
 		src: k.client,
 		dst: k.client,
+	}
+
+	if a, _ := k.logAggregationMode(ctx, c.src); a != defaults.ConfigMapValueMonitorAggregatonNone {
+		k.flowAggregation = true
 	}
 
 	// In single-cluster environment, automatically detect a single-node
@@ -917,6 +945,14 @@ func (k *K8sConnectivityCheck) initClients(ctx context.Context) (*deploymentClie
 
 		c.dst = dst
 		c.dstInOtherCluster = true
+
+		if a, _ := k.logAggregationMode(ctx, c.dst); a != defaults.ConfigMapValueMonitorAggregatonNone {
+			k.flowAggregation = true
+		}
+	}
+
+	if k.flowAggregation {
+		k.Log("ℹ️  Monitor aggregation detected, will skip some flow validation steps")
 	}
 
 	return c, nil
@@ -1241,6 +1277,10 @@ func (k *K8sConnectivityCheck) PrintFlows() bool {
 
 func (k *K8sConnectivityCheck) AllFlows() bool {
 	return k.params.AllFlows
+}
+
+func (k *K8sConnectivityCheck) FlowAggregation() bool {
+	return k.flowAggregation
 }
 
 func (k *K8sConnectivityCheck) EchoPods() map[string]PodContext {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"time"
 
@@ -150,6 +151,14 @@ func newLocalReadinessProbe(port int, path string) *corev1.Probe {
 	}
 }
 
+type k8sPolicyImplementation interface {
+	ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error)
+	GetCiliumNetworkPolicy(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*ciliumv2.CiliumNetworkPolicy, error)
+	CreateCiliumNetworkPolicy(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy, opts metav1.CreateOptions) (*ciliumv2.CiliumNetworkPolicy, error)
+	UpdateCiliumNetworkPolicy(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy, opts metav1.UpdateOptions) (*ciliumv2.CiliumNetworkPolicy, error)
+	DeleteCiliumNetworkPolicy(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
+}
+
 type k8sConnectivityImplementation interface {
 	GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error)
 	GetService(ctx context.Context, namespace, service string, opts metav1.GetOptions) (*corev1.Service, error)
@@ -169,6 +178,8 @@ type k8sConnectivityImplementation interface {
 	ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error)
 	ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error)
 	ClusterName() (name string)
+
+	k8sPolicyImplementation
 }
 
 // PodContext is a pod acting as a peer in a connectivity test
@@ -240,6 +251,12 @@ type TestContext interface {
 	// EchoServices returns a map of all deployed echo services
 	EchoServices() map[string]ServiceContext
 
+	// ApplyCNPs applies the given CNP to the test context, returns the number of failures
+	ApplyCNPs(ctx context.Context, deletePrevious bool, cnps []*ciliumv2.CiliumNetworkPolicy) int
+
+	// DeleteCNP deleted the given CNP from the test context
+	DeleteCNPs(ctx context.Context, cnps []*ciliumv2.CiliumNetworkPolicy)
+
 	// Log is used to log a status update
 	Log(format string, a ...interface{})
 
@@ -254,6 +271,9 @@ type TestContext interface {
 
 	// AllFlows returns true if all flows should be shown
 	AllFlows() bool
+
+	// Verbose returns true if additional diagnostic messages should be shown
+	Verbose() bool
 
 	// FlowAggregation returns true if flow aggregation is enabled in any
 	// of the clusters
@@ -290,6 +310,12 @@ type TestRun struct {
 	// dst is the peer used as the destination (server)
 	dst TestPeer
 
+	// expectedEgress is the expected test result for egress from the source pod
+	expectedEgress Result
+
+	// expectedIngress is the expected test result for the ingress in to the destination pod
+	expectedIngress Result
+
 	// flows is a map of all flow logs, indexed by pod name
 	flows map[string]*flowsSet
 
@@ -306,12 +332,12 @@ type TestRun struct {
 }
 
 // NewTestRun creates a new test run
-func NewTestRun(name string, c TestContext, src, dst TestPeer) *TestRun {
-	c.Header("🔌 [%s] Testing %s -> %s...", name, src.Name(), dst.Name())
+func NewTestRun(t ConnectivityTest, c TestContext, src, dst TestPeer) *TestRun {
+	c.Header("🔌 [%s] Testing %s -> %s...", t.Name(), src.Name(), dst.Name())
 
-	return &TestRun{
-		name:        name,
-		verboseName: name + ": " + src.Name() + " -> " + dst.Name(),
+	run := &TestRun{
+		name:        t.Name(),
+		verboseName: fmt.Sprintf("%s: %s -> %s", t.Name(), src.Name(), dst.Name()),
 		context:     c,
 		src:         src,
 		dst:         dst,
@@ -319,6 +345,17 @@ func NewTestRun(name string, c TestContext, src, dst TestPeer) *TestRun {
 		flows:       map[string]*flowsSet{},
 		flowResults: map[string]FlowRequirementResults{},
 	}
+
+	// Record policy apply failure on each test run
+	k := c.(*K8sConnectivityCheck)
+	if k.policyFailures > 0 {
+		run.Failure("Policy apply failed")
+	}
+
+	// Set policy expectations for this test run
+	run.expectedEgress, run.expectedIngress = t.getExpectations(run)
+
+	return run
 }
 
 // Failure must be called when a failure is detected performing the test
@@ -330,6 +367,34 @@ func (t *TestRun) Failure(format string, a ...interface{}) {
 // Success can be called to log a successful event
 func (t *TestRun) Success(format string, a ...interface{}) {
 	t.context.Log("✅ "+format, a...)
+}
+
+// Waiting can be called to log a slow event
+func (t *TestRun) Waiting(format string, a ...interface{}) {
+	t.context.Log("⌛ "+format+"...", a...)
+}
+
+// LogResult can be called to log command results
+func (t *TestRun) LogResult(cmd []string, err error, stdout bytes.Buffer) {
+	cmdName := cmd[0]
+	cmdStr := strings.Join(cmd, " ")
+	shouldSucceed := t.expectedEgress == ResultOK && t.expectedIngress == ResultOK
+	if err != nil {
+		if shouldSucceed {
+			t.Failure("%s command %q failed: %w", cmdName, cmdStr, err)
+		} else {
+			t.Success("%s command %q failed as expected: %w", cmdName, cmdStr, err)
+		}
+	} else {
+		if shouldSucceed {
+			t.Success("%s command %q succeeded", cmdName, cmdStr)
+		} else {
+			t.Failure("%s command %q succeeded while it should have failed", cmdName, cmdStr)
+		}
+		if t.context.Verbose() {
+			t.context.Log("ℹ️  %s output: %s", cmdName, stdout.String())
+		}
+	}
 }
 
 // Warning must be called when a warning is detected performing the test
@@ -392,7 +457,7 @@ type FlowRequirementResults struct {
 	LastMatchTimestamp time.Time
 }
 
-func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, pod string, req filters.FlowSetRequirement) (r FlowRequirementResults) {
+func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, pod string, req *filters.FlowSetRequirement) (r FlowRequirementResults) {
 	var goodLog []string
 
 	r.Matched = MatchMap{}
@@ -471,9 +536,198 @@ func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, po
 	return
 }
 
+// L4Protocol identifies the network protocol being tested
+type L4Protocol int
+
+const (
+	TCP L4Protocol = iota
+	UDP
+	ICMP
+)
+
+// FlowParameters defines parameters for test result flow matching
+type FlowParameters struct {
+	// Protocol is the network protocol being tested
+	Protocol L4Protocol
+
+	// DNSRequired is true if DNS flows must be seen before the test protocol
+	DNSRequired bool
+
+	// RSTAllowed is true if TCP connection may end with either RST or FIN
+	RSTAllowed bool
+
+	// DstPort is the destination port number to be mached. Ignored for ICMP.
+	DstPort int
+
+	// NodePort, if non-zero, indicates an alternative port number for the DstPort to be matched
+	NodePort int
+}
+
+func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequirement {
+	var egress *filters.FlowSetRequirement
+	srcIP := t.src.Address()
+	dstIP := t.dst.Address()
+
+	if dstIP != "" && net.ParseIP(dstIP) == nil {
+		// dstIP is not an IP address, assume it is a domain name
+		dstIP = ""
+	}
+
+	ipResponse := filters.IP(dstIP, srcIP)
+	ipRequest := filters.IP(srcIP, dstIP)
+
+	switch p.Protocol {
+	case ICMP:
+		icmpRequest := filters.Or(filters.ICMP(8), filters.ICMPv6(128))
+		icmpResponse := filters.Or(filters.ICMP(0), filters.ICMPv6(129))
+
+		switch t.expectedEgress {
+		case ResultOK:
+			egress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+				Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.Drop(), Msg: "Drop"},
+				},
+			}
+		case ResultDrop:
+			egress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest, filters.Drop()), Msg: "Drop"},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response"},
+				},
+			}
+		default:
+			t.Failure("Invalid expected egress result %s", t.expectedEgress.String())
+		}
+	case TCP:
+		tcpRequest := filters.TCP(0, p.DstPort)
+		tcpResponse := filters.TCP(p.DstPort, 0)
+		if p.NodePort != 0 {
+			tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
+			tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
+		}
+
+		switch t.expectedEgress {
+		case ResultOK:
+			if p.RSTAllowed {
+				egress = &filters.FlowSetRequirement{
+					First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
+					Middle: []filters.FlowRequirement{
+						{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
+					},
+					// For the connection termination, we will either see:
+					// a) FIN + FIN b) FIN + RST c) RST
+					Last: filters.FlowRequirement{Filter: filters.And(ipResponse, tcpResponse, filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true},
+					Except: []filters.FlowRequirement{
+						{Filter: filters.Drop(), Msg: "Drop"},
+					},
+				}
+			} else {
+				egress = &filters.FlowSetRequirement{
+					First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
+					Middle: []filters.FlowRequirement{
+						{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
+					},
+					// Either side may FIN first
+					Last: filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.FIN()), Msg: "FIN"},
+					Except: []filters.FlowRequirement{
+						{Filter: filters.RST(), Msg: "RST"},
+						{Filter: filters.Drop(), Msg: "Drop"},
+					},
+				}
+			}
+		case ResultDrop:
+			egress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
+				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.Drop()), Msg: "Drop"},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.SYNACK(), Msg: "SYN-ACK"},
+					{Filter: filters.FIN(), Msg: "FIN"},
+				},
+			}
+		default:
+			t.Failure("Invalid expected egress result %s", t.expectedEgress.String())
+		}
+	case UDP:
+		t.Failure("UDP egress flow matching not implemented yet")
+	default:
+		t.Failure("Invalid egress flow matching protocol %d", p.Protocol)
+	}
+
+	if p.DNSRequired {
+		dnsRequest := filters.Or(filters.UDP(0, 53), filters.TCP(0, 53))
+		dnsResponse := filters.Or(filters.UDP(53, 0), filters.TCP(53, 0))
+
+		first := egress.First
+		egress.First = filters.FlowRequirement{Filter: filters.And(ipRequest, dnsRequest), Msg: "DNS request"}
+		egress.Middle = append([]filters.FlowRequirement{
+			{Filter: filters.And(ipResponse, dnsResponse), Msg: "DNS response"},
+			first,
+		}, egress.Middle...)
+	}
+
+	return egress
+}
+
+func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequirement {
+	srcIP := t.src.Address()
+	dstIP := t.dst.Address()
+
+	var ingress *filters.FlowSetRequirement
+
+	if dstIP != "" && net.ParseIP(dstIP) == nil {
+		// dstIP is not an IP address, assume it is a domain name
+		dstIP = ""
+	}
+
+	ipResponse := filters.IP(dstIP, srcIP)
+	ipRequest := filters.IP(srcIP, dstIP)
+
+	tcpRequest := filters.TCP(0, p.DstPort)
+	tcpResponse := filters.TCP(p.DstPort, 0)
+	if p.NodePort != 0 {
+		tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
+		tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
+	}
+
+	switch p.Protocol {
+	case ICMP:
+		t.Failure("ICMP ingress flow matching not implemented yet")
+	case TCP:
+		switch t.expectedIngress {
+		case ResultOK:
+			ingress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
+				Middle: []filters.FlowRequirement{
+					{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
+				},
+				// Either side may FIN first
+				Last: filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.FIN()), Msg: "FIN"},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.RST(), Msg: "RST"},
+					{Filter: filters.Drop(), Msg: "Drop"},
+				},
+			}
+		case ResultNone:
+			// Nothing, used when expecting a drop in egress so that packet does not show up at ingress
+		default:
+			// Ingress drops not supported yet
+			t.Failure("Invalid expected ingress result %s", t.expectedIngress.String())
+		}
+	case UDP:
+		t.Failure("UDP ingress flow matching not implemented yet")
+	default:
+		t.Failure("Invalid ingress flow matching protocol %d", p.Protocol)
+	}
+
+	return ingress
+}
+
 // ValidateFlows retrieves the flow pods of the specified pod and validates
 // that all filters find a match. On failure, t.Failure() is called.
-func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, req filters.FlowSetRequirement) {
+func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, req *filters.FlowSetRequirement) {
 	hubbleClient := t.context.HubbleClient()
 	if hubbleClient == nil {
 		return
@@ -577,6 +831,8 @@ type TestPeer interface {
 
 // ConnectivityTest is the interface to implement for all connectivity tests
 type ConnectivityTest interface {
+	Policy
+
 	// Name must return the name of the test
 	Name() string
 
@@ -633,6 +889,8 @@ type K8sConnectivityCheck struct {
 	results            TestResults
 	lastFlowTimestamps map[string]time.Time
 	flowAggregation    bool
+	policies           map[string]*ciliumv2.CiliumNetworkPolicy
+	policyFailures     int
 }
 
 func NewK8sConnectivityCheck(client k8sConnectivityImplementation, p Parameters) (*K8sConnectivityCheck, error) {
@@ -798,6 +1056,7 @@ type Parameters struct {
 	FlowValidation        string
 	AllFlows              bool
 	Writer                io.Writer
+	Verbose               bool
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {
@@ -1245,6 +1504,8 @@ func (k *K8sConnectivityCheck) validateDeployment(ctx context.Context) error {
 		k.waitForService(ctx, k.client, serviceName)
 	}
 
+	k.policies = map[string]*ciliumv2.CiliumNetworkPolicy{}
+
 	return nil
 }
 
@@ -1277,6 +1538,10 @@ func (k *K8sConnectivityCheck) PrintFlows() bool {
 
 func (k *K8sConnectivityCheck) AllFlows() bool {
 	return k.params.AllFlows
+}
+
+func (k *K8sConnectivityCheck) Verbose() bool {
+	return k.params.Verbose
 }
 
 func (k *K8sConnectivityCheck) FlowAggregation() bool {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -676,7 +676,8 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 			if p.RSTAllowed {
 				// For the connection termination, we will either see:
 				// a) FIN + FIN b) FIN + RST c) RST
-				egress.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, tcpResponse, filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true}
+				// Either side may RST or FIN first
+				egress.Last = filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true}
 			} else {
 				egress.Except = append(egress.Except, filters.FlowRequirement{Filter: filters.RST(), Msg: "RST"})
 			}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -259,6 +259,13 @@ type TestContext interface {
 
 	// Report is called to report the outcome of a test
 	Report(r TestResult)
+
+	// StoreLastTimestamp stores the last flow timestamp of a test run to
+	// allow later tests to skip flows up to this point
+	StoreLastTimestamp(pod string, t time.Time)
+
+	// LoadLastTimestamp loads the last flow timestamp of a previous test for a particular pod
+	LoadLastTimestamp(pod string) time.Time
 }
 
 // TestRun is the state of an individual test run
@@ -371,12 +378,13 @@ func (t *TestRun) printFlows(pod string, f *flowsSet, r FlowRequirementResults) 
 type MatchMap map[int]bool
 
 type FlowRequirementResults struct {
-	FirstMatch    int
-	LastMatch     int
-	Matched       MatchMap
-	Log           []string
-	Failures      int
-	NeedMoreFlows bool
+	FirstMatch         int
+	LastMatch          int
+	Matched            MatchMap
+	Log                []string
+	Failures           int
+	NeedMoreFlows      bool
+	LastMatchTimestamp time.Time
 }
 
 func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, pod string, req filters.FlowSetRequirement) (r FlowRequirementResults) {
@@ -384,8 +392,8 @@ func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, po
 
 	r.Matched = MatchMap{}
 
-	match := func(expect bool, f filters.FlowRequirement) (int, bool) {
-		index, match := flows.Contains(f.Filter)
+	match := func(expect bool, f filters.FlowRequirement) (int, bool, *flow.Flow) {
+		index, match, flow := flows.Contains(f.Filter)
 
 		if match {
 			r.Matched[index] = expect
@@ -405,25 +413,25 @@ func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, po
 
 			r.Log = append(r.Log, fmt.Sprintf("❌ %s %s %s for pod %s", f.Msg, f.Filter.String(), msgSuffix, pod))
 			r.Failures++
-			return 0, false
-		}
-
-		msgSuffix := "found"
-		if !expect {
-			msgSuffix = "not found"
-		}
-
-		entry := "✅ " + fmt.Sprintf("%s %s for pod %s", f.Msg, msgSuffix, pod)
-		// Either show all flows or collect them so we can attach on failure
-		if t.context.AllFlows() {
-			r.Log = append(r.Log, entry)
 		} else {
-			goodLog = append(goodLog, entry)
+			msgSuffix := "found"
+			if !expect {
+				msgSuffix = "not found"
+			}
+
+			entry := "✅ " + fmt.Sprintf("%s %s for pod %s", f.Msg, msgSuffix, pod)
+			// Either show all flows or collect them so we can attach on failure
+			if t.context.AllFlows() {
+				r.Log = append(r.Log, entry)
+			} else {
+				goodLog = append(goodLog, entry)
+			}
 		}
-		return index, true
+
+		return index, expect, flow
 	}
 
-	if index, match := match(true, req.First); !match {
+	if index, match, _ := match(true, req.First); !match {
 		r.NeedMoreFlows = true
 	} else {
 		r.FirstMatch = index
@@ -433,10 +441,17 @@ func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, po
 		match(true, f)
 	}
 
-	if index, match := match(true, req.Last); !match {
+	if index, match, lastFlow := match(true, req.Last); !match {
 		r.NeedMoreFlows = true
 	} else {
 		r.LastMatch = index
+
+		if lastFlow != nil {
+			flowTimestamp, err := ptypes.Timestamp(lastFlow.Time)
+			if err == nil {
+				r.LastMatchTimestamp = flowTimestamp
+			}
+		}
 	}
 
 	for _, f := range req.Except {
@@ -463,7 +478,7 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, req filt
 	defer w.Cancel()
 
 retry:
-	flows, err := getFlows(ctx, hubbleClient, t.started.Add(-2*time.Second), pod, podIP)
+	flows, err := t.getFlows(ctx, hubbleClient, t.started.Add(100*time.Millisecond), pod, podIP)
 	if err != nil || flows == nil || len(flows.flows) == 0 {
 		if err == nil {
 			err = fmt.Errorf("no flows returned")
@@ -486,6 +501,10 @@ retry:
 
 	t.flows[pod] = flows
 	t.flowResults[pod] = r
+
+	if !r.LastMatchTimestamp.IsZero() {
+		t.context.StoreLastTimestamp(pod, r.LastMatchTimestamp)
+	}
 
 	if r.Failures == 0 {
 		t.context.Log("✅ Flow validation successful for pod %s (first: %d, last: %d, matched: %d, nlog: %d)", pod, r.FirstMatch, r.LastMatch, len(r.Matched), len(r.Log))
@@ -593,15 +612,16 @@ func (t TestResults) Failed() (failed int) {
 }
 
 type K8sConnectivityCheck struct {
-	client          k8sConnectivityImplementation
-	ciliumNamespace string
-	hubbleClient    observer.ObserverClient
-	params          Parameters
-	clients         *deploymentClients
-	echoPods        map[string]PodContext
-	clientPods      map[string]PodContext
-	echoServices    map[string]ServiceContext
-	results         TestResults
+	client             k8sConnectivityImplementation
+	ciliumNamespace    string
+	hubbleClient       observer.ObserverClient
+	params             Parameters
+	clients            *deploymentClients
+	echoPods           map[string]PodContext
+	clientPods         map[string]PodContext
+	echoServices       map[string]ServiceContext
+	results            TestResults
+	lastFlowTimestamps map[string]time.Time
 }
 
 func NewK8sConnectivityCheck(client k8sConnectivityImplementation, p Parameters) (*K8sConnectivityCheck, error) {
@@ -610,9 +630,10 @@ func NewK8sConnectivityCheck(client k8sConnectivityImplementation, p Parameters)
 	}
 
 	k := &K8sConnectivityCheck{
-		client:          client,
-		ciliumNamespace: "kube-system",
-		params:          p,
+		client:             client,
+		ciliumNamespace:    "kube-system",
+		params:             p,
+		lastFlowTimestamps: map[string]time.Time{},
 	}
 
 	return k, nil
@@ -653,7 +674,7 @@ type flowsSet struct {
 	flows []*observer.GetFlowsResponse
 }
 
-func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since time.Time, pod, podIP string) (*flowsSet, error) {
+func (t *TestRun) getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since time.Time, pod, podIP string) (*flowsSet, error) {
 	set := &flowsSet{}
 
 	if hubbleClient == nil {
@@ -663,6 +684,15 @@ func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since t
 	sinceTimestamp, err := ptypes.TimestampProto(since)
 	if err != nil {
 		return nil, fmt.Errorf("invalid since value %s: %s", since, err)
+	}
+
+	lastFlowTimestamp := t.context.LoadLastTimestamp(pod)
+	if !lastFlowTimestamp.IsZero() && lastFlowTimestamp.After(since) {
+		t.context.Log("Using last flow timestamp: %s", lastFlowTimestamp)
+		sinceTimestamp, err = ptypes.TimestampProto(lastFlowTimestamp)
+		if err != nil {
+			return nil, fmt.Errorf("invalid since value %s: %s", since, err)
+		}
 	}
 
 	// The filter is liberal, it includes any flow that:
@@ -706,18 +736,19 @@ func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since t
 	}
 }
 
-func (f *flowsSet) Contains(filter filters.FlowFilterImplementation) (int, bool) {
+func (f *flowsSet) Contains(filter filters.FlowFilterImplementation) (int, bool, *flow.Flow) {
 	if f == nil {
-		return 0, false
+		return 0, false, nil
 	}
 
 	for i, res := range f.flows {
-		if filter.Match(res.GetFlow()) {
-			return i, true
+		flow := res.GetFlow()
+		if filter.Match(flow) {
+			return i, true, flow
 		}
 	}
 
-	return 0, false
+	return 0, false, nil
 }
 
 func (k *K8sConnectivityCheck) Print(pod string, f *flowsSet) {
@@ -1183,6 +1214,14 @@ func (k *K8sConnectivityCheck) validateDeployment(ctx context.Context) error {
 
 func (k *K8sConnectivityCheck) Log(format string, a ...interface{}) {
 	fmt.Fprintf(k.params.Writer, format+"\n", a...)
+}
+
+func (k *K8sConnectivityCheck) StoreLastTimestamp(pod string, t time.Time) {
+	k.lastFlowTimestamps[pod] = t
+}
+
+func (k *K8sConnectivityCheck) LoadLastTimestamp(pod string) time.Time {
+	return k.lastFlowTimestamps[pod]
 }
 
 func (k *K8sConnectivityCheck) Header(format string, a ...interface{}) {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -488,7 +488,7 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, req filt
 	defer w.Cancel()
 
 retry:
-	flows, err := t.getFlows(ctx, hubbleClient, t.started.Add(100*time.Millisecond), pod, podIP)
+	flows, err := t.getFlows(ctx, hubbleClient, t.started, pod, podIP)
 	if err != nil || flows == nil || len(flows.flows) == 0 {
 		if err == nil {
 			err = fmt.Errorf("no flows returned")

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -251,6 +251,9 @@ type TestContext interface {
 	// PrintFlows returns true if flow logs should be printed
 	PrintFlows() bool
 
+	// AllFlows returns true if all flows should be shown
+	AllFlows() bool
+
 	// FlowSettleSleepDuration is the duration to wait before collecting flows
 	FlowSettleSleepDuration() time.Duration
 
@@ -281,6 +284,8 @@ type TestRun struct {
 	// flows is a map of all flow logs, indexed by pod name
 	flows map[string]*flowsSet
 
+	flowResults map[string]FlowRequirementResults
+
 	// started is the timestamp the test started
 	started time.Time
 
@@ -306,6 +311,7 @@ func NewTestRun(name string, c TestContext, src, dst TestPeer) *TestRun {
 		dst:         dst,
 		started:     time.Now(),
 		flows:       map[string]*flowsSet{},
+		flowResults: map[string]FlowRequirementResults{},
 	}
 }
 
@@ -315,25 +321,56 @@ func (t *TestRun) Failure(format string, a ...interface{}) {
 	t.failures++
 }
 
+// Success can be called to log a successful event
+func (t *TestRun) Success(format string, a ...interface{}) {
+	t.context.Log("✅ "+format, a...)
+}
+
 // Warning must be called when a warning is detected performing the test
 func (t *TestRun) Warning(format string, a ...interface{}) {
 	t.context.Log("⚠️  "+format, a...)
 	t.warnings++
 }
 
-func (t *TestRun) printFlows(pod string, f *flowsSet) {
+func (t *TestRun) printFlows(pod string, f *flowsSet, r FlowRequirementResults) {
 	if f == nil {
 		t.context.Log("📄 No flows recorded for pod %s", pod)
 		return
 	}
 
 	t.context.Log("📄 Flow logs of pod %s:", pod)
-	printer := hubprinter.New(hubprinter.Compact())
+	printer := hubprinter.New(hubprinter.Compact(), hubprinter.WithIPTranslation())
 	defer printer.Close()
-	for _, flow := range f.flows {
-		if err := printer.WriteProtoFlow(flow); err != nil {
-			t.context.Log("Unable to print flow: %s", err)
+	for index, flow := range f.flows {
+		if !t.context.AllFlows() && r.FirstMatch > 0 && r.FirstMatch > index {
+			continue
 		}
+
+		if !t.context.AllFlows() && r.LastMatch > 0 && r.LastMatch < index {
+			continue
+		}
+
+		f := flow.GetFlow()
+
+		src, dst := printer.GetHostNames(f)
+
+		ts := "N/A"
+		flowTimestamp, err := ptypes.Timestamp(f.GetTime())
+		if err == nil {
+			ts = flowTimestamp.Format(time.StampMilli)
+		}
+
+		flowPrefix := "❓"
+		if expect, ok := r.Matched[index]; ok {
+			if expect {
+				flowPrefix = "✅"
+			} else {
+				flowPrefix = "❌"
+			}
+		}
+
+		//lint:ignore SA1019 Summary is deprecated but there is no real alternative yet
+		t.context.Log("%s%s: %s -> %s %s %s (%s)", flowPrefix, ts, src, dst, hubprinter.GetFlowType(f), f.Verdict.String(), f.Summary)
 	}
 }
 
@@ -352,9 +389,87 @@ func (t *TestRun) settleFlows(ctx context.Context) error {
 	return nil
 }
 
+type MatchMap map[int]bool
+
+type FlowRequirementResults struct {
+	FirstMatch    int
+	LastMatch     int
+	Matched       MatchMap
+	Log           []string
+	Failures      int
+	NeedMoreFlows bool
+}
+
+func (t *TestRun) matchFlowRequirements(ctx context.Context, flows *flowsSet, pod string, req filters.FlowSetRequirement) (r FlowRequirementResults) {
+	var goodLog []string
+
+	r.Matched = MatchMap{}
+
+	match := func(expect bool, f filters.FlowRequirement) (int, bool) {
+		index, match := flows.Contains(f.Filter)
+
+		if match {
+			r.Matched[index] = expect
+		}
+
+		if match != expect {
+			// Unless we show all flows, good flows are only shown on failure
+			if !t.context.AllFlows() {
+				r.Log = append(r.Log, goodLog...)
+				goodLog = []string{}
+			}
+
+			msgSuffix := "not found"
+			if !expect {
+				msgSuffix = "found"
+			}
+
+			r.Log = append(r.Log, fmt.Sprintf("❌ %s %s %s for pod %s", f.Msg, f.Filter.String(), msgSuffix, pod))
+			r.Failures++
+			return 0, false
+		}
+
+		msgSuffix := "found"
+		if !expect {
+			msgSuffix = "not found"
+		}
+
+		entry := "✅ " + fmt.Sprintf("%s %s for pod %s", f.Msg, msgSuffix, pod)
+		// Either show all flows or collect them so we can attach on failure
+		if t.context.AllFlows() {
+			r.Log = append(r.Log, entry)
+		} else {
+			goodLog = append(goodLog, entry)
+		}
+		return index, true
+	}
+
+	if index, match := match(true, req.First); !match {
+		r.NeedMoreFlows = true
+	} else {
+		r.FirstMatch = index
+	}
+
+	for _, f := range req.Middle {
+		match(true, f)
+	}
+
+	if index, match := match(true, req.Last); !match {
+		r.NeedMoreFlows = true
+	} else {
+		r.LastMatch = index
+	}
+
+	for _, f := range req.Except {
+		match(false, f)
+	}
+
+	return
+}
+
 // ValidateFlows retrieves the flow pods of the specified pod and validates
 // that all filters find a match. On failure, t.Failure() is called.
-func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, filterPairs []filters.Pair) {
+func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, req filters.FlowSetRequirement) {
 	hubbleClient := t.context.HubbleClient()
 	if hubbleClient == nil {
 		return
@@ -364,56 +479,53 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, filterPa
 		return
 	}
 
-	flows, ok := t.flows[pod]
-	if !ok {
-		w := utils.NewWaitObserver(ctx, utils.WaitParameters{
-			Timeout:       defaults.FlowWaitTimeout,
-			RetryInterval: defaults.FlowRetryInterval,
-			Log: func(err error, wait string) {
-				t.context.Log("⌛ Waiting (%s) for flows: %s", wait, err)
-			}})
-		defer w.Cancel()
+	w := utils.NewWaitObserver(ctx, utils.WaitParameters{
+		Timeout:       defaults.FlowWaitTimeout,
+		RetryInterval: defaults.FlowRetryInterval,
+		Log: func(err error, wait string) {
+			t.context.Log("⌛ Waiting (%s) for flows: %s", wait, err)
+		}})
+	defer w.Cancel()
 
-		var err error
+	var err error
 
-	retry:
-		flows, err = getFlows(ctx, hubbleClient, t.started.Add(-2*time.Second), pod, podIP)
-		if err != nil || flows == nil || len(flows.flows) == 0 {
-			if err == nil {
-				err = fmt.Errorf("no flows returned")
-			}
-			if err := w.Retry(err); err != nil {
-				t.Failure("Unable to retrieve flows of pod %q: %s", pod, err)
-				return
-			}
-			goto retry
+retry:
+	flows, err := getFlows(ctx, hubbleClient, t.started.Add(-2*time.Second), pod, podIP)
+	if err != nil || flows == nil || len(flows.flows) == 0 {
+		if err == nil {
+			err = fmt.Errorf("no flows returned")
 		}
-
-		t.flows[pod] = flows
+		if err := w.Retry(err); err != nil {
+			t.Failure("Unable to retrieve flows of pod %q: %s", pod, err)
+			return
+		}
+		goto retry
 	}
 
-	var goodLog []string
-
-	for _, p := range filterPairs {
-		if flows.Contains(p.Filter) != p.Expect {
-			for _, g := range goodLog {
-				t.context.Log(g)
-			}
-			goodLog = []string{}
-
-			msgSuffix := "found"
-			if p.Expect {
-				msgSuffix = "not found"
-			}
-			t.Failure(fmt.Sprintf("%s %s %s for pod %s", p.Msg, p.Filter.String(), msgSuffix, pod))
-		} else {
-			msgSuffix := "not found"
-			if p.Expect {
-				msgSuffix = "found"
-			}
-			msg := fmt.Sprintf("%s %s for pod %s", p.Msg, msgSuffix, pod)
-			goodLog = append(goodLog, "✅ "+msg)
+	r := t.matchFlowRequirements(ctx, flows, pod, req)
+	if r.NeedMoreFlows {
+		// Retry until timeout. On timeout, print the flows and
+		// consider it a failure
+		if err := w.Retry(err); err != nil {
+			goto retry
 		}
+	}
+
+	t.flows[pod] = flows
+	t.flowResults[pod] = r
+
+	if r.Failures == 0 {
+		t.context.Log("✅ Flow validation successful for pod %s (first: %d, last: %d, matched: %d, nlog: %d)", pod, r.FirstMatch, r.LastMatch, len(r.Matched), len(r.Log))
+	} else {
+		t.context.Log("❌ Flow validation failed for pod %s: %d failures (first: %d, last: %d, matched: %d, nlog: %d)", pod, r.Failures, r.FirstMatch, r.LastMatch, len(r.Matched), len(r.Log))
+	}
+
+	for _, p := range r.Log {
+		t.context.Log(p)
+	}
+
+	if r.Failures > 0 {
+		t.failures++
 	}
 }
 
@@ -423,7 +535,7 @@ func (t *TestRun) ValidateFlows(ctx context.Context, pod, podIP string, filterPa
 func (t *TestRun) End() {
 	if t.context.PrintFlows() || t.failures > 0 || t.warnings > 0 {
 		for name, flows := range t.flows {
-			t.printFlows(name, flows)
+			t.printFlows(name, flows, t.flowResults[name])
 		}
 	}
 
@@ -621,28 +733,18 @@ func getFlows(ctx context.Context, hubbleClient observer.ObserverClient, since t
 	}
 }
 
-func (f *flowsSet) Contains(filter filters.FlowFilterImplementation) bool {
+func (f *flowsSet) Contains(filter filters.FlowFilterImplementation) (int, bool) {
 	if f == nil {
-		return false
+		return 0, false
 	}
 
-	for _, res := range f.flows {
+	for i, res := range f.flows {
 		if filter.Match(res.GetFlow()) {
-			return true
+			return i, true
 		}
 	}
 
-	return false
-}
-
-func (k *K8sConnectivityCheck) Validate(pod string, f *flowsSet, filterPairs []filters.Pair) (success bool) {
-	for _, p := range filterPairs {
-		if f.Contains(p.Filter) != p.Expect {
-			k.Log("❌ %s in pod %s", p.Msg, pod)
-			success = false
-		}
-	}
-	return
+	return 0, false
 }
 
 func (k *K8sConnectivityCheck) Print(pod string, f *flowsSet) {
@@ -652,7 +754,7 @@ func (k *K8sConnectivityCheck) Print(pod string, f *flowsSet) {
 	}
 
 	k.Log("📄 Flow logs of pod %s:", pod)
-	printer := hubprinter.New(hubprinter.Compact())
+	printer := hubprinter.New(hubprinter.Compact(), hubprinter.WithIPTranslation())
 	defer printer.Close()
 	for _, flow := range f.flows {
 		if err := printer.WriteProtoFlow(flow); err != nil {
@@ -680,6 +782,7 @@ type Parameters struct {
 	PostTestSleepDuration   time.Duration
 	FlowSettleSleepDuration time.Duration
 	FlowValidation          string
+	AllFlows                bool
 	Writer                  io.Writer
 }
 
@@ -1123,6 +1226,10 @@ func (k *K8sConnectivityCheck) HubbleClient() observer.ObserverClient {
 
 func (k *K8sConnectivityCheck) PrintFlows() bool {
 	return k.params.PrintFlows
+}
+
+func (k *K8sConnectivityCheck) AllFlows() bool {
+	return k.params.AllFlows
 }
 
 func (k *K8sConnectivityCheck) EchoPods() map[string]PodContext {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -273,6 +275,9 @@ type TestContext interface {
 	// ClientPods returns a map of all deployed client pods
 	ClientPods() map[string]PodContext
 
+	// RandomClientPod returns a randomly selected client pod, if available
+	RandomClientPod() *PodContext
+
 	// EchoServices returns a map of all deployed echo services
 	EchoServices() map[string]ServiceContext
 
@@ -335,6 +340,9 @@ type TestRun struct {
 	// Dst is the peer used as the destination (server)
 	Dst TestPeer
 
+	// DstPort is the destination port number used by the traffic in this test case
+	DstPort int
+
 	// expectedEgress is the expected test result for egress from the source pod
 	expectedEgress Result
 
@@ -357,15 +365,16 @@ type TestRun struct {
 }
 
 // NewTestRun creates a new test run
-func NewTestRun(t ConnectivityTest, c TestContext, src, dst TestPeer) *TestRun {
-	c.Header("🔌 [%s] Testing %s -> %s...", t.Name(), src.Name(), dst.Name())
+func NewTestRun(t ConnectivityTest, c TestContext, src, dst TestPeer, dstPort int) *TestRun {
+	c.Header("🔌 [%s] Testing %s -> %s:%d...", t.Name(), src.Name(), dst.Name(), dstPort)
 
 	run := &TestRun{
 		name:        t.Name(),
-		verboseName: fmt.Sprintf("%s: %s -> %s", t.Name(), src.Name(), dst.Name()),
+		verboseName: fmt.Sprintf("%s: %s -> %s:%d", t.Name(), src.Name(), dst.Name(), dstPort),
 		context:     c,
 		Src:         src,
 		Dst:         dst,
+		DstPort:     dstPort,
 		started:     time.Now(),
 		flows:       map[string]*flowsSet{},
 		flowResults: map[string]FlowRequirementResults{},
@@ -403,7 +412,7 @@ func (t *TestRun) Waiting(format string, a ...interface{}) {
 func (t *TestRun) LogResult(cmd []string, err error, stdout bytes.Buffer) {
 	cmdName := cmd[0]
 	cmdStr := strings.Join(cmd, " ")
-	shouldSucceed := t.expectedEgress == ResultOK && t.expectedIngress == ResultOK
+	shouldSucceed := !t.expectedEgress.Drop && !t.expectedIngress.Drop
 	if err != nil {
 		if shouldSucceed {
 			t.Failure("%s command %q failed: %w", cmdName, cmdStr, err)
@@ -581,9 +590,6 @@ type FlowParameters struct {
 	// RSTAllowed is true if TCP connection may end with either RST or FIN
 	RSTAllowed bool
 
-	// DstPort is the destination port number to be mached. Ignored for ICMP.
-	DstPort int
-
 	// NodePort, if non-zero, indicates an alternative port number for the DstPort to be matched
 	NodePort int
 }
@@ -606,10 +612,17 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 		icmpRequest := filters.Or(filters.ICMP(8), filters.ICMPv6(128))
 		icmpResponse := filters.Or(filters.ICMP(0), filters.ICMPv6(129))
 
-		switch t.expectedEgress {
-		case ResultOK:
-			if t.expectedIngress != ResultOK {
-				// If ingress drops we may get the drop flows also for egress, tolerate that
+		if t.expectedEgress.Drop {
+			egress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest, filters.Drop()), Msg: "Drop"},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response"},
+				},
+			}
+		} else {
+			if t.expectedIngress.Drop {
+				// If ingress drops is in the same node we get the drop flows also for egress, tolerate that
 				egress = &filters.FlowSetRequirement{
 					First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
 					Last:  filters.FlowRequirement{Filter: filters.Or(filters.And(ipResponse, icmpResponse), filters.And(ipRequest, filters.Drop())), Msg: "ICMP response or request drop", SkipOnAggregation: true},
@@ -623,55 +636,16 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 					},
 				}
 			}
-		case ResultDrop:
-			egress = &filters.FlowSetRequirement{
-				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
-				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest, filters.Drop()), Msg: "Drop"},
-				Except: []filters.FlowRequirement{
-					{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response"},
-				},
-			}
-		default:
-			t.Failure("Invalid expected ICMP egress result %s", t.expectedEgress.String())
 		}
 	case TCP:
-		tcpRequest := filters.TCP(0, p.DstPort)
-		tcpResponse := filters.TCP(p.DstPort, 0)
+		tcpRequest := filters.TCP(0, t.DstPort)
+		tcpResponse := filters.TCP(t.DstPort, 0)
 		if p.NodePort != 0 {
 			tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
 			tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
 		}
 
-		switch t.expectedEgress {
-		case ResultOK:
-			if p.RSTAllowed {
-				egress = &filters.FlowSetRequirement{
-					First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
-					Middle: []filters.FlowRequirement{
-						{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
-					},
-					// For the connection termination, we will either see:
-					// a) FIN + FIN b) FIN + RST c) RST
-					Last: filters.FlowRequirement{Filter: filters.And(ipResponse, tcpResponse, filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true},
-					Except: []filters.FlowRequirement{
-						{Filter: filters.Drop(), Msg: "Drop"},
-					},
-				}
-			} else {
-				egress = &filters.FlowSetRequirement{
-					First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
-					Middle: []filters.FlowRequirement{
-						{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
-					},
-					// Either side may FIN first
-					Last: filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.FIN()), Msg: "FIN"},
-					Except: []filters.FlowRequirement{
-						{Filter: filters.RST(), Msg: "RST"},
-						{Filter: filters.Drop(), Msg: "Drop"},
-					},
-				}
-			}
-		case ResultDrop:
+		if t.expectedEgress.Drop {
 			egress = &filters.FlowSetRequirement{
 				First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
 				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.Drop()), Msg: "Drop"},
@@ -680,8 +654,32 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 					{Filter: filters.FIN(), Msg: "FIN"},
 				},
 			}
-		default:
-			t.Failure("Invalid expected TCP egress result %s", t.expectedEgress.String())
+		} else {
+			egress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
+				Middle: []filters.FlowRequirement{
+					{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
+				},
+				// Either side may FIN first
+				Last: filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.FIN()), Msg: "FIN"},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.Drop(), Msg: "Drop"},
+				},
+			}
+			if t.expectedEgress.HTTP.Status != "" || t.expectedEgress.HTTP.Method != "" || t.expectedEgress.HTTP.URL != "" {
+				code, err := strconv.Atoi(t.expectedEgress.HTTP.Status)
+				if err != nil {
+					code = math.MaxUint32
+				}
+				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.HTTP(uint32(code), t.expectedEgress.HTTP.Method, t.expectedEgress.HTTP.URL), Msg: "HTTP"})
+			}
+			if p.RSTAllowed {
+				// For the connection termination, we will either see:
+				// a) FIN + FIN b) FIN + RST c) RST
+				egress.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, tcpResponse, filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true}
+			} else {
+				egress.Except = append(egress.Except, filters.FlowRequirement{Filter: filters.RST(), Msg: "RST"})
+			}
 		}
 	case UDP:
 		t.Failure("UDP egress flow matching not implemented yet")
@@ -689,7 +687,7 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 		t.Failure("Invalid egress flow matching protocol %d", p.Protocol)
 	}
 
-	if p.DNSRequired {
+	if p.DNSRequired || t.expectedEgress.DNSProxy {
 		dnsRequest := filters.Or(filters.UDP(0, 53), filters.TCP(0, 53))
 		dnsResponse := filters.Or(filters.UDP(53, 0), filters.TCP(53, 0))
 
@@ -699,17 +697,25 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 			{Filter: filters.And(ipResponse, dnsResponse), Msg: "DNS response"},
 			first,
 		}, egress.Middle...)
+
+		if t.expectedEgress.DNSProxy {
+			egress.Middle = append([]filters.FlowRequirement{
+				{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(t.Dst.Address()+".", 0)), Msg: "DNS proxy"},
+			}, egress.Middle...)
+		}
 	}
 
 	return egress
 }
 
 func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequirement {
+	var ingress *filters.FlowSetRequirement
+	if t.expectedIngress.None {
+		return ingress
+	}
+
 	srcIP := t.Src.Address()
 	dstIP := t.Dst.Address()
-
-	var ingress *filters.FlowSetRequirement
-
 	if dstIP != "" && net.ParseIP(dstIP) == nil {
 		// dstIP is not an IP address, assume it is a domain name
 		dstIP = ""
@@ -718,8 +724,8 @@ func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequi
 	ipResponse := filters.IP(dstIP, srcIP)
 	ipRequest := filters.IP(srcIP, dstIP)
 
-	tcpRequest := filters.TCP(0, p.DstPort)
-	tcpResponse := filters.TCP(p.DstPort, 0)
+	tcpRequest := filters.TCP(0, t.DstPort)
+	tcpResponse := filters.TCP(t.DstPort, 0)
 	if p.NodePort != 0 {
 		tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
 		tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
@@ -730,16 +736,7 @@ func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequi
 		icmpRequest := filters.Or(filters.ICMP(8), filters.ICMPv6(128))
 		icmpResponse := filters.Or(filters.ICMP(0), filters.ICMPv6(129))
 
-		switch t.expectedIngress {
-		case ResultOK:
-			ingress = &filters.FlowSetRequirement{
-				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
-				Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
-				Except: []filters.FlowRequirement{
-					{Filter: filters.Drop(), Msg: "Drop"},
-				},
-			}
-		case ResultDrop:
+		if t.expectedIngress.Drop {
 			ingress = &filters.FlowSetRequirement{
 				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
 				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest, filters.Drop()), Msg: "Drop"},
@@ -747,12 +744,20 @@ func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequi
 					{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response"},
 				},
 			}
-		default:
-			t.Failure("Invalid expected ICMP ingress result %s", t.expectedEgress.String())
+		} else {
+			ingress = &filters.FlowSetRequirement{
+				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
+				Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
+				Except: []filters.FlowRequirement{
+					{Filter: filters.Drop(), Msg: "Drop"},
+				},
+			}
 		}
 	case TCP:
-		switch t.expectedIngress {
-		case ResultOK:
+		if t.expectedIngress.Drop {
+			// Ingress drops not supported yet
+			t.Failure("Unimplemented expected TCP ingress result %s", t.expectedIngress.String())
+		} else {
 			ingress = &filters.FlowSetRequirement{
 				First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
 				Middle: []filters.FlowRequirement{
@@ -765,11 +770,6 @@ func (t *TestRun) GetIngressRequirements(p FlowParameters) *filters.FlowSetRequi
 					{Filter: filters.Drop(), Msg: "Drop"},
 				},
 			}
-		case ResultNone:
-			// Nothing, used when expecting a drop in egress so that packet does not show up at ingress
-		default:
-			// Ingress drops not supported yet
-			t.Failure("Invalid expected TCP ingress result %s", t.expectedIngress.String())
 		}
 	case UDP:
 		t.Failure("UDP ingress flow matching not implemented yet")
@@ -1485,7 +1485,7 @@ func (k *K8sConnectivityCheck) waitForDeploymentsReady(ctx context.Context, clie
 	return nil
 }
 
-func (k *K8sConnectivityCheck) randomClientPod() *PodContext {
+func (k *K8sConnectivityCheck) RandomClientPod() *PodContext {
 	for _, p := range k.clientPods {
 		return &p
 	}
@@ -1498,7 +1498,7 @@ func (k *K8sConnectivityCheck) waitForService(ctx context.Context, client k8sCon
 	ctx, cancel := context.WithTimeout(ctx, k.params.serviceReadyTimeout())
 	defer cancel()
 
-	clientPod := k.randomClientPod()
+	clientPod := k.RandomClientPod()
 	if clientPod == nil {
 		return fmt.Errorf("no client pod available")
 	}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -1669,6 +1669,10 @@ func (k *K8sConnectivityCheck) Report(r TestResult) {
 		k.results = TestResults{}
 	}
 
+	if _, ok := k.results[r.Name]; ok {
+		k.Log("❌ Overwriting results for test $q, failing the test", r.Name)
+		r.Failures++
+	}
 	k.results[r.Name] = r
 }
 

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -1,0 +1,368 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Result int
+
+const (
+	ResultOK Result = iota
+	ResultNone
+	ResultDrop
+	ResultL7Drop
+	ResultL7Rejected
+)
+
+func (k Result) String() string {
+	switch k {
+	case ResultOK:
+		return "OK"
+	case ResultNone:
+		return "None"
+	case ResultDrop:
+		return "Drop"
+	case ResultL7Drop:
+		return "L7Drop"
+	case ResultL7Rejected:
+		return "L7Rejected"
+	default:
+		return "invalid"
+	}
+}
+
+type GetExpectations func(t *TestRun) (egress, ingress Result)
+
+type Policy interface {
+	// WithPolicy attaches a policy YAML with to a test case
+	WithPolicy(yaml string) ConnectivityTest
+
+	// WithExpectations attaches a function that returns test case expected policy enforcement results
+	WithExpectations(f GetExpectations) ConnectivityTest
+
+	// getExpectations is for internal use only
+	getExpectations(t *TestRun) (egress, ingress Result)
+}
+
+// PolicyContext implements ConnectivityTest interface so that
+// policies can be applied between tests and policy apply failures can
+// be reported like any other test results.
+type PolicyContext struct {
+	runner     ConnectivityTest
+	err        error
+	CNPs       []*ciliumv2.CiliumNetworkPolicy
+	expectFunc GetExpectations
+}
+
+// WithPolicyRunner sets the test runner to use and stores the policy for the tests
+func (pc *PolicyContext) WithPolicyRunner(runner ConnectivityTest, yaml string) ConnectivityTest {
+	pc.runner = runner
+	return pc.WithPolicy(yaml)
+}
+
+// Name returns the absolute name of the policy
+func (pc *PolicyContext) Name() string {
+	if pc.runner != nil {
+		return pc.runner.Name()
+	}
+	if len(pc.CNPs) == 0 {
+		return fmt.Sprintf("PolicyContext %p", pc)
+	}
+	return fmt.Sprintf("%s/%s", pc.CNPs[0].Namespace, pc.CNPs[0].Name)
+}
+
+// Run applies the policy, use no policy to delete all policies
+func (pc *PolicyContext) Run(ctx context.Context, c TestContext) {
+	if pc.runner != nil {
+		policyFailures, cleanup := pc.ApplyPolicy(ctx, c)
+		c.(*K8sConnectivityCheck).policyFailures = policyFailures
+		defer cleanup()
+
+		pc.runner.Run(ctx, c)
+	} else {
+		failures := c.ApplyCNPs(ctx, len(pc.CNPs) == 0, pc.CNPs)
+		c.Report(TestResult{
+			Name:     pc.Name(),
+			Failures: failures,
+			Warnings: 0,
+		})
+	}
+}
+
+// WithPolicy sets the policy to use during tests
+func (pc *PolicyContext) WithPolicy(yaml string) ConnectivityTest {
+	pc.ParsePolicy(yaml)
+	return pc
+}
+
+// WithExpectations sets the getExpectations test result function to use during tests
+func (pc *PolicyContext) WithExpectations(f GetExpectations) ConnectivityTest {
+	pc.expectFunc = f
+	return pc
+}
+
+// getExpectations returns the expected results for a specific test case
+func (pc *PolicyContext) getExpectations(t *TestRun) (egress, ingress Result) {
+	// Default to success
+	if pc.expectFunc == nil {
+		return ResultOK, ResultOK
+	}
+
+	egress, ingress = pc.expectFunc(t)
+	if egress != ResultOK || ingress != ResultOK {
+		t.Waiting("The following command is expected to fail")
+	}
+
+	return egress, ingress
+}
+
+func (pc *PolicyContext) ParsePolicy(policy string) {
+	pc.CNPs, pc.err = ParsePolicyYAML(policy)
+}
+
+// ApplyPolicy returns the number of failures and a cancel function that deletes the applied policies
+func (pc *PolicyContext) ApplyPolicy(ctx context.Context, c TestContext) (failures int, cancel func()) {
+	if pc.err != nil {
+		return 1, func() {}
+	}
+
+	return c.ApplyCNPs(ctx, false, pc.CNPs), func() {
+		c.DeleteCNPs(ctx, pc.CNPs)
+	}
+}
+
+// ParsePolicyYAML decodes policy yaml into a slice of CiliumNetworkPolicies
+func ParsePolicyYAML(policy string) (cnps []*ciliumv2.CiliumNetworkPolicy, err error) {
+	if policy == "" {
+		return nil, nil
+	}
+	yamls := strings.Split(policy, "---")
+	for _, yaml := range yamls {
+		if strings.TrimSpace(yaml) == "" {
+			continue
+		}
+		obj, groupVersionKind, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(yaml), nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("resource decode error (%s) in: %s", err, yaml)
+		}
+		switch groupVersionKind.Kind {
+		case "CiliumNetworkPolicy":
+			cnp, ok := obj.(*ciliumv2.CiliumNetworkPolicy)
+			if !ok {
+				return nil, fmt.Errorf("object cast to CiliumNetworkPolicy failed: %s", yaml)
+			}
+			cnps = append(cnps, cnp)
+		default:
+			return nil, fmt.Errorf("unknown policy type '%s' in: %s", groupVersionKind.Kind, yaml)
+		}
+	}
+	return cnps, nil
+}
+
+// DeleteCNP deletes a CNP
+func (k *K8sConnectivityCheck) DeleteCNP(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy) {
+	name := cnp.Namespace + "/" + cnp.Name
+	if err := k.deleteCNP(ctx, cnp); err != nil {
+		k.Log("❌ [%s] policy delete failed: %s", name, err)
+	}
+	delete(k.policies, name)
+}
+
+// DeleteCNPs deletes a set of CNPs
+func (k *K8sConnectivityCheck) DeleteCNPs(ctx context.Context, cnps []*ciliumv2.CiliumNetworkPolicy) {
+	// bail out if nothing to do:
+	if len(cnps) == 0 {
+		return
+	}
+
+	// Get current policy revisions in all Cilium pods
+	revisions, err := k.GetCiliumPolicyRevisions(ctx)
+	if err != nil {
+		k.Log("❌ unable to get policy revisions for Cilium pods: %w", err)
+	}
+	if k.params.Verbose {
+		for pod, revision := range revisions {
+			k.Log("ℹ️  pod %s current policy revision %d", pod.Name, revision)
+		}
+	}
+
+	for _, cnp := range cnps {
+		k.DeleteCNP(ctx, cnp)
+	}
+
+	// Wait for policies to be deleted on all Cilium nodes
+	err = k.WaitCiliumPolicyRevisions(ctx, revisions)
+	if err != nil {
+		k.Log("❌ policies are not deleted in all Cilium nodes in time")
+	}
+}
+
+// GetCiliumPolicyRevision returns the current policy revision in a Cilium pod
+func (k *K8sConnectivityCheck) GetCiliumPolicyRevision(ctx context.Context, pod *corev1.Pod) (int, error) {
+	stdout, err := k.clients.src.ExecInPod(ctx, pod.Namespace, pod.Name, "cilium-agent", []string{"cilium", "policy", "get", "-o", "jsonpath='{.revision}'"})
+	if err != nil {
+		return 0, err
+	}
+	revision, err := strconv.Atoi(strings.Trim(stdout.String(), "'\n"))
+	if err != nil {
+		return 0, fmt.Errorf("revision '%s' is not valid: %w", stdout.String(), err)
+	}
+	return revision, nil
+}
+
+// CiliumPolicyWaitForRevision waits for a specific policy revision to be deployed in a Cilium pod
+func (k *K8sConnectivityCheck) CiliumPolicyWaitForRevision(ctx context.Context, pod *corev1.Pod, rev int, timeout time.Duration) error {
+	revStr := strconv.Itoa(rev)
+	timeoutStr := strconv.Itoa(int(timeout.Seconds()))
+	_, err := k.clients.src.ExecInPod(ctx, pod.Namespace, pod.Name, "cilium-agent", []string{"cilium", "policy", "wait", revStr, "--max-wait-time", timeoutStr})
+	return err
+}
+
+// GetCiliumPolicyRevisions returns the current policy revisions of all Cilium pods
+func (k *K8sConnectivityCheck) GetCiliumPolicyRevisions(ctx context.Context) (map[*corev1.Pod]int, error) {
+	revisions := make(map[*corev1.Pod]int)
+	pods, err := k.clients.src.ListPods(ctx, k.ciliumNamespace, metav1.ListOptions{LabelSelector: "k8s-app=cilium"})
+	if err != nil {
+		return revisions, err
+	}
+
+	for i := range pods.Items {
+		// Get the address of the pod we can use as a map key
+		pod := &pods.Items[i]
+		revision, err := k.GetCiliumPolicyRevision(ctx, pod)
+		if err != nil {
+			return revisions, err
+		}
+		revisions[pod] = revision
+	}
+	return revisions, nil
+}
+
+// WaitCiliumPolicyRevisions waits for the Cilium policy revisions to be bumped
+func (k *K8sConnectivityCheck) WaitCiliumPolicyRevisions(ctx context.Context, revisions map[*corev1.Pod]int) error {
+	var err error
+	for pod, oldRevision := range revisions {
+		err = k.CiliumPolicyWaitForRevision(ctx, pod, oldRevision+1, defaults.PolicyWaitTimeout)
+		if err == nil {
+			if k.params.Verbose {
+				k.Log("ℹ️  pod %s revision > %d", pod.Name, oldRevision)
+			}
+			delete(revisions, pod)
+		}
+	}
+	if len(revisions) == 0 {
+		return nil
+	}
+	return err
+}
+
+// ApplyCNPs applies policies and returns the number of failures
+func (k *K8sConnectivityCheck) ApplyCNPs(ctx context.Context, deletePrevious bool, cnps []*ciliumv2.CiliumNetworkPolicy) int {
+	wait := false
+	failures := 0
+
+	// bail out if nothing to do (nothing to delete and nothing to add):
+	if (!deletePrevious || deletePrevious && len(k.policies) == 0) && len(cnps) == 0 {
+		return 0
+	}
+
+	// Get current policy revisions in all Cilium pods
+	revisions, err := k.GetCiliumPolicyRevisions(ctx)
+	if err != nil {
+		k.Log("❌ unable to get policy revisions for Cilium pods: %w", err)
+		failures++
+	}
+	if k.params.Verbose {
+		for pod, revision := range revisions {
+			k.Log("ℹ️  pod %s current policy revision %d", pod.Name, revision)
+		}
+	}
+
+	var deleted []string
+	if deletePrevious {
+		k.Header("🔌 Deleting all previously applied policies...")
+		for _, cnp := range k.policies {
+			name := cnp.Namespace + "/" + cnp.Name
+			deleted = append(deleted, name)
+			k.DeleteCNP(ctx, cnp)
+			wait = true
+		}
+	}
+
+	var applied []string
+	for _, cnp := range cnps {
+		name := cnp.Namespace + "/" + cnp.Name
+		k.Header("🔌 [%s] Applying CiliumNetworkPolicy...", name)
+		k8sCNP, err := k.updateOrCreateCNP(ctx, cnp)
+		if err != nil {
+			k.Log("❌ policy apply failed: %s", err)
+			failures++
+		} else {
+			applied = append(applied, name)
+			k.policies[name] = k8sCNP
+			wait = true
+		}
+	}
+
+	if wait {
+		// Wait for policies to take effect on all Cilium nodes
+		err = k.WaitCiliumPolicyRevisions(ctx, revisions)
+		if err != nil {
+			k.Log("❌ policy is not applied in all Cilium nodes in time")
+			failures++
+			wait = false
+		}
+	}
+
+	if wait {
+		if len(deleted) > 0 {
+			k.Log("✅ deleted CiliumNetworkPolicies: %s", strings.Join(deleted, ","))
+		}
+		if len(applied) > 0 {
+			k.Log("✅ applied CiliumNetworkPolicies: %s", strings.Join(applied, ","))
+		}
+	}
+
+	return failures
+}
+
+func (k *K8sConnectivityCheck) updateOrCreateCNP(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy) (*ciliumv2.CiliumNetworkPolicy, error) {
+	k8sCNP, err := k.clients.src.GetCiliumNetworkPolicy(ctx, cnp.Namespace, cnp.Name, metav1.GetOptions{})
+	if err == nil {
+		k8sCNP.ObjectMeta.Labels = cnp.ObjectMeta.Labels
+		k8sCNP.Spec = cnp.Spec
+		k8sCNP.Specs = cnp.Specs
+		k8sCNP.Status = ciliumv2.CiliumNetworkPolicyStatus{}
+		return k.clients.src.UpdateCiliumNetworkPolicy(ctx, k8sCNP, metav1.UpdateOptions{})
+	}
+	return k.clients.src.CreateCiliumNetworkPolicy(ctx, cnp, metav1.CreateOptions{})
+}
+
+func (k *K8sConnectivityCheck) deleteCNP(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy) error {
+	return k.clients.src.DeleteCiliumNetworkPolicy(ctx, cnp.Namespace, cnp.Name, metav1.DeleteOptions{})
+}

--- a/connectivity/filters/filters.go
+++ b/connectivity/filters/filters.go
@@ -31,8 +31,9 @@ type FlowFilterImplementation interface {
 }
 
 type FlowRequirement struct {
-	Filter FlowFilterImplementation
-	Msg    string
+	Filter            FlowFilterImplementation
+	Msg               string
+	SkipOnAggregation bool
 }
 
 type FlowSetRequirement struct {

--- a/connectivity/filters/filters.go
+++ b/connectivity/filters/filters.go
@@ -30,10 +30,16 @@ type FlowFilterImplementation interface {
 	String() string
 }
 
-type Pair struct {
+type FlowRequirement struct {
 	Filter FlowFilterImplementation
 	Msg    string
-	Expect bool
+}
+
+type FlowSetRequirement struct {
+	First  FlowRequirement
+	Middle []FlowRequirement
+	Last   FlowRequirement
+	Except []FlowRequirement
 }
 
 type andFilter struct {

--- a/connectivity/manifests/allow-all.yaml
+++ b/connectivity/manifests/allow-all.yaml
@@ -1,0 +1,13 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: allow-all
+spec:
+  endpointSelector: {}
+  egress:
+  - toEntities:
+    - all
+  ingress:
+  - fromEntities:
+    - all

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-only-dns
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -1,0 +1,26 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-echo
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: cilium-test
+        k8s:kind: echo
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns

--- a/connectivity/manifests/client-egress-to-fqdns-google.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-google.yaml
@@ -1,0 +1,31 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-fqdns-google
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/"
+    toFQDNs:
+    - matchName: "google.com"
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns

--- a/connectivity/manifests/client-ingress-from-client2.yaml
+++ b/connectivity/manifests/client-ingress-from-client2.yaml
@@ -1,0 +1,13 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-ingress-from-client2
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        k8s:other: client

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -31,40 +31,57 @@ var (
 
 	//go:embed manifests/client-egress-to-echo.yaml
 	clientEgressToEchoPolicyYAML string
+
+	//go:embed manifests/client-ingress-from-client2.yaml
+	clientIngressFromClient2PolicyYAML string
 )
 
 func Run(ctx context.Context, k *check.K8sConnectivityCheck) error {
 	return k.Run(ctx,
 		// First all tests without policies
 		&tests.PodToPod{},
+		&tests.ClientToClient{},
 		&tests.PodToService{},
 		&tests.PodToNodePort{},
 		&tests.PodToLocalNodePort{},
 		&tests.PodToWorld{},
 		&tests.PodToHost{},
+
 		// Then test with an allow-all policy
 		(&check.PolicyContext{}).WithPolicy(allowAllPolicyYAML),
 		&tests.PodToPod{Variant: "-allow-all"},
+		&tests.ClientToClient{Variant: "-allow-all"},
 		&tests.PodToService{Variant: "-allow-all"},
 		&tests.PodToNodePort{Variant: "-allow-all"},
 		&tests.PodToLocalNodePort{Variant: "-allow-all"},
 		&tests.PodToWorld{Variant: "-allow-all"},
 		&tests.PodToHost{Variant: "-allow-all"},
-
 		// By itself this should fail, but allow-all policy is in effect so this succeeds
 		(&tests.PodToPod{Variant: "-client-egress-only-dns-with-allow-all"}).WithPolicy(clientEgressOnlyDNSPolicyYAML),
 		(&check.PolicyContext{}).WithPolicy(""), // delete all applied policies
-		// Now this should fail
+
+		// This policy allows ingress from client2 to client only
+		(&tests.ClientToClient{Variant: "-client-ingress-from-client"}).
+			WithPolicy(clientIngressFromClient2PolicyYAML).
+			WithExpectations(func(t *check.TestRun) (egress, ingress check.Result) {
+				if t.Src.HasLabel("other", "client") {
+					return check.ResultOK, check.ResultOK
+				} else {
+					return check.ResultOK, check.ResultDrop
+				}
+			}),
+
+		// Now this should fail as allow-all policy is not in effect any more
 		(&tests.PodToPod{Variant: "-client-egress-only-dns"}).
 			WithPolicy(clientEgressOnlyDNSPolicyYAML).
-			WithExpectations(
-				func(t *check.TestRun) (egress, ingress check.Result) {
-					return check.ResultDrop, check.ResultNone
-				}),
+			WithExpectations(func(t *check.TestRun) (egress, ingress check.Result) {
+				return check.ResultDrop, check.ResultNone
+			}),
+
 		// Policy installed with 'WithPolicy()' is automatically removed, so this should succeed:
 		&tests.PodToPod{Variant: "-no-policy"},
+
 		// This policy allows port 8080 from client to echo, so this should succeed
 		(&tests.PodToPod{Variant: "-client-egress-to-echo"}).WithPolicy(clientEgressToEchoPolicyYAML),
-		(&check.PolicyContext{}).WithPolicy(""), // delete all applied policies
 	)
 }

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -41,7 +41,7 @@ func (t *ClientToClient) Run(ctx context.Context, c check.TestContext) {
 				continue
 			}
 			run := check.NewTestRun(t, c, src, dst)
-			cmd := []string{"ping", "-c", "3", dst.Pod.Status.PodIP}
+			cmd := []string{"ping", "-w", "3", "-c", "1", dst.Pod.Status.PodIP}
 			stdout, err := src.K8sClient.ExecInPod(ctx, src.Pod.Namespace, src.Pod.Name, "", cmd)
 			run.LogResult(cmd, err, stdout)
 			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -42,8 +42,8 @@ func (t *ClientToClient) Run(ctx context.Context, c check.TestContext) {
 			}
 			run := check.NewTestRun(t, c, src, dst, 0) // 0 port number for ICMP
 			cmd := []string{"ping", "-w", "3", "-c", "1", dst.Pod.Status.PodIP}
-			stdout, err := src.K8sClient.ExecInPod(ctx, src.Pod.Namespace, src.Pod.Name, "", cmd)
-			run.LogResult(cmd, err, stdout)
+			stdout, stderr, err := src.K8sClient.ExecInPodWithStderr(ctx, src.Pod.Namespace, src.Pod.Name, "", cmd)
+			run.LogResult(cmd, err, stdout, stderr)
 			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 				Protocol: check.ICMP,
 			})

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -40,7 +40,7 @@ func (t *ClientToClient) Run(ctx context.Context, c check.TestContext) {
 				// Currently we only get flows once per IP
 				continue
 			}
-			run := check.NewTestRun(t, c, src, dst)
+			run := check.NewTestRun(t, c, src, dst, 0) // 0 port number for ICMP
 			cmd := []string{"ping", "-w", "3", "-c", "1", dst.Pod.Status.PodIP}
 			stdout, err := src.K8sClient.ExecInPod(ctx, src.Pod.Namespace, src.Pod.Name, "", cmd)
 			run.LogResult(cmd, err, stdout)

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -15,5 +15,5 @@
 package tests
 
 func curlCommand(target string) []string {
-	return []string{"curl", "-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}\n", "--silent", "--fail", "--show-error", "--connect-timeout", "5", "--output", "/dev/null", target}
+	return []string{"curl", "-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}\n", "--show-error", "--silent", "--fail", "--show-error", "--connect-timeout", "5", "--output", "/dev/null", target}
 }

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -15,5 +15,5 @@
 package tests
 
 func curlCommand(target string) []string {
-	return []string{"curl", "--silent", "--fail", "--show-error", "--connect-timeout", "5", "--output", "/dev/null", target}
+	return []string{"curl", "-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}\n", "--silent", "--fail", "--show-error", "--connect-timeout", "5", "--output", "/dev/null", target}
 }

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -51,7 +51,7 @@ func (t *PodToHost) Run(ctx context.Context, c check.TestContext) {
 		for hostIP := range hostIPs {
 			cmd := []string{"ping", "-c", "3", hostIP}
 			run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: hostIP})
-			stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, cmd)
+			stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
 			run.LogResult(cmd, err, stdout)
 			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 				Protocol: check.ICMP,

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -49,7 +49,7 @@ func (t *PodToHost) Run(ctx context.Context, c check.TestContext) {
 
 	for _, client := range c.ClientPods() {
 		for hostIP := range hostIPs {
-			cmd := []string{"ping", "-c", "3", hostIP}
+			cmd := []string{"ping", "-w", "3", "-c", "1", hostIP}
 			run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: hostIP})
 			stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
 			run.LogResult(cmd, err, stdout)

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -55,7 +55,7 @@ func (t *PodToHost) Run(ctx context.Context, c check.TestContext) {
 
 			run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, filters.FlowSetRequirement{
 				First: filters.FlowRequirement{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, hostIP), filters.Or(filters.ICMP(8), filters.ICMPv6(128))), Msg: "ICMP request"},
-				Last:  filters.FlowRequirement{Filter: filters.And(filters.IP(hostIP, client.Pod.Status.PodIP), filters.Or(filters.ICMP(0), filters.ICMPv6(129))), Msg: "ICMP response"},
+				Last:  filters.FlowRequirement{Filter: filters.And(filters.IP(hostIP, client.Pod.Status.PodIP), filters.Or(filters.ICMP(0), filters.ICMPv6(129))), Msg: "ICMP response", SkipOnAggregation: true},
 				Except: []filters.FlowRequirement{
 					{Filter: filters.Drop(), Msg: "Drop"},
 				},

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -50,7 +50,7 @@ func (t *PodToHost) Run(ctx context.Context, c check.TestContext) {
 	for _, client := range c.ClientPods() {
 		for hostIP := range hostIPs {
 			cmd := []string{"ping", "-w", "3", "-c", "1", hostIP}
-			run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: hostIP})
+			run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: hostIP}, 0) // 0 port number for ICMP
 			stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
 			run.LogResult(cmd, err, stdout)
 			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -51,8 +51,8 @@ func (t *PodToHost) Run(ctx context.Context, c check.TestContext) {
 		for hostIP := range hostIPs {
 			cmd := []string{"ping", "-w", "3", "-c", "1", hostIP}
 			run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: hostIP}, 0) // 0 port number for ICMP
-			stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
-			run.LogResult(cmd, err, stdout)
+			stdout, stderr, err := client.K8sClient.ExecInPodWithStderr(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
+			run.LogResult(cmd, err, stdout, stderr)
 			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 				Protocol: check.ICMP,
 			})

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -40,8 +40,8 @@ func (t *PodToPod) Run(ctx context.Context, c check.TestContext) {
 		for _, echo := range c.EchoPods() {
 			run := check.NewTestRun(t, c, client, echo, 8080)
 			cmd := curlCommand(net.JoinHostPort(echo.Pod.Status.PodIP, strconv.Itoa(8080)))
-			stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
-			run.LogResult(cmd, err, stdout)
+			stdout, stderr, err := client.K8sClient.ExecInPodWithStderr(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
+			run.LogResult(cmd, err, stdout, stderr)
 			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{})
 			run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
 			ingressFlowRequirements := run.GetIngressRequirements(check.FlowParameters{})

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -38,17 +38,13 @@ func (t *PodToPod) Name() string {
 func (t *PodToPod) Run(ctx context.Context, c check.TestContext) {
 	for _, client := range c.ClientPods() {
 		for _, echo := range c.EchoPods() {
-			run := check.NewTestRun(t, c, client, echo)
+			run := check.NewTestRun(t, c, client, echo, 8080)
 			cmd := curlCommand(net.JoinHostPort(echo.Pod.Status.PodIP, strconv.Itoa(8080)))
 			stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
 			run.LogResult(cmd, err, stdout)
-			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
-				DstPort: 8080,
-			})
+			egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{})
 			run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
-			ingressFlowRequirements := run.GetIngressRequirements(check.FlowParameters{
-				DstPort: 8080,
-			})
+			ingressFlowRequirements := run.GetIngressRequirements(check.FlowParameters{})
 			if ingressFlowRequirements != nil {
 				run.ValidateFlows(ctx, echo.Name(), echo.Pod.Status.PodIP, ingressFlowRequirements)
 			}

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -131,8 +131,8 @@ func testConnetivityToServiceDefinition(ctx context.Context, c check.TestContext
 			Peer:       destination,
 		}, 8080)
 		cmd := curlCommand(destination)
-		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
-		run.LogResult(cmd, err, stdout)
+		stdout, stderr, err := client.K8sClient.ExecInPodWithStderr(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
+		run.LogResult(cmd, err, stdout, stderr)
 		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 			DNSRequired: definition.dns,
 			NodePort:    definition.port,

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -20,13 +20,19 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
-	"github.com/cilium/cilium-cli/connectivity/filters"
 )
 
-type PodToService struct{}
+type PodToService struct {
+	check.PolicyContext
+	Variant string
+}
+
+func (t *PodToService) WithPolicy(yaml string) check.ConnectivityTest {
+	return t.WithPolicyRunner(t, yaml)
+}
 
 func (t *PodToService) Name() string {
-	return "pod-to-service"
+	return "pod-to-service" + t.Variant
 }
 
 func (t *PodToService) Run(ctx context.Context, c check.TestContext) {
@@ -40,15 +46,22 @@ func (t *PodToService) Run(ctx context.Context, c check.TestContext) {
 			}
 		}
 
-		testConnetivityToServiceDefinition(ctx, c, t.Name(), client, serviceDestinations)
+		testConnetivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
 	}
 
 }
 
-type PodToNodePort struct{}
+type PodToNodePort struct {
+	check.PolicyContext
+	Variant string
+}
+
+func (t *PodToNodePort) WithPolicy(yaml string) check.ConnectivityTest {
+	return t.WithPolicyRunner(t, yaml)
+}
 
 func (t *PodToNodePort) Name() string {
-	return "pod-to-nodeport"
+	return "pod-to-nodeport" + t.Variant
 }
 
 func (t *PodToNodePort) Run(ctx context.Context, c check.TestContext) {
@@ -65,14 +78,21 @@ func (t *PodToNodePort) Run(ctx context.Context, c check.TestContext) {
 			}
 		}
 
-		testConnetivityToServiceDefinition(ctx, c, t.Name(), client, serviceDestinations)
+		testConnetivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
 	}
 }
 
-type PodToLocalNodePort struct{}
+type PodToLocalNodePort struct {
+	check.PolicyContext
+	Variant string
+}
+
+func (t *PodToLocalNodePort) WithPolicy(yaml string) check.ConnectivityTest {
+	return t.WithPolicyRunner(t, yaml)
+}
 
 func (t *PodToLocalNodePort) Name() string {
-	return "pod-to-local-nodeport"
+	return "pod-to-local-nodeport" + t.Variant
 }
 
 func (t *PodToLocalNodePort) Run(ctx context.Context, c check.TestContext) {
@@ -91,7 +111,7 @@ func (t *PodToLocalNodePort) Run(ctx context.Context, c check.TestContext) {
 			}
 		}
 
-		testConnetivityToServiceDefinition(ctx, c, t.Name(), client, serviceDestinations)
+		testConnetivityToServiceDefinition(ctx, c, t, client, serviceDestinations)
 	}
 }
 
@@ -103,56 +123,22 @@ type serviceDefinition struct {
 
 type serviceDefinitionMap map[string]serviceDefinition
 
-func testConnetivityToServiceDefinition(ctx context.Context, c check.TestContext, name string, client check.PodContext, def serviceDefinitionMap) {
+func testConnetivityToServiceDefinition(ctx context.Context, c check.TestContext, t check.ConnectivityTest, client check.PodContext, def serviceDefinitionMap) {
 	for peer, definition := range def {
 		destination := net.JoinHostPort(peer, strconv.Itoa(definition.port))
-		run := check.NewTestRun(name, c, client, check.NetworkEndpointContext{
+		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{
 			CustomName: destination + " (" + definition.name + ")",
 			Peer:       destination,
 		})
-
 		cmd := curlCommand(destination)
-		_, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, cmd)
-		if err != nil {
-			run.Failure("curl connectivity check command failed: %s", err)
-		} else {
-			run.Success("curl command %q succeeded", cmd)
-		}
-
-		clientToEcho := filters.IP(client.Pod.Status.PodIP, "")
-		echoToClient := filters.IP("", client.Pod.Status.PodIP)
-
-		// Depending on whether NodePort is enabled or
-		// not, the port will be differnt. Ideally we
-		// look at Cilium to define this but this
-		// information is not yet available.
-		tcpRequest := filters.Or(filters.TCP(0, definition.port), filters.TCP(0, 8080))  // request to 8080 or NodePort
-		tcpResponse := filters.Or(filters.TCP(definition.port, 0), filters.TCP(8080, 0)) // response from port 8080 or NodePort
-
-		flowRequirements := filters.FlowSetRequirement{
-			First: filters.FlowRequirement{Filter: filters.And(clientToEcho, tcpRequest, filters.SYN()), Msg: "SYN"},
-			Middle: []filters.FlowRequirement{
-				{Filter: filters.And(clientToEcho, tcpRequest, filters.SYN()), Msg: "SYN"},
-				{Filter: filters.And(echoToClient, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
-				{Filter: filters.And(clientToEcho, tcpRequest, filters.FIN()), Msg: "FIN"},
-				{Filter: filters.And(echoToClient, tcpResponse, filters.FIN()), Msg: "FIN-ACK"},
-			},
-			Last: filters.FlowRequirement{Filter: filters.And(echoToClient, tcpResponse, filters.FIN()), Msg: "FIN-ACK"},
-			Except: []filters.FlowRequirement{
-				{Filter: filters.RST(), Msg: "RST"},
-				{Filter: filters.Drop(), Msg: "Drop"},
-			},
-		}
-
-		if definition.dns {
-			flowRequirements.First = filters.FlowRequirement{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.UDP(0, 53)), Msg: "DNS request"}
-
-			flowRequirements.Middle = append(flowRequirements.Middle,
-				filters.FlowRequirement{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.UDP(53, 0)), Msg: "DNS response"})
-		}
-
-		run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, flowRequirements)
-
+		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, cmd)
+		run.LogResult(cmd, err, stdout)
+		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
+			DNSRequired: definition.dns,
+			DstPort:     8080,
+			NodePort:    definition.port,
+		})
+		run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
 		run.End()
 	}
 }

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -131,7 +131,7 @@ func testConnetivityToServiceDefinition(ctx context.Context, c check.TestContext
 			Peer:       destination,
 		})
 		cmd := curlCommand(destination)
-		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, cmd)
+		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
 		run.LogResult(cmd, err, stdout)
 		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 			DNSRequired: definition.dns,

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -129,13 +129,12 @@ func testConnetivityToServiceDefinition(ctx context.Context, c check.TestContext
 		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{
 			CustomName: destination + " (" + definition.name + ")",
 			Peer:       destination,
-		})
+		}, 8080)
 		cmd := curlCommand(destination)
 		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
 		run.LogResult(cmd, err, stdout)
 		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 			DNSRequired: definition.dns,
-			DstPort:     8080,
 			NodePort:    definition.port,
 		})
 		run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)

--- a/connectivity/tests/testloop.sh
+++ b/connectivity/tests/testloop.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+for i in $(seq 1 1000); do
+    cilium connectivity test -v
+done

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -40,8 +40,8 @@ func (t *PodToWorld) Run(ctx context.Context, c check.TestContext) {
 	if client := c.RandomClientPod(); client != nil {
 		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: fqdn}, 443)
 		cmd := curlCommand("https://" + fqdn)
-		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
-		run.LogResult(cmd, err, stdout)
+		stdout, stderr, err := client.K8sClient.ExecInPodWithStderr(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
+		run.LogResult(cmd, err, stdout, stderr)
 		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 			DNSRequired: true,
 			RSTAllowed:  true,
@@ -54,8 +54,8 @@ func (t *PodToWorld) Run(ctx context.Context, c check.TestContext) {
 	if client := c.RandomClientPod(); client != nil {
 		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: fqdn}, 80)
 		cmd := curlCommand("http://" + fqdn)
-		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
-		run.LogResult(cmd, err, stdout)
+		stdout, stderr, err := client.K8sClient.ExecInPodWithStderr(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
+		run.LogResult(cmd, err, stdout, stderr)
 		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 			DNSRequired: true,
 			RSTAllowed:  true,
@@ -69,8 +69,8 @@ func (t *PodToWorld) Run(ctx context.Context, c check.TestContext) {
 	if client := c.RandomClientPod(); client != nil {
 		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: fqdn2}, 80)
 		cmd := curlCommand("http://" + fqdn2)
-		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
-		run.LogResult(cmd, err, stdout)
+		stdout, stderr, err := client.K8sClient.ExecInPodWithStderr(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
+		run.LogResult(cmd, err, stdout, stderr)
 		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 			DNSRequired: true,
 			RSTAllowed:  true,

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -18,44 +18,35 @@ import (
 	"context"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
-	"github.com/cilium/cilium-cli/connectivity/filters"
 )
 
-type PodToWorld struct{}
+type PodToWorld struct {
+	check.PolicyContext
+	Variant string
+}
+
+func (t *PodToWorld) WithPolicy(yaml string) check.ConnectivityTest {
+	return t.WithPolicyRunner(t, yaml)
+}
 
 func (t *PodToWorld) Name() string {
-	return "pod-to-world"
+	return "pod-to-world" + t.Variant
 }
 
 func (t *PodToWorld) Run(ctx context.Context, c check.TestContext) {
-	fqdn := "https://google.com"
+	fqdn := "google.com"
 
 	for _, client := range c.ClientPods() {
-		run := check.NewTestRun(t.Name(), c, client, check.NetworkEndpointContext{Peer: fqdn})
-
-		cmd := curlCommand(fqdn)
-		_, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, cmd)
-		if err != nil {
-			run.Failure("curl connectivity check command failed: %s", err)
-		} else {
-			run.Success("curl command %q succeeded", cmd)
-		}
-
-		run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, filters.FlowSetRequirement{
-			First: filters.FlowRequirement{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.UDP(0, 53)), Msg: "DNS request"},
-			Middle: []filters.FlowRequirement{
-				{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.UDP(53, 0)), Msg: "DNS response"},
-				{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.TCP(0, 443), filters.SYN()), Msg: "SYN"},
-				{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.SYNACK()), Msg: "SYN-ACK", SkipOnAggregation: true},
-			},
-			// For the connection termination, we will either see:
-			// a) FIN + FIN b) FIN + RST c) RST
-			Last: filters.FlowRequirement{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true},
-			Except: []filters.FlowRequirement{
-				{Filter: filters.Drop(), Msg: "Drop"},
-			},
+		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: fqdn})
+		cmd := curlCommand("https://" + fqdn)
+		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, cmd)
+		run.LogResult(cmd, err, stdout)
+		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
+			DNSRequired: true,
+			RSTAllowed:  true,
+			DstPort:     443,
 		})
-
+		run.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
 		run.End()
 	}
 }

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -39,7 +39,7 @@ func (t *PodToWorld) Run(ctx context.Context, c check.TestContext) {
 	for _, client := range c.ClientPods() {
 		run := check.NewTestRun(t, c, client, check.NetworkEndpointContext{Peer: fqdn})
 		cmd := curlCommand("https://" + fqdn)
-		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, check.ClientDeploymentName, cmd)
+		stdout, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Labels["name"], cmd)
 		run.LogResult(cmd, err, stdout)
 		egressFlowRequirements := run.GetEgressRequirements(check.FlowParameters{
 			DNSRequired: true,

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -46,11 +46,11 @@ func (t *PodToWorld) Run(ctx context.Context, c check.TestContext) {
 			Middle: []filters.FlowRequirement{
 				{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.UDP(53, 0)), Msg: "DNS response"},
 				{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.TCP(0, 443), filters.SYN()), Msg: "SYN"},
-				{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.SYNACK()), Msg: "SYN-ACK"},
+				{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.SYNACK()), Msg: "SYN-ACK", SkipOnAggregation: true},
 			},
 			// For the connection termination, we will either see:
 			// a) FIN + FIN b) FIN + RST c) RST
-			Last: filters.FlowRequirement{Filter: filters.And(filters.IP(client.Pod.Status.PodIP, ""), filters.TCP(0, 443), filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST"},
+			Last: filters.FlowRequirement{Filter: filters.And(filters.IP("", client.Pod.Status.PodIP), filters.TCP(443, 0), filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true},
 			Except: []filters.FlowRequirement{
 				{Filter: filters.Drop(), Msg: "Drop"},
 			},

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -89,6 +89,8 @@ const (
 	FlowWaitTimeout   = 5 * time.Second
 	FlowRetryInterval = 500 * time.Millisecond
 
+	PolicyWaitTimeout = 10 * time.Second
+
 	ConfigMapKeyMonitorAggregation      = "monitor-aggregation"
 	ConfigMapValueMonitorAggregatonNone = "none"
 )

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -86,10 +86,10 @@ const (
 	WaitRetryInterval   = 2 * time.Second
 	WaitWarningInterval = 10 * time.Second
 
-	FlowWaitTimeout   = 5 * time.Second
+	FlowWaitTimeout   = 10 * time.Second
 	FlowRetryInterval = 500 * time.Millisecond
 
-	PolicyWaitTimeout = 10 * time.Second
+	PolicyWaitTimeout = 30 * time.Second
 
 	ConfigMapKeyMonitorAggregation      = "monitor-aggregation"
 	ConfigMapValueMonitorAggregatonNone = "none"

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -88,6 +88,9 @@ const (
 
 	FlowWaitTimeout   = 5 * time.Second
 	FlowRetryInterval = 500 * time.Millisecond
+
+	ConfigMapKeyMonitorAggregation      = "monitor-aggregation"
+	ConfigMapValueMonitorAggregatonNone = "none"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium-cli
 
-go 1.15
+go 1.16
 
 replace (
 	github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -132,9 +132,11 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		switch f.Kind {
 		case k8s.KindKind:
 			k.params.DatapathMode = DatapathTunnel
-			k.Log("ℹ️  kube-proxy-replacement disabled")
-			k.params.KubeProxyReplacement = "disabled"
 
+			if k.params.KubeProxyReplacement == "" {
+				k.Log("ℹ️  kube-proxy-replacement disabled")
+				k.params.KubeProxyReplacement = "disabled"
+			}
 		case k8s.KindMinikube:
 			k.params.DatapathMode = DatapathTunnel
 		case k8s.KindEKS:
@@ -148,7 +150,6 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 				k.Log("ℹ️  kube-proxy-replacement disabled")
 				k.params.KubeProxyReplacement = "disabled"
 			}
-
 		}
 
 		if k.params.DatapathMode != "" {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -72,6 +72,7 @@ func newCmdConnectivityCheck() *cobra.Command {
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().StringSliceVar(&params.Tests, "test", []string{}, "Run a particular set of tests")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
+	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
 
 	return cmd
 }

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -71,6 +71,7 @@ func newCmdConnectivityCheck() *cobra.Command {
 	cmd.Flags().StringSliceVar(&params.Tests, "test", []string{}, "Run a particular set of tests")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
 	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
+	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show additional diagnostic messages")
 
 	return cmd
 }

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"os"
-	"time"
 
 	"github.com/cilium/cilium-cli/connectivity"
 	"github.com/cilium/cilium-cli/connectivity/check"
@@ -61,7 +60,6 @@ func newCmdConnectivityCheck() *cobra.Command {
 
 	cmd.Flags().BoolVar(&params.SingleNode, "single-node", false, "Limit to tests able to run on a single node")
 	cmd.Flags().BoolVar(&params.PrintFlows, "print-flows", false, "Print flow logs for each test")
-	cmd.Flags().DurationVar(&params.FlowSettleSleepDuration, "pre-flow-collect-sleep", 2*time.Second, "Wait time before collecting flows after testing connectivity")
 	cmd.Flags().DurationVar(&params.PostTestSleepDuration, "post-test-sleep", 0, "Wait time after each test before next test starts")
 	cmd.Flags().BoolVar(&params.ForceDeploy, "force-deploy", false, "Force re-deploying test artifacts")
 	cmd.Flags().BoolVar(&params.Hubble, "hubble", true, "Automatically use Hubble for flow validation & troubleshooting")

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -68,7 +68,7 @@ func newCmdConnectivityCheck() *cobra.Command {
 	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity test in")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
-	cmd.Flags().StringSliceVar(&params.Tests, "test", []string{}, "Run a particular set of tests")
+	cmd.Flags().StringSliceVar(&params.Tests, "test", []string{}, "Run tests that start with one of the given prefixes, skip tests by starting the prefix with '!'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
 	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show additional diagnostic messages")

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -235,11 +235,7 @@ func (c *Client) ExecInPodWithStderr(ctx context.Context, namespace, pod, contai
 		Container: container,
 		Command:   command,
 	})
-	if err != nil {
-		return bytes.Buffer{}, bytes.Buffer{}, err
-	}
-
-	return result.Stdout, result.Stderr, nil
+	return result.Stdout, result.Stderr, err
 }
 
 func (c *Client) ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error) {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -423,3 +423,43 @@ func (c *Client) CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2
 func (c *Client) DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.CiliumClientset.CiliumV2().CiliumExternalWorkloads().Delete(ctx, name, opts)
 }
+
+func (c *Client) ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(namespace).List(ctx, opts)
+}
+
+func (c *Client) GetCiliumNetworkPolicy(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*ciliumv2.CiliumNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(namespace).Get(ctx, name, opts)
+}
+
+func (c *Client) CreateCiliumNetworkPolicy(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy, opts metav1.CreateOptions) (*ciliumv2.CiliumNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace).Create(ctx, cnp, opts)
+}
+
+func (c *Client) UpdateCiliumNetworkPolicy(ctx context.Context, cnp *ciliumv2.CiliumNetworkPolicy, opts metav1.UpdateOptions) (*ciliumv2.CiliumNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace).Update(ctx, cnp, opts)
+}
+
+func (c *Client) DeleteCiliumNetworkPolicy(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(namespace).Delete(ctx, name, opts)
+}
+
+func (c *Client) ListCiliumClusterwideNetworkPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumClusterwideNetworkPolicyList, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().List(ctx, opts)
+}
+
+func (c *Client) GetCiliumClusterwideNetworkPolicy(ctx context.Context, name string, opts metav1.GetOptions) (*ciliumv2.CiliumClusterwideNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Get(ctx, name, opts)
+}
+
+func (c *Client) CreateCiliumClusterwideNetworkPolicy(ctx context.Context, ccnp *ciliumv2.CiliumClusterwideNetworkPolicy, opts metav1.CreateOptions) (*ciliumv2.CiliumClusterwideNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Create(ctx, ccnp, opts)
+}
+
+func (c *Client) UpdateCiliumClusterwideNetworkPolicy(ctx context.Context, ccnp *ciliumv2.CiliumClusterwideNetworkPolicy, opts metav1.UpdateOptions) (*ciliumv2.CiliumClusterwideNetworkPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Update(ctx, ccnp, opts)
+}
+
+func (c *Client) DeleteCiliumClusterwideNetworkPolicy(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.CiliumClientset.CiliumV2().CiliumClusterwideNetworkPolicies().Delete(ctx, name, opts)
+}

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -67,9 +67,5 @@ func (c *Client) execInPod(ctx context.Context, p ExecParameters) (*ExecResult, 
 		Stderr: &result.Stderr,
 		Tty:    false,
 	})
-	if err != nil {
-		return nil, fmt.Errorf("error in stream: %w", err)
-	}
-
-	return result, nil
+	return result, err
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -97,7 +97,10 @@ func (w *WaitObserver) Retry(err error) error {
 
 	select {
 	case <-w.ctx.Done():
-		return fmt.Errorf("timeout while waiting for condition, last error: %s", err)
+		if err != nil {
+			return fmt.Errorf("timeout while waiting for condition, last error: %s", err)
+		}
+		return fmt.Errorf("timeout while waiting for condition")
 	case <-time.After(w.params.retryInterval()):
 	}
 


### PR DESCRIPTION
**Note:** first four commits are from another PR (#128) that this PR depends on.

Policy can be installed and removed as a test step between other
tests, or applied to a single test with `WithPolicy()`. Go syntax for
WithPolicy() use requires scoping address-of operator, which is not
ideal.

Policy is expressed as yaml and must specify the namespace in which
the policy is to be applied. Same test cases can be repeated with different
policies and corresponding egress/ingress enforcement expectations.

Use Go 1.16 //go:embed to include policy YAMLs as strings to Go source
code. This makes test authoring mush easier.

`cilium connectivity test` now has `--verbose` (or `-v`) mode that prints additional diagnostic information such as test command output and policy revision information.

`curl` output is formatted to show the source and destination addresses and ports as well as the HTTP return code.

`ping` has been optimized to exit after first successful ping with the timeout (`-w`) option.

Design considerations:
 - Currently policies are expressed as stand-alone yaml, parsed in to CiliumNetworkPolicies. Policies need to specify in which namespace they apply and this must match the namespace in which the tests are executed. This, however, is a configurable parameter, and may need to be overridden after the YAMLs have been parsed.
   - More complicated policy tests may require use of multiple namespaces, but the current test setup with a single configurable test namespace seems ill-suited for that.

Infrastructure TODOs:
- [ ] make sure multi-cluster testing is not broken by this
  - [ ] Apply testing policies in all appropriate clusters
- [x] Finalize policy apply/delete infra within the test suite (i.e., between or with the tests)
- [x] Add support for different expected test outcomes (currently drops are never expected)
  - [x] Allow the same test case be run against different policies with different expected outcomes
- [ ] Add support for CiliumClusterwideNetworkPolicies
- [ ] Add support for k8s NetworkPolicies
    
Policy test cases needed (Once the infra is in place adding these should not need any new Go code):
 - [x] L3 policy ingress
 - [x] L3 policy egress
 - [ ] L3/L4 policy ingress
 - [x] L3/L4 policy egress
 - [ ] `toEntities`/`fromEntities`
 - [ ] `toEntities`/`fromEntities`
 - [ ] CIDR
 - [x] HTTP (adds use of Envoy)
 - [ ] Kafka (adds use of proxylib with Envoy)
 - [x] `toFQDNs`
 - [ ] L3-dependent L7 with HTTP
 - [ ] L3-dependent L7 with `toFQDNs` with HTTP
