### PR TITLE
Install: Upgrade/downgrade support for micro releases

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -923,11 +924,13 @@ type k8sInstallerImplementation interface {
 	CreateDaemonSet(ctx context.Context, namespace string, ds *appsv1.DaemonSet, opts metav1.CreateOptions) (*appsv1.DaemonSet, error)
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	DeleteDaemonSet(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
+	PatchDaemonSet(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.DaemonSet, error)
 	CreateService(ctx context.Context, namespace string, service *corev1.Service, opts metav1.CreateOptions) (*corev1.Service, error)
 	DeleteService(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	DeleteDeployment(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	CreateDeployment(ctx context.Context, namespace string, deployment *appsv1.Deployment, opts metav1.CreateOptions) (*appsv1.Deployment, error)
 	GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error)
+	PatchDeployment(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.Deployment, error)
 	DeploymentIsReady(ctx context.Context, namespace, deployment string) error
 	DeleteNamespace(ctx context.Context, namespace string, opts metav1.DeleteOptions) error
 	CreateNamespace(ctx context.Context, namespace string, opts metav1.CreateOptions) (*corev1.Namespace, error)

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -1,0 +1,106 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/status"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (k *K8sInstaller) Upgrade(ctx context.Context) error {
+	daemonSet, err := k.client.GetDaemonSet(ctx, k.params.Namespace, defaults.AgentDaemonSetName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to retrieve DaemonSet of cilium-agent: %s", err)
+	}
+
+	deployment, err := k.client.GetDeployment(ctx, k.params.Namespace, defaults.OperatorDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to retrieve Deployment of cilium-operator: %s", err)
+	}
+
+	var patched int
+
+	if deployment.Spec.Template.Spec.Containers[0].Image == k.fqOperatorImage() {
+		k.Log("✅ cilium-operator is already up to date")
+	} else {
+		k.Log("🚀 Upgrading cilium-operator to version %s...", k.fqOperatorImage())
+		patch := []byte(`{"spec":{"template":{"spec":{"containers":[{"name": "cilium-operator", "image":"` + k.fqOperatorImage() + `"}]}}}}`)
+
+		_, err = k.client.PatchDeployment(ctx, k.params.Namespace, defaults.OperatorDeploymentName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to patch Deployment %s with patch %q: %w", defaults.OperatorDeploymentName, patch, err)
+		}
+
+		patched++
+	}
+
+	agentImage := k.fqAgentImage()
+	var containerPatches []string
+	for _, c := range daemonSet.Spec.Template.Spec.Containers {
+		if c.Image != agentImage {
+			containerPatches = append(containerPatches, `{"name":"`+c.Name+`", "image":"`+agentImage+`"}`)
+		}
+	}
+	var initContainerPatches []string
+	for _, c := range daemonSet.Spec.Template.Spec.InitContainers {
+		if c.Image != agentImage {
+			initContainerPatches = append(initContainerPatches, `{"name":"`+c.Name+`", "image":"`+agentImage+`"}`)
+		}
+	}
+
+	if len(containerPatches) == 0 && len(initContainerPatches) == 0 {
+		k.Log("✅ Cilium is already up to date")
+	} else {
+		k.Log("🚀 Upgrading cilium to version %s...", k.fqAgentImage())
+
+		patch := []byte(`{"spec":{"template":{"spec":{"containers":[` + strings.Join(containerPatches, ",") + `], "initContainers":[` + strings.Join(initContainerPatches, ",") + `]}}}}`)
+		_, err = k.client.PatchDaemonSet(ctx, k.params.Namespace, defaults.AgentDaemonSetName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to patch DaemonSet %s with patch %q: %w", defaults.AgentDaemonSetName, patch, err)
+		}
+
+		patched++
+	}
+
+	if patched > 0 && k.params.Wait {
+		k.Log("⌛ Waiting for Cilium to be upgraded...")
+		collector, err := status.NewK8sStatusCollector(ctx, k.client, status.K8sStatusParameters{
+			Namespace:       k.params.Namespace,
+			Wait:            true,
+			WaitDuration:    k.params.WaitDuration,
+			WarningFreePods: []string{defaults.AgentDaemonSetName, defaults.OperatorDeploymentName},
+		})
+		if err != nil {
+			return err
+		}
+
+		s, err := collector.Status(ctx)
+		if err != nil {
+			if s != nil {
+				fmt.Println(s.Format())
+			}
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -84,6 +84,7 @@ cilium connectivity test`,
 		newCmdInstall(),
 		newCmdStatus(),
 		newCmdUninstall(),
+		newCmdUpgrade(),
 		newCmdVersion(),
 	)
 	cmd.SetOut(os.Stdout)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -171,6 +171,10 @@ func (c *Client) DeleteDeployment(ctx context.Context, namespace, name string, o
 	return c.Clientset.AppsV1().Deployments(namespace).Delete(ctx, name, opts)
 }
 
+func (c *Client) PatchDeployment(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.Deployment, error) {
+	return c.Clientset.AppsV1().Deployments(namespace).Patch(ctx, name, pt, data, opts)
+}
+
 func (c *Client) DeploymentIsReady(ctx context.Context, namespace, deployment string) error {
 	d, err := c.GetDeployment(ctx, namespace, deployment, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
Adds a new "cilium upgrade" command that sets image tags on all required
container images. The command can later be extended to also apply the
required diff to move between minor releases.

```
cilium upgrade
🚀 Upgrading cilium-operator to version quay.io/cilium/operator-generic:v1.9.5...
🚀 Upgrading cilium to version quay.io/cilium/cilium:v1.9.5...
⌛ Waiting for Cilium to be upgraded...
```