### PR TITLE
hubble: Add cilium hubble port-forward command

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Relay Port Forward
         run: |
-          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          cilium hubble port-forward&
           sleep 5s
 
       - name: Connectivity Test

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Relay Port Forward
         run: |
-          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          cilium hubble port-forward&
           sleep 5s
 
       - name: Connectivity Test

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Relay Port Forward
         run: |
-          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          cilium hubble port-forward&
           sleep 5s
 
       - name: Connectivity Test

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Relay Port Forward
         run: |
-          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          cilium hubble port-forward&
           sleep 5s
 
       - name: Connectivity Test

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Relay Port Forward
         run: |
-          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          cilium hubble port-forward&
           sleep 5s
 
       - name: Connectivity Test

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Relay Port Forward
         run: |
           CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
-          kubectl --context $CONTEXT1 port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          cilium hubble port-forward --context $CONTEXT1&
           sleep 5s
 
       - name: Connectivity test

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -73,6 +73,7 @@ type Parameters struct {
 	RelayImage       string
 	RelayVersion     string
 	RelayServiceType string
+	PortForward      int
 	CreateCA         bool
 	Writer           io.Writer
 }

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -34,6 +34,7 @@ func newCmdHubble() *cobra.Command {
 	cmd.AddCommand(
 		newCmdHubbleEnable(),
 		newCmdHubbleDisable(),
+		newCmdPortForwardCommand(),
 	)
 
 	return cmd
@@ -88,6 +89,31 @@ func newCmdHubbleDisable() *cobra.Command {
 
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+
+	return cmd
+}
+
+func newCmdPortForwardCommand() *cobra.Command {
+	var params = hubble.Parameters{
+		Writer: os.Stdout,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "port-forward",
+		Short: "Forward the relay port to the local machine",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			h := hubble.NewK8sHubble(k8sClient, params)
+			if err := h.PortForwardCommand(context.Background()); err != nil {
+				fatalf("Unable to port forward: %s", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
+	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+	cmd.Flags().IntVar(&params.PortForward, "port-forward", 4245, "Local port to forward to")
 
 	return cmd
 }


### PR DESCRIPTION
Simplify the local forwarding of the relay port and allow users to run
the command `cilium hubble port-forward`

```
cilium hubble port-forward
Forwarding from 0.0.0.0:4245 -> 4245
Forwarding from [::]:4245 -> 4245
```

Signed-off-by: Thomas Graf <thomas@cilium.io>