### PR TITLE
hubble: add the hubble-cli Deployment

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -59,6 +59,8 @@ const (
 	HubbleUIConfigMapName      = "hubble-ui-envoy"
 	HubbleUIDeploymentName     = "hubble-ui"
 
+	HubbleCLIDeploymentName = "hubble-cli"
+
 	ClusterMeshDeploymentName             = "clustermesh-apiserver"
 	ClusterMeshServiceAccountName         = "clustermesh-apiserver"
 	ClusterMeshClusterRoleName            = "clustermesh-apiserver"
@@ -107,6 +109,11 @@ var (
 	// HubbleUIDeploymentLabels are the labels set on the Hubble UI Deployment by default.
 	HubbleUIDeploymentLabels = map[string]string{
 		"k8s-app": "hubble-ui",
+	}
+
+	// HubbleCLIDeploymentLabels are the labels set on the Hubble CLI Deployment by default.
+	HubbleCLIDeploymentLabels = map[string]string{
+		"k8s-app": "hubble-cli",
 	}
 
 	// ClusterMeshDeploymentLabels are the labels set on the clustermesh API server by default.

--- a/hubble/cli.go
+++ b/hubble/cli.go
@@ -1,0 +1,167 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hubble
+
+import (
+	"context"
+
+	"github.com/cilium/cilium-cli/defaults"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var hubbleCLIReplicas = int32(1)
+
+func (k *K8sHubble) generateHubbleCLIDeployment() *appsv1.Deployment {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   defaults.HubbleCLIDeploymentName,
+			Labels: defaults.HubbleCLIDeploymentLabels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &hubbleCLIReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: defaults.HubbleCLIDeploymentLabels,
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   defaults.HubbleCLIDeploymentName,
+					Labels: defaults.HubbleCLIDeploymentLabels,
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:      corev1.RestartPolicyAlways,
+					ServiceAccountName: defaults.RelayServiceAccountName,
+					Containers: []corev1.Container{
+						{
+							Name: "hubble-cli",
+							// NOTE: just run forever
+							Command: []string{"tail"},
+							Args: []string{
+								"-f",
+								"/dev/null",
+							},
+							Image: "quay.io/cilium/hubble:latest",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "HUBBLE_SERVER",
+									Value: "$(HUBBLE_RELAY_SERVICE_HOST):$(HUBBLE_RELAY_SERVICE_PORT)",
+								},
+							},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "hubble-sock-dir",
+									MountPath: "/var/run/cilium",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "tls",
+									MountPath: "/var/lib/hubble-relay/tls",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "hubble-sock-dir",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/run/cilium",
+									Type: &hostPathDirectoryOrCreate,
+								},
+							},
+						},
+						{
+							Name: "tls",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{
+										{
+											Secret: &corev1.SecretProjection{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: defaults.RelayClientSecretName,
+												},
+												Items: []corev1.KeyToPath{
+													{
+														Key:  corev1.TLSCertKey,
+														Path: "client.crt",
+													},
+													{
+														Key:  corev1.TLSPrivateKeyKey,
+														Path: "client.key",
+													},
+												},
+											},
+										},
+										{
+											Secret: &corev1.SecretProjection{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: defaults.CASecretName,
+												},
+												Items: []corev1.KeyToPath{
+													{
+														Key:  defaults.CASecretCertName,
+														Path: "hubble-server-ca.crt",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return d
+}
+
+func (k *K8sHubble) disableHubbleCLI(ctx context.Context) error {
+	k.Log("🔥 Deleting Hubble CLI...")
+	k.client.DeleteDeployment(ctx, k.params.Namespace, defaults.HubbleCLIDeploymentName, metav1.DeleteOptions{})
+	return nil
+}
+
+func (k *K8sHubble) enableHubbleCLI(ctx context.Context) error {
+	_, err := k.client.GetDeployment(ctx, k.params.Namespace, defaults.HubbleCLIDeploymentName, metav1.GetOptions{})
+	if err == nil {
+		k.Log("✅ Hubble CLI is already deployed")
+		return nil
+	}
+
+	// We need relay to be deployed since we're using its ServiceAccountName
+	// and Secret.
+	_, err = k.client.GetDeployment(ctx, k.params.Namespace, defaults.RelayDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		k.Log("❌ Relay is not deployed")
+		return err
+	}
+
+	k.Log("✨ Deploying Hubble CLI...")
+	_, err = k.client.CreateDeployment(ctx, k.params.Namespace, k.generateHubbleCLIDeployment(), metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -76,6 +76,7 @@ type Parameters struct {
 	PortForward      int
 	CreateCA         bool
 	UI               bool
+	CLI              bool
 	UIPortForward    int
 	Writer           io.Writer
 	Context          string // Only for 'kubectl' pass-through commands
@@ -250,6 +251,12 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 
 	if k.params.UI {
 		if err := k.enableUI(ctx); err != nil {
+			return err
+		}
+	}
+
+	if k.params.CLI {
+		if err := k.enableHubbleCLI(ctx); err != nil {
 			return err
 		}
 	}

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -251,6 +251,10 @@ func (k *K8sHubble) relayImage() string {
 }
 
 func (k *K8sHubble) disableRelay(ctx context.Context) error {
+	// XXX: should we also disable Hubble UI here?
+	if err := k.disableHubbleCLI(ctx); err != nil {
+		return err
+	}
 	k.Log("🔥 Deleting Relay...")
 	k.client.DeleteService(ctx, k.params.Namespace, defaults.RelayServiceName, metav1.DeleteOptions{})
 	k.client.DeleteDeployment(ctx, k.params.Namespace, defaults.RelayDeploymentName, metav1.DeleteOptions{})
@@ -274,8 +278,6 @@ func (k *K8sHubble) enableRelay(ctx context.Context) error {
 	if err := k.createRelayCertificates(ctx); err != nil {
 		return err
 	}
-
-	//	k.Log("✨ Generating certificates...")
 
 	k.Log("✨ Deploying Relay...")
 	if _, err := k.client.CreateConfigMap(ctx, k.params.Namespace, k.generateRelayConfigMap(), metav1.CreateOptions{}); err != nil {

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -65,6 +65,7 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().StringVar(&params.RelayVersion, "relay-version", defaults.Version, "Version of Relay to deploy")
 	cmd.Flags().StringVar(&params.RelayServiceType, "relay-service-type", "ClusterIP", "Type of Kubernetes service to expose Hubble Relay")
 	cmd.Flags().BoolVar(&params.UI, "ui", false, "Enable Hubble UI")
+	cmd.Flags().BoolVar(&params.CLI, "cli", false, "Enable Hubble CLI")
 	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", false, "Automatically create CA if needed")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 


### PR DESCRIPTION
In order to debug Relay to Hubble connectivity issues, it is sometimes useful to have a Pod running with the Hubble CLI.

Because the Relay image is based on a scratch image, kubectl exec'ing into it is not possible. While the Hubble CLI can be found in the Cilium Pods, the Relay certificate needed to establish the mTLS handshake to the Hubble server is not mounted into the Cilium Pods.

This commit introduce a new hubble-cli Deployment. When debugging Relay mTLS issues, it can be used to quickly run a hubble-cli Pod:

    cilium hubble enable --cli

Since the Relay mTLS certificates are mounted into the hubble-cli Pods, one can connect to a Hubble server given it's IP address and ServerName:

    kubectl exec -it -n kube-system deployment/hubble-cli -- \
        hubble observe --server tls://${IP?}:4244 \
            --tls-server-name ${SERVERNAME?} \
            --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt \
            --tls-client-cert-file /var/lib/hubble-relay/tls/client.crt \
            --tls-client-key-file /var/lib/hubble-relay/tls/client.key

Both `${IP}` and `${SERVERNAME}` can be obtained by either looking at the Hubble Relay Pod logs or alternatively by running:

    kubectl exec -it -n kube-system deployment/hubble-cli -- hubble peer watch

See https://github.com/cilium/cilium/pull/14615 for additional context.