### PR TITLE
ci: use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,7 +1,7 @@
 name: AKS
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
       - master

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -1,7 +1,7 @@
 name: EKS (tunnel)
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
       - master

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,7 +1,7 @@
 name: EKS (ENI)
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
       - master

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -1,7 +1,7 @@
 name: External Workloads
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
       - master

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,7 +1,7 @@
 name: GKE
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
       - master

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ name: Go
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -1,7 +1,7 @@
 name: Kind
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
       - master

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -1,7 +1,7 @@
 name: Multicluster
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
       - master


### PR DESCRIPTION
Before this patch, PRs made from forks would not have access to repository's Secrets and CI login would fail.