### PR TITLE
check: Skip SYN-ACK validation when flow aggregation is on (again)

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -671,7 +671,7 @@ func (t *TestRun) GetEgressRequirements(p FlowParameters) *filters.FlowSetRequir
 			egress = &filters.FlowSetRequirement{
 				First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
 				Middle: []filters.FlowRequirement{
-					{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK"},
+					{Filter: filters.And(ipResponse, tcpResponse, filters.SYNACK()), Msg: "SYN-ACK", SkipOnAggregation: true},
 				},
 				// Either side may FIN first
 				Last: filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.FIN()), Msg: "FIN"},


### PR DESCRIPTION
PR #158 accidentally removed the SkipOnAggregation flag for SYN-ACK
flow validation, causing flow validation errors when flow aggregation
is enabled. Fix by adding it back.

Fixes: #158
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>