### PR TITLE
test: Change `--test` args to regexp matches

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1124,7 +1125,8 @@ type Parameters struct {
 	Hubble                bool
 	HubbleServer          string
 	MultiCluster          string
-	Tests                 []string
+	RunTests              []*regexp.Regexp
+	SkipTests             []*regexp.Regexp
 	PostTestSleepDuration time.Duration
 	FlowValidation        string
 	AllFlows              bool
@@ -1155,37 +1157,20 @@ func (p Parameters) validate() error {
 }
 
 func (p Parameters) testEnabled(test string) bool {
-	if len(p.Tests) == 0 {
-		return true
-	}
-
-	numAllow := 0
-	numDeny := 0
-
-	for _, p := range p.Tests {
-		result := true
-		if p[0] == '!' {
-			numDeny++
-			p = p[1:]
-			result = false
-		} else {
-			numAllow++
-		}
-
-		if strings.HasPrefix(test, p) {
-			return result
+	// Skip 'test' if any SkipTest matches
+	for _, re := range p.SkipTests {
+		if re.MatchString(test) {
+			return false
 		}
 	}
-
-	if numDeny == 0 {
-		return false
+	// Run 'test' if any RunTest matches
+	for _, re := range p.RunTests {
+		if re.MatchString(test) {
+			return true
+		}
 	}
-
-	if numAllow > 0 {
-		return false
-	}
-
-	return true
+	// Else run if tests are not limited
+	return len(p.RunTests) == 0
 }
 
 func (k *K8sConnectivityCheck) deleteDeployments(ctx context.Context, client k8sConnectivityImplementation) error {


### PR DESCRIPTION
Treat each --test string as a regular expression matching a substring
in the test name rather than prefix. This makes it simpler to include
or exclude tests based on regular expression matches.

The '!' syntax is retained, so '!' in the beginning of a string
excludes matching tests.

For example, to only test tests that match "world", but not "FQDN":

$ cilium connectivity test --test 'world,!FQDN'

(bash requires single quotes to retain '!')

To only test "pod" tests with an "egress" policy:

$ cilium connectivity test --test 'pod.*egress'

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>