### PR TITLE
test: Dump Cilium logs when policy apply times out

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -189,6 +190,8 @@ type k8sConnectivityImplementation interface {
 	ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error)
 	ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error)
 	ClusterName() (name string)
+
+	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
 
 	k8sPolicyImplementation
 }

--- a/connectivity/manifests/client-egress-to-fqdns-google.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-google.yaml
@@ -25,6 +25,7 @@ spec:
       rules:
         dns:
         - matchPattern: "*"
+        - matchPattern: "*.-name.com"
     toEndpoints:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -97,7 +97,7 @@ const (
 	FlowWaitTimeout   = 10 * time.Second
 	FlowRetryInterval = 500 * time.Millisecond
 
-	PolicyWaitTimeout = 30 * time.Second
+	PolicyWaitTimeout = 15 * time.Second
 
 	ConfigMapKeyMonitorAggregation      = "monitor-aggregation"
 	ConfigMapValueMonitorAggregatonNone = "none"


### PR DESCRIPTION
    Make policy tests easier to debug by:
    
    1. Use strict decoder for policy YAMLs. Wihtout this any errors in
    policy YAMLs are silently ignored, which may lead to confusing test
    outcomes.
    
    2. Print out the applied policy in verbose mode. The printout is in
    JSON as it was easier to generate.
    
    3. Dump out the Cilium agent logs for the relevant time duration
    whenever policy apply or delete fails.
    
    4. Skip running the test traffic if policy apply fails. There is no
    point in running the tests if the required policy cannot be applied.
    
    5. Do not try to delete policies if the policy apply failed. Note that
    if policy apply succeeds, but Cilium agent still fails to apply the
    policy we still have to delete the policy. In this case waiting for
    the policy delete to complete in all Cilium agents may time out, as
    the agent policy rrevisions are not changing if the policy was never
    successfully imported.
    
    Example of Cilium agent logs when testing with a policy that passed CRD validation but failed to import:
    
    ---------------------------------------------------------------------------------------------------------------------
    🔌 [cilium-test/client-egress-to-fqdns-google] Applying CiliumNetworkPolicy...
    ---------------------------------------------------------------------------------------------------------------------
    ❌ policy is not applied in all Cilium nodes in time
    ℹ️  Cilium agent kube-system/cilium-94v4p logs since 2021-04-22 21:55:12.480199533 +0000 UTC m=-0.628134827:
    2021-04-22T21:55:13.815991494Z level=warning msg="Unable to add CiliumNetworkPolicy" ciliumNetworkPolicyName=client-egress-to-fqdns-google error="Invalid CiliumNetworkPolicy spec: Invalid characters in MatchPattern: \"*._name.com\". Only 0-9, a-z, A-Z and ., - and * characters are allowed" k8sApiVersion= k8sNamespace=cilium-test subsys=k8s-watcher
    
    ℹ️  Cilium agent kube-system/cilium-sgsrl logs since 2021-04-22 21:55:12.480199533 +0000 UTC m=-0.628134827:
    2021-04-22T21:55:13.815977567Z level=warning msg="Unable to add CiliumNetworkPolicy" ciliumNetworkPolicyName=client-egress-to-fqdns-google error="Invalid CiliumNetworkPolicy spec: Invalid characters in MatchPattern: \"*._name.com\". Only 0-9, a-z, A-Z and ., - and * characters are allowed" k8sApiVersion= k8sNamespace=cilium-test subsys=k8s-watcher
    
    ❌ policy apply failed
    ❌ policies are not deleted in all Cilium nodes in time
    ℹ️  Cilium agent kube-system/cilium-94v4p logs since 2021-04-22 21:55:43.324304655 +0000 UTC m=+30.215970253:
    2021-04-22T21:55:44.642749404Z level=warning msg="Unable to delete CiliumNetworkPolicy" ciliumNetworkPolicyName=client-egress-to-fqdns-google error="policy not found" k8sApiVersion= k8sNamespace=cilium-test subsys=k8s-watcher
    
    ℹ️  Cilium agent kube-system/cilium-sgsrl logs since 2021-04-22 21:55:43.324304655 +0000 UTC m=+30.215970253:
    2021-04-22T21:55:44.643319288Z level=warning msg="Unable to delete CiliumNetworkPolicy" ciliumNetworkPolicyName=client-egress-to-fqdns-google error="policy not found" k8sApiVersion= k8sNamespace=cilium-test subsys=k8s-watcher
