### PR TITLE
Multicluster policy test fixes

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -47,13 +47,13 @@ jobs:
 
       - name: Create GKE cluster1
         run: |
-          gcloud container clusters create ${{ env.clusterName1 }} --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone ${{ env.zone }}
+          gcloud container clusters create ${{ env.clusterName1 }} --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone ${{ env.zone }} --enable-ip-alias
           gcloud container clusters get-credentials ${{ env.clusterName1 }} --zone ${{ env.zone }}
           echo "CONTEXT1=$(kubectl config get-contexts -o name | grep ${{ env.clusterName1 }})" >> $GITHUB_ENV
 
       - name: Install cilium in cluster1
         run: |
-          cilium install --cluster-name ${{ env.clusterName1 }} --cluster-id 1 --restart-unmanaged-pods=false --config monitor-aggregation=none --config tunnel=vxlan
+          cilium install --cluster-name ${{ env.clusterName1 }} --cluster-id 1 --restart-unmanaged-pods=false --config monitor-aggregation=none --native-routing-cidr=10.0.0.0/9
           cilium hubble enable
 
       - name: Enable ClusterMesh cluster1
@@ -62,13 +62,24 @@ jobs:
 
       - name: Create GKE cluster2
         run: |
-          gcloud container clusters create ${{ env.clusterName2 }} --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone ${{ env.zone }}
+          gcloud container clusters create ${{ env.clusterName2 }} --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone ${{ env.zone }} --enable-ip-alias
           gcloud container clusters get-credentials ${{ env.clusterName2 }} --zone ${{ env.zone }}
           echo "CONTEXT2=$(kubectl config get-contexts -o name | grep ${{ env.clusterName2 }})" >> $GITHUB_ENV
 
+      - name: Allow cross-cluster traffic
+        run: |
+          TAG1=$(gcloud compute firewall-rules list --filter="name~^gke-${{ env.clusterName1 }}-[0-9a-z]*-all$" --format="value(name)")
+          TAG2=$(gcloud compute firewall-rules list --filter="name~^gke-${{ env.clusterName2 }}-[0-9a-z]*-all$" --format="value(name)")
+          GCP_FW_RULE=cilium-cli-ci-multicluster-${{ github.run_number }}-rule
+          gcloud compute firewall-rules describe $TAG1
+          gcloud compute firewall-rules describe $TAG2
+          gcloud compute firewall-rules create $GCP_FW_RULE --allow tcp,udp,icmp,sctp,esp,ah --priority=999 --source-ranges=10.0.0.0/9 --target-tags=${TAG1/-all/-node},${TAG2/-all/-node}
+          gcloud compute firewall-rules describe $GCP_FW_RULE
+          echo "GCP_FW_RULE=$GCP_FW_RULE" >> $GITHUB_ENV
+
       - name: Install cilium in cluster2
         run: |
-          cilium install --cluster-name ${{ env.clusterName2 }} --cluster-id 2 --restart-unmanaged-pods=false --config monitor-aggregation=none --config tunnel=vxlan --context $CONTEXT2 --inherit-ca $CONTEXT1
+          cilium install --cluster-name ${{ env.clusterName2 }} --cluster-id 2 --restart-unmanaged-pods=false --config monitor-aggregation=none --native-routing-cidr=10.0.0.0/9 --context $CONTEXT2 --inherit-ca $CONTEXT1
           cilium hubble enable --relay=false
 
       - name: Enable ClusterMesh cluster2
@@ -114,6 +125,7 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
+          gcloud compute firewall-rules delete --quiet $GCP_FW_RULE
           gcloud container clusters delete --quiet ${{ env.clusterName1 }} --zone ${{ env.zone }}
           gcloud container clusters delete --quiet ${{ env.clusterName2 }} --zone ${{ env.zone }}
         shell: bash {0}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -49,6 +49,7 @@ jobs:
         run: |
           gcloud container clusters create ${{ env.clusterName1 }} --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone ${{ env.zone }}
           gcloud container clusters get-credentials ${{ env.clusterName1 }} --zone ${{ env.zone }}
+          echo "CONTEXT1=$(kubectl config get-contexts -o name | grep ${{ env.clusterName1 }})" >> $GITHUB_ENV
 
       - name: Install cilium in cluster1
         run: |
@@ -63,11 +64,10 @@ jobs:
         run: |
           gcloud container clusters create ${{ env.clusterName2 }} --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone ${{ env.zone }}
           gcloud container clusters get-credentials ${{ env.clusterName2 }} --zone ${{ env.zone }}
+          echo "CONTEXT2=$(kubectl config get-contexts -o name | grep ${{ env.clusterName2 }})" >> $GITHUB_ENV
 
       - name: Install cilium in cluster2
         run: |
-          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
-          CONTEXT2=$(kubectl config view | grep ${{ env.clusterName2 }} | head -1 | awk '{print $2}')
           cilium install --cluster-name ${{ env.clusterName2 }} --cluster-id 2 --restart-unmanaged-pods=false --config monitor-aggregation=none --config tunnel=vxlan --context $CONTEXT2 --inherit-ca $CONTEXT1
           cilium hubble enable --relay=false
 
@@ -77,47 +77,36 @@ jobs:
 
       - name: Wait for ClusterMesh to be enabled cluster1
         run: |
-          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
           cilium --context $CONTEXT1 clustermesh status --wait
 
       - name: Wait for ClusterMesh to be enabled cluster2
         run: |
-          CONTEXT2=$(kubectl config view | grep ${{ env.clusterName2 }} | head -1 | awk '{print $2}')
           cilium --context $CONTEXT2 clustermesh status --wait
 
       - name: Connect clusters
         run: |
-          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
-          CONTEXT2=$(kubectl config view | grep ${{ env.clusterName2 }} | head -1 | awk '{print $2}')
           cilium --context $CONTEXT1 clustermesh connect --destination-context $CONTEXT2
 
       - name: Wait for ClusterMesh to be connected cluster1
         run: |
-          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
           cilium --context $CONTEXT1 clustermesh status --wait --wait-duration 5m
 
       - name: Wait for ClusterMesh to be connected cluster2
         run: |
-          CONTEXT2=$(kubectl config view | grep ${{ env.clusterName2 }} | head -1 | awk '{print $2}')
           cilium --context $CONTEXT2 clustermesh status --wait --wait-duration 5m
 
       - name: Relay Port Forward
         run: |
-          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
           cilium hubble port-forward --context $CONTEXT1&
           sleep 5s
 
       - name: Connectivity test
         run: |
-          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
-          CONTEXT2=$(kubectl config view | grep ${{ env.clusterName2 }} | head -1 | awk '{print $2}')
           cilium --context $CONTEXT1 connectivity test --multi-cluster $CONTEXT2 --test '!pod-to-nodeport' --test '!pod-to-local-nodeport'
 
       - name: Cleanup
         if: ${{ always() }}
         run: |
-          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
-          CONTEXT2=$(kubectl config view | grep ${{ env.clusterName2 }} | head -1 | awk '{print $2}')
           cilium --context $CONTEXT1 status
           cilium --context $CONTEXT1 clustermesh status
           cilium --context $CONTEXT2 status

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   installation-and-connectivity:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install cilium in cluster1
         run: |
-          cilium install --cluster-name ${{ env.clusterName1 }} --cluster-id 1 --kube-proxy-replacement disabled --config monitor-aggregation=none
+          cilium install --cluster-name ${{ env.clusterName1 }} --cluster-id 1 --restart-unmanaged-pods=false --config monitor-aggregation=none --config tunnel=vxlan
           cilium hubble enable
 
       - name: Enable ClusterMesh cluster1
@@ -66,8 +66,10 @@ jobs:
 
       - name: Install cilium in cluster2
         run: |
-          cilium install --cluster-name ${{ env.clusterName2 }} --cluster-id 2 --kube-proxy-replacement disabled --config monitor-aggregation=none
-          cilium hubble enable
+          CONTEXT1=$(kubectl config view | grep ${{ env.clusterName1 }} | head -1 | awk '{print $2}')
+          CONTEXT2=$(kubectl config view | grep ${{ env.clusterName2 }} | head -1 | awk '{print $2}')
+          cilium install --cluster-name ${{ env.clusterName2 }} --cluster-id 2 --restart-unmanaged-pods=false --config monitor-aggregation=none --config tunnel=vxlan --context $CONTEXT2 --inherit-ca $CONTEXT1
+          cilium hubble enable --relay=false
 
       - name: Enable ClusterMesh cluster2
         run: |

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -1239,13 +1239,13 @@ func (k *K8sConnectivityCheck) deploymentList() (srcList []string, dstList []str
 }
 
 type deploymentClients struct {
-	dstInOtherCluster bool
-	src               k8sConnectivityImplementation
-	dst               k8sConnectivityImplementation
+	src k8sConnectivityImplementation
+	dst k8sConnectivityImplementation
 }
 
+// clients return a slice of unique k8s clients to use
 func (d *deploymentClients) clients() []k8sConnectivityImplementation {
-	if d.dstInOtherCluster {
+	if d.src != d.dst {
 		return []k8sConnectivityImplementation{d.src, d.dst}
 	}
 	return []k8sConnectivityImplementation{d.src}
@@ -1323,7 +1323,6 @@ func (k *K8sConnectivityCheck) initClients(ctx context.Context) (*deploymentClie
 		}
 
 		c.dst = dst
-		c.dstInOtherCluster = true
 
 		if a, _ := k.logAggregationMode(ctx, c.dst); a != defaults.ConfigMapValueMonitorAggregatonNone {
 			k.flowAggregation = true

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -1172,6 +1172,7 @@ type Parameters struct {
 	AllFlows              bool
 	Writer                io.Writer
 	Verbose               bool
+	PauseOnFail           bool
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {
@@ -1759,6 +1760,11 @@ func (k *K8sConnectivityCheck) Report(r TestResult) {
 		r.Failures++
 	}
 	k.results[r.Name] = r
+
+	if r.Failures > 0 && k.params.PauseOnFail {
+		fmt.Println("Pausing after test failure, press the Enter key to continue:")
+		fmt.Scanln()
+	}
 }
 
 func (k *K8sConnectivityCheck) Run(ctx context.Context, tests ...ConnectivityTest) error {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -938,6 +938,9 @@ type ConnectivityTest interface {
 	// Name must return the name of the test
 	Name() string
 
+	// PolicyOnly returns true if there is policy setup but no traffic scenario with this test
+	PolicyOnly() bool
+
 	// Run is called to run the connectivity test
 	Run(ctx context.Context, c TestContext)
 }
@@ -1761,11 +1764,9 @@ func (k *K8sConnectivityCheck) Run(ctx context.Context, tests ...ConnectivityTes
 	}
 
 	for _, test := range tests {
-		if !k.params.testEnabled(test.Name()) {
-			continue
+		if test.PolicyOnly() || k.params.testEnabled(test.Name()) {
+			test.Run(ctx, k)
 		}
-
-		test.Run(ctx, k)
 	}
 
 	k.Header("📋 Test Report")

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -1271,6 +1271,10 @@ func (k *K8sConnectivityCheck) initClients(ctx context.Context) (*deploymentClie
 		k.flowAggregation = true
 	}
 
+	if k.params.MultiCluster != "" && k.params.SingleNode {
+		return nil, fmt.Errorf("single-node test can not be enabled with multi-cluster test")
+	}
+
 	// In single-cluster environment, automatically detect a single-node
 	// environment so we can skip deploying tests which depend on multiple
 	// nodes.
@@ -1309,7 +1313,7 @@ func (k *K8sConnectivityCheck) initClients(ctx context.Context) (*deploymentClie
 			k.Log("ℹ️  Single node environment detected, enabling single node connectivity test")
 			k.params.SingleNode = true
 		}
-	} else {
+	} else if k.params.MultiCluster != "" {
 		dst, err := k8s.NewClient(k.params.MultiCluster, "")
 		if err != nil {
 			return nil, fmt.Errorf("unable to create Kubernetes client for remote cluster %q: %w", k.params.MultiCluster, err)

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -116,12 +116,18 @@ type PolicyContext struct {
 	err        error
 	CNPs       []*ciliumv2.CiliumNetworkPolicy
 	expectFunc GetExpectations
+	policyOnly bool
 }
 
 // WithPolicyRunner sets the test runner to use and stores the policy for the tests
 func (pc *PolicyContext) WithPolicyRunner(runner ConnectivityTest, yaml string) ConnectivityTest {
 	pc.runner = runner
 	return pc.WithPolicy(yaml)
+}
+
+// PolicyOnly returns true if there is no traffic scenario with this PolicyContext
+func (pc *PolicyContext) PolicyOnly() bool {
+	return pc.policyOnly
 }
 
 // Name returns the absolute name of the policy
@@ -176,6 +182,8 @@ func (pc *PolicyContext) Run(ctx context.Context, c TestContext) {
 
 // WithPolicy sets the policy to use during tests
 func (pc *PolicyContext) WithPolicy(yaml string) ConnectivityTest {
+	// Set policyOnly flag if runner is not set
+	pc.policyOnly = pc.runner == nil
 	pc.ParsePolicy(yaml)
 	return pc
 }

--- a/connectivity/manifests/echo-ingress-from-other-client.yaml
+++ b/connectivity/manifests/echo-ingress-from-other-client.yaml
@@ -1,0 +1,14 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: echo-ingress-from-other-client
+spec:
+  description: "Allow other client to contact echo"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        k8s:other: client

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -78,6 +78,11 @@ type Parameters struct {
 	UI               bool
 	UIPortForward    int
 	Writer           io.Writer
+	Context          string // Only for 'kubectl' pass-through commands
+}
+
+func (p *Parameters) Log(format string, a ...interface{}) {
+	fmt.Fprintf(p.Writer, format+"\n", a...)
 }
 
 func NewK8sHubble(client k8sHubbleImplementation, p Parameters) *K8sHubble {

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -412,19 +412,23 @@ func (k *K8sHubble) createRelayClientCertificate(ctx context.Context) error {
 	return nil
 }
 
-func (k *K8sHubble) PortForwardCommand(ctx context.Context) error {
+func (p *Parameters) PortForwardCommand(ctx context.Context) error {
 	cmd := "kubectl"
 	args := []string{
 		"port-forward",
-		"-n", k.params.Namespace,
+		"-n", p.Namespace,
 		"svc/hubble-relay",
 		"--address", "0.0.0.0",
 		"--address", "::",
-		fmt.Sprintf("%d:%d", k.params.PortForward, defaults.RelayServicePlaintextPort)}
+		fmt.Sprintf("%d:%d", p.PortForward, defaults.RelayServicePlaintextPort)}
+
+	if p.Context != "" {
+		args = append([]string{"--context", p.Context}, args...)
+	}
 
 	c := exec.Command(cmd, args...)
-	c.Stdout = k.params.Writer
-	c.Stderr = k.params.Writer
+	c.Stdout = p.Writer
+	c.Stderr = p.Writer
 
 	if err := c.Run(); err != nil {
 		return fmt.Errorf("unable to execute command %s %v: %s", cmd, args, err)

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -299,30 +299,34 @@ func (k *K8sHubble) enableUI(ctx context.Context) error {
 	return nil
 }
 
-func (k *K8sHubble) UIPortForwardCommand(ctx context.Context) error {
+func (p *Parameters) UIPortForwardCommand(ctx context.Context) error {
 	cmd := "kubectl"
 	args := []string{
 		"port-forward",
-		"-n", k.params.Namespace,
+		"-n", p.Namespace,
 		"svc/hubble-ui",
 		"--address", "0.0.0.0",
 		"--address", "::",
-		fmt.Sprintf("%d:80", k.params.UIPortForward)}
+		fmt.Sprintf("%d:80", p.UIPortForward)}
+
+	if p.Context != "" {
+		args = append([]string{"--context", p.Context}, args...)
+	}
 
 	c := exec.Command(cmd, args...)
-	c.Stdout = k.params.Writer
-	c.Stderr = k.params.Writer
+	c.Stdout = p.Writer
+	c.Stderr = p.Writer
 
 	go func() {
 		time.Sleep(5 * time.Second)
-		url := fmt.Sprintf("http://localhost:%d", k.params.UIPortForward)
+		url := fmt.Sprintf("http://localhost:%d", p.UIPortForward)
 
 		c := exec.Command("open", url)
-		c.Stdout = k.params.Writer
-		c.Stderr = k.params.Writer
+		c.Stdout = p.Writer
+		c.Stderr = p.Writer
 		if err := c.Run(); err != nil {
-			k.Log("⚠️  Unable to execute command %s %v: %s", cmd, args, err)
-			k.Log("ℹ️  Opening the following URL in your browser:" + url)
+			p.Log("⚠️  Unable to execute command %s %v: %s", cmd, args, err)
+			p.Log("ℹ️  Opening the following URL in your browser:" + url)
 		}
 	}()
 

--- a/install/certs.go
+++ b/install/certs.go
@@ -65,12 +65,18 @@ func (k *K8sInstaller) createHubbleServerCertificate(ctx context.Context) error 
 	return nil
 }
 
-func (k *K8sUninstaller) uninstallCerts(ctx context.Context) error {
-	if err := k.client.DeleteSecret(ctx, k.params.Namespace, defaults.HubbleServerSecretName, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("unable to delete secret %s/%s: %w", k.params.Namespace, defaults.HubbleServerSecretName, err)
+func (k *K8sUninstaller) uninstallCerts(ctx context.Context) (err error) {
+	if err = k.client.DeleteSecret(ctx, k.params.Namespace, defaults.HubbleServerSecretName, metav1.DeleteOptions{}); err != nil {
+		err = fmt.Errorf("unable to delete secret %s/%s: %w", k.params.Namespace, defaults.HubbleServerSecretName, err)
+	}
+	if err2 := k.client.DeleteSecret(ctx, k.params.Namespace, defaults.CASecretName, metav1.DeleteOptions{}); err2 != nil {
+		err2 = fmt.Errorf("unable to delete CA secret %s/%s: %w", k.params.Namespace, defaults.CASecretName, err2)
+		if err == nil {
+			err = err2
+		}
 	}
 
-	return nil
+	return err
 }
 
 func (k *K8sInstaller) installCerts(ctx context.Context) error {

--- a/install/install.go
+++ b/install/install.go
@@ -965,8 +965,15 @@ func (k *K8sInstaller) generateOperatorDeployment() *appsv1.Deployment {
 }
 
 type k8sInstallerImplementation interface {
+	ClusterName() string
+	ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error)
+	GetCiliumExternalWorkload(ctx context.Context, name string, opts metav1.GetOptions) (*ciliumv2.CiliumExternalWorkload, error)
+	CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2.CiliumExternalWorkload, opts metav1.CreateOptions) (*ciliumv2.CiliumExternalWorkload, error)
+	DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	ListCiliumExternalWorkloads(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error)
 	CreateServiceAccount(ctx context.Context, namespace string, account *corev1.ServiceAccount, opts metav1.CreateOptions) (*corev1.ServiceAccount, error)
 	DeleteServiceAccount(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
+	GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error)
 	CreateConfigMap(ctx context.Context, namespace string, config *corev1.ConfigMap, opts metav1.CreateOptions) (*corev1.ConfigMap, error)
 	DeleteConfigMap(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	CreateClusterRole(ctx context.Context, config *rbacv1.ClusterRole, opts metav1.CreateOptions) (*rbacv1.ClusterRole, error)
@@ -977,6 +984,7 @@ type k8sInstallerImplementation interface {
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	DeleteDaemonSet(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	PatchDaemonSet(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.DaemonSet, error)
+	GetService(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Service, error)
 	CreateService(ctx context.Context, namespace string, service *corev1.Service, opts metav1.CreateOptions) (*corev1.Service, error)
 	DeleteService(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	DeleteDeployment(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
@@ -993,6 +1001,7 @@ type k8sInstallerImplementation interface {
 	CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error)
 	DeleteSecret(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	GetSecret(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Secret, error)
+	PatchSecret(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Secret, error)
 	CreateResourceQuota(ctx context.Context, namespace string, r *corev1.ResourceQuota, opts metav1.CreateOptions) (*corev1.ResourceQuota, error)
 	DeleteResourceQuota(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	AutodetectFlavor(ctx context.Context) (k8s.Flavor, error)

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -80,6 +80,7 @@ func newCmdConnectivityCheck() *cobra.Command {
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
 	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show additional diagnostic messages")
+	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 
 	return cmd
 }

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -105,8 +105,7 @@ func newCmdPortForwardCommand() *cobra.Command {
 		Short: "Forward the relay port to the local machine",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			h := hubble.NewK8sHubble(k8sClient, params)
-			if err := h.PortForwardCommand(context.Background()); err != nil {
+			if err := params.PortForwardCommand(context.Background()); err != nil {
 				fatalf("Unable to port forward: %s", err)
 			}
 			return nil
@@ -114,7 +113,7 @@ func newCmdPortForwardCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
-	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+	cmd.Flags().StringVar(&params.Context, "context", "", "Kubernetes configuration context")
 	cmd.Flags().IntVar(&params.PortForward, "port-forward", 4245, "Local port to forward to")
 
 	return cmd
@@ -129,8 +128,7 @@ func newCmdUI() *cobra.Command {
 		Use:   "ui",
 		Short: "Open the Hubble UI",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			h := hubble.NewK8sHubble(k8sClient, params)
-			if err := h.UIPortForwardCommand(context.Background()); err != nil {
+			if err := params.UIPortForwardCommand(context.Background()); err != nil {
 				fatalf("Unable to port forward: %s", err)
 			}
 			return nil
@@ -138,7 +136,7 @@ func newCmdUI() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
-	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+	cmd.Flags().StringVar(&params.Context, "context", "", "Kubernetes configuration context")
 	cmd.Flags().IntVar(&params.UIPortForward, "port-forward", 12000, "Local port to use for the port forward")
 
 	return cmd

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/hubble"
 	"github.com/cilium/cilium-cli/install"
 
@@ -94,9 +95,7 @@ func newCmdUninstall() *cobra.Command {
 				Namespace: params.Namespace,
 				Writer:    params.Writer,
 			})
-			if err := h.Disable(context.Background()); err != nil {
-				fatalf("Unable to disable Hubble:  %s", err)
-			}
+			h.Disable(context.Background())
 			uninstaller := install.NewK8sUninstaller(k8sClient, params)
 			if err := uninstaller.Uninstall(context.Background()); err != nil {
 				fatalf("Unable to uninstall Cilium:  %s", err)
@@ -106,6 +105,7 @@ func newCmdUninstall() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace to uninstall Cilium from")
+	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to uninstall Cilium tests from")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait for uninstallation to have completed")
 


### PR DESCRIPTION
Add ingress policy testing that validates multi-cluster ingress policy enforcement when `cilium connectivity test` is run with `--multi-cluster` option.

Introductory commits add smaller fixes for:
- Avoid creating a 2nd k8s client when not needed
- Enable policy-only test regardless of the `--test` flag options
- Eliminate unnecessary bool member
- Track Cilium pods as PodContexts, apply policies in all clusters
  - adds support for ingress TCP flow validation,
   - lists Cilium pods only once,
  - applies policies in all clusters,
  - adds a new policy test case allowing ingress to echo only from one of the clients
    - In multi-cluster case `echo-other-node` is located in the destination cluster, so this tests multi-cluster policy enforcement
- Add --pause-on-fail (-p) flag to `cilium connectivity test`
- Make `cilium uninstall` idempotent and not fail if to-be-uninstalled resources are not found
  - Delete test namespace and uninstall clustermesh
- Pass k8s context to kubectl passthrough commands (`cilium hubble port-forward` and `cilium hubble ui`)

The last few commits then fixes the multicluster GH workflow:
- Copy `cilium install` options from working GKE workflows:
  - remove `--kube-proxy-replacement disabled`
  - add ` --restart-unmanaged-pods=false`
  - add `--native-routing-cidr=10.0.0.0/9` to cover all clusters and avoid masquerading between clusters
- Inherit Cilium CA from cluster1 to cluster2
- Only run `hubble-relay` in cluster1, as it connects to the Cilium nodes in both clusters
- Configure GKE clusters in VPC-native mode (`--enable-ip-alias`)
  - add GCP firewall rule to allow traffic from all clusters