### PR TITLE
tls: store the CA certificate under ca.crt in hubble-server-certs

### DIFF
--- a/install/certs.go
+++ b/install/certs.go
@@ -54,9 +54,9 @@ func (k *K8sInstaller) createHubbleServerCertificate(ctx context.Context) error 
 	}
 
 	data := map[string][]byte{
-		corev1.TLSCertKey:        cert,
-		corev1.TLSPrivateKeyKey:  key,
-		defaults.CASecretKeyName: k.certManager.CACertBytes(),
+		corev1.TLSCertKey:         cert,
+		corev1.TLSPrivateKeyKey:   key,
+		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.HubbleServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})


### PR DESCRIPTION
Missed by https://github.com/cilium/cilium-cli/pull/145, see https://github.com/cilium/cilium-cli/pull/145#issuecomment-830006217 for context.