### PR TITLE
install: aks: drop --name from service principal creation command

### DIFF
--- a/install/azure.go
+++ b/install/azure.go
@@ -58,7 +58,7 @@ type accountInfo struct {
 func (k *K8sInstaller) createAzureServicePrincipal(ctx context.Context) error {
 	if k.params.Azure.TenantID == "" {
 		k.Log("🚀 Creating service principal for Cilium operator...")
-		args := []string{"ad", "sp", "create-for-rbac", "--name", "cilium-operator"}
+		args := []string{"ad", "sp", "create-for-rbac"}
 		cmd := azCommand(args...)
 		bytes, err := cmd.Output()
 		if err != nil {


### PR DESCRIPTION
Remove the --name argument from the `az ad sp create-for-rbac` command
used to create a new service principal as:

* it's not required (if not set the CLI will generate a new one)
* specifying a --name increases the risk of the command to fail in case
  a sp with the same name already exists and the user doesn't have
  permissions to patch it.