### PR TITLE
Make cilium install idempotent

### DIFF
--- a/install/certs.go
+++ b/install/certs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -61,7 +62,9 @@ func (k *K8sInstaller) createHubbleServerCertificate(ctx context.Context) error 
 
 	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.HubbleServerSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.HubbleServerSecretName, err)
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.HubbleServerSecretName, err)
+		}
 	}
 
 	return nil

--- a/install/install.go
+++ b/install/install.go
@@ -33,6 +33,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1504,28 +1505,40 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 
 	k.Log("🚀 Creating Service accounts...")
 	if _, err := k.client.CreateServiceAccount(ctx, k.params.Namespace, k8s.NewServiceAccount(defaults.AgentServiceAccountName), metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	if _, err := k.client.CreateServiceAccount(ctx, k.params.Namespace, k8s.NewServiceAccount(defaults.OperatorServiceAccountName), metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	k.Log("🚀 Creating Cluster roles...")
 	if _, err := k.client.CreateClusterRole(ctx, ciliumClusterRole, metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	if _, err := k.client.CreateClusterRoleBinding(ctx, k8s.NewClusterRoleBinding(defaults.AgentClusterRoleName, k.params.Namespace, defaults.AgentServiceAccountName), metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	if _, err := k.client.CreateClusterRole(ctx, operatorClusterRole, metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	if _, err := k.client.CreateClusterRoleBinding(ctx, k8s.NewClusterRoleBinding(defaults.OperatorClusterRoleName, k.params.Namespace, defaults.OperatorServiceAccountName), metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	if k.params.Encryption == encryptionIPsec {
@@ -1541,7 +1554,9 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 	}
 
 	if _, err := k.client.CreateConfigMap(ctx, k.params.Namespace, configMap, metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	switch k.flavor.Kind {
@@ -1554,12 +1569,16 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 
 	k.Log("🚀 Creating Agent DaemonSet...")
 	if _, err := k.client.CreateDaemonSet(ctx, k.params.Namespace, k.generateAgentDaemonSet(), metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	k.Log("🚀 Creating Operator Deployment...")
 	if _, err := k.client.CreateDeployment(ctx, k.params.Namespace, k.generateOperatorDeployment(), metav1.CreateOptions{}); err != nil {
-		return err
+		if ok := errors.IsAlreadyExists(err); !ok {
+			return err
+		}
 	}
 
 	if k.params.Wait {


### PR DESCRIPTION
[No tests yet, waiting for discussion with Authors]

This PR makes the command cilium install idempotent.
It checks the error returned from the API and continues
in case the resource has been created already.

Fixes: #205

Signed-off-by: Lorenzo Fundaró <lorenzofundaro@gmail.com>