### PR TITLE
handle default image and versions at the flag level

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/k8s"
 )
 
@@ -98,10 +97,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		}
 	}
 
-	if k.params.Version == "" {
-		k.Log("ℹ️  Cilium version not set, using default version %q", defaults.Version)
-		k.params.Version = defaults.Version
-	}
+	k.Log("ℹ️  using Cilium version %q", k.params.Version)
 
 	if k.params.ClusterName == "" {
 		if f.ClusterName != "" {

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -74,8 +74,8 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.Encryption, "encryption", "disabled", "Enable encryption of all workloads traffic { disabled | ipsec | wireguard }")
 	cmd.Flags().BoolVar(&params.NodeEncryption, "node-encryption", false, "Enable encryption of all node to node traffic")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Set ConfigMap entries (key=value)")
-	cmd.Flags().StringVar(&params.AgentImage, "agent-image", "", "Image path to use for Cilium agent")
-	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", "", "Image path to use for Cilium operator")
+	cmd.Flags().StringVar(&params.AgentImage, "agent-image", defaults.AgentImage, "Image path to use for Cilium agent")
+	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", defaults.OperatorImage, "Image path to use for Cilium operator")
 	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
 		"Timeout for Cilium to become ready before restarting unmanaged pods")
 
@@ -150,8 +150,8 @@ cilium upgrade --version v1.9.8
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait for status")
-	cmd.Flags().StringVar(&params.AgentImage, "agent-image", "", "Image path to use for Cilium agent")
-	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", "", "Image path to use for Cilium operator")
+	cmd.Flags().StringVar(&params.AgentImage, "agent-image", defaults.AgentImage, "Image path to use for Cilium agent")
+	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", defaults.OperatorImage, "Image path to use for Cilium operator")
 
 	return cmd
 }

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -60,7 +60,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace to install Cilium into")
 	cmd.Flags().StringVar(&params.ClusterName, "cluster-name", "", "Name of the cluster")
 	cmd.Flags().StringSliceVar(&params.DisableChecks, "disable-check", []string{}, "Disable a particular validation check")
-	cmd.Flags().StringVar(&params.Version, "version", "", "Cilium version to install")
+	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use")
 	cmd.Flags().StringVar(&params.IPAM, "ipam", "", "IP Address Management (IPAM) mode")
 	cmd.Flags().StringVar(&params.NativeRoutingCIDR, "native-routing-cidr", "", "CIDR within which native routing is possible")
@@ -146,7 +146,7 @@ cilium upgrade --version v1.9.8
 	}
 
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace to install Cilium into")
-	cmd.Flags().StringVar(&params.Version, "version", "", "Cilium version to install")
+	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait for status")


### PR DESCRIPTION
I got bitten trying `cilium install --version 1.10.0-rc1` (notice the missing `v` prefix). `cilium install --help` wasn't helpful about the expected "format" of the `--version` flag.

I've considered checking and adding the `v` prefix to `version` in `utils.BuildImagePath` when it was missing, but ultimately elected against it in order to support using non-version tags (e.g. `stable`). Maybe we could try to do something smart like checking against `^\d+\.\d+\.d+` and adding the `v` prefix if it matches, happy to hear thoughts about this.