### PR TITLE
install: don't delete the 'aws-node' DaemonSet

### DIFF
--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -106,6 +106,10 @@ jobs:
       - name: Wait for test job
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
+      
+      - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
+        run: |
+          [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 
       - name: Post-test information gathering
         if: ${{ failure() }}

--- a/install/aws.go
+++ b/install/aws.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+const (
+	AwsNodeDaemonSetName              = "aws-node"
+	AwsNodeDaemonSetNamespace         = "kube-system"
+	AwsNodeDaemonSetNodeSelectorKey   = "io.cilium/aws-node-enabled"
+	AwsNodeDaemonSetNodeSelectorValue = "true"
+)

--- a/install/install.go
+++ b/install/install.go
@@ -1506,9 +1506,11 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 
 	switch k.flavor.Kind {
 	case k8s.KindEKS:
-		if _, err := k.client.GetDaemonSet(ctx, "kube-system", "aws-node", metav1.GetOptions{}); err == nil {
-			k.Log("🔥 Deleting aws-node DaemonSet...")
-			if err := k.client.DeleteDaemonSet(ctx, "kube-system", "aws-node", metav1.DeleteOptions{}); err != nil {
+		if _, err := k.client.GetDaemonSet(ctx, AwsNodeDaemonSetNamespace, AwsNodeDaemonSetName, metav1.GetOptions{}); err == nil {
+			k.Log("🔥 Patching the %q DaemonSet to evict its pods...", AwsNodeDaemonSetName)
+			patch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"nodeSelector":{"%s":"%s"}}}}}`, AwsNodeDaemonSetNodeSelectorKey, AwsNodeDaemonSetNodeSelectorValue))
+			if _, err := k.client.PatchDaemonSet(ctx, AwsNodeDaemonSetNamespace, AwsNodeDaemonSetName, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+				k.Log("❌ Unable to patch the %q DaemonSet", AwsNodeDaemonSetName)
 				return err
 			}
 		}


### PR DESCRIPTION
Instead of deleting the `aws-node` DaemonSet, which is permanent, we can be gentler and just evict its pods by setting a node selector that won't ever be matched (unless someone wants it to by explicitly setting the required label on a node).

This allows `cilium uninstall` to gracefully revert the `aws-node` `DaemonSet` to its previous state, as it might contain customizations that would otherwise be lost.