### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    labels:
+    - enhancement
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    labels:
+    - enhancement


### PR DESCRIPTION
This adds [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/), a tool to help keep dependencies up to date. The configuration will ensure Go packages and Github Action plugins are kept up to date.
