### PR TITLE
Log output and print command as string on error when invoking external commands

### DIFF
--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -17,7 +17,6 @@ package hubble
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/cilium/cilium-cli/defaults"
@@ -397,7 +396,6 @@ func (k *K8sHubble) createRelayClientCertificate(ctx context.Context) error {
 }
 
 func (p *Parameters) PortForwardCommand(ctx context.Context) error {
-	cmd := "kubectl"
 	args := []string{
 		"port-forward",
 		"-n", p.Namespace,
@@ -410,13 +408,6 @@ func (p *Parameters) PortForwardCommand(ctx context.Context) error {
 		args = append([]string{"--context", p.Context}, args...)
 	}
 
-	c := exec.Command(cmd, args...)
-	c.Stdout = p.Writer
-	c.Stderr = p.Writer
-
-	if err := c.Run(); err != nil {
-		return fmt.Errorf("unable to execute command %s %v: %s", cmd, args, err)
-	}
-
-	return nil
+	_, err := utils.Exec(p, "kubectl", args...)
+	return err
 }

--- a/install/gke.go
+++ b/install/gke.go
@@ -17,7 +17,6 @@ package install
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/cilium/cilium-cli/defaults"
@@ -42,11 +41,9 @@ func (k *K8sInstaller) gkeNativeRoutingCIDR(ctx context.Context, contextName str
 		return "", fmt.Errorf("unable to derive region and zone from context name %q: not in the form gke_PROJECT_ZONE_NAME", contextName)
 	}
 
-	args := []string{"container", "clusters", "describe", parts[3], "--zone", parts[2], "--format", "value(clusterIpv4Cidr)"}
-	result := exec.Command("gcloud", args...)
-	bytes, err := result.Output()
+	bytes, err := k.Exec("gcloud", "container", "clusters", "describe", parts[3], "--zone", parts[2], "--format", "value(clusterIpv4Cidr)")
 	if err != nil {
-		return "", fmt.Errorf("unable to execute gcloud %s to extract native routing CIDR: %w", args, err)
+		return "", err
 	}
 
 	cidr := strings.TrimSuffix(string(bytes), "\n")

--- a/install/install.go
+++ b/install/install.go
@@ -1143,6 +1143,10 @@ func (k *K8sInstaller) Log(format string, a ...interface{}) {
 	fmt.Fprintf(k.params.Writer, format+"\n", a...)
 }
 
+func (k *K8sInstaller) Exec(command string, args ...string) ([]byte, error) {
+	return utils.Exec(k, command, args...)
+}
+
 func (k *K8sInstaller) generateConfigMap() (*corev1.ConfigMap, error) {
 	m := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/install/kind.go
+++ b/install/kind.go
@@ -17,7 +17,6 @@ package install
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"regexp"
 
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -34,10 +33,9 @@ func (m *kindVersionValidation) Name() string {
 }
 
 func (m *kindVersionValidation) Check(ctx context.Context, k *K8sInstaller) error {
-	cmd := exec.Command("kind", "version")
-	bytes, err := cmd.Output()
+	bytes, err := k.Exec("kind", "version")
 	if err != nil {
-		return fmt.Errorf("unable to execute \"kind version\": %w", err)
+		return err
 	}
 
 	ver := regexp.MustCompile(`(v[0-9]+\.[0-9]+\.[0-9]+)`)

--- a/install/minikube.go
+++ b/install/minikube.go
@@ -17,7 +17,6 @@ package install
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"regexp"
 
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -34,10 +33,9 @@ func (m *minikubeVersionValidation) Name() string {
 }
 
 func (m *minikubeVersionValidation) Check(ctx context.Context, k *K8sInstaller) error {
-	cmd := exec.Command("minikube", "version")
-	bytes, err := cmd.Output()
+	bytes, err := k.Exec("minkube", "version")
 	if err != nil {
-		return fmt.Errorf("unable to execute \"minikube version\": %w", err)
+		return err
 	}
 
 	ver := regexp.MustCompile(`(v[0-9]+\.[0-9]+\.[0-9]+)`)

--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Logger interface {
+	Log(format string, args ...interface{})
+}
+
+func Exec(l Logger, command string, args ...string) ([]byte, error) {
+	c := exec.Command(command, args...)
+	bytes, err := c.CombinedOutput()
+	if err != nil {
+		cmdStr := fmt.Sprintf("%s %s", command, strings.Join(args, " "))
+		l.Log("❌ Unable to execute %q:", cmdStr)
+		if len(bytes) > 0 {
+			l.Log(" %s", string(bytes))
+		}
+		return []byte{}, fmt.Errorf("unable to execute %q: %w", cmdStr, err)
+	}
+
+	return bytes, err
+}

--- a/internal/utils/exec_test.go
+++ b/internal/utils/exec_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type UtilsSuite struct{}
+
+var _ = check.Suite(&UtilsSuite{})
+
+type failIfCalled struct {
+	c *check.C
+}
+
+func (f *failIfCalled) Log(fmt string, args ...interface{}) {
+	f.c.Error("log method should not be called")
+}
+
+type countIfCalled struct {
+	count int
+}
+
+func (c *countIfCalled) Log(fmt string, args ...interface{}) {
+	c.count++
+}
+
+func (b *UtilsSuite) TestExec(c *check.C) {
+	_, err := Exec(&failIfCalled{c}, "true")
+	c.Assert(err, check.IsNil)
+
+	cl := &countIfCalled{0}
+	_, err = Exec(cl, "false")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(cl.count, check.Equals, 1)
+
+	cl.count = 0
+	_, err = Exec(cl, "sh", "-c", "'echo foo; exit 1'")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(cl.count, check.Equals, 2)
+}


### PR DESCRIPTION
When a command fails to execute, its args are shown in the slice syntax
which makes it cumbersome to copy&paste said command for further
analysis, e.g.
    
        Error: Unable to install Cilium:  unable to execute "az [aks show --resource-group foo-test-12960 --name foo-test-12960]": exit status 3
    
Change the command args to be printed as a space separated string, so
they can be easily copy&pasted from the error message:
    
        Error: Unable to install Cilium: unable to execute "az aks show --resource-group foo-test-12960 --name foo-test-12960": exit status 3

Also consistently log the stdout/stderr of the invoked command on error.