### PR TITLE
install: allow to set Azure subscription ID

### DIFF
--- a/install/azure.go
+++ b/install/azure.go
@@ -92,9 +92,12 @@ func (k *K8sInstaller) createAzureServicePrincipal(ctx context.Context) error {
 	}
 
 	k.Log("✅ Derived Azure subscription id %s", ai.ID)
-	k.params.Azure.SubscriptionID = ai.ID
+	k.params.Azure.DerivedSubscriptionID = ai.ID
 
 	args = []string{"aks", "show", "--resource-group", k.params.Azure.ResourceGroupName, "--name", k.params.ClusterName}
+	if k.params.Azure.SubscriptionID != "" {
+		args = append(args, "--subscription", k.params.Azure.SubscriptionID)
+	}
 	cmd = azCommand(args...)
 	bytes, err = cmd.Output()
 	if err != nil {

--- a/install/install.go
+++ b/install/install.go
@@ -908,7 +908,7 @@ func (k *K8sInstaller) generateOperatorDeployment() *appsv1.Deployment {
 		c := &deployment.Spec.Template.Spec.Containers[0]
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "AZURE_SUBSCRIPTION_ID",
-			Value: k.params.Azure.SubscriptionID,
+			Value: k.params.Azure.DerivedSubscriptionID,
 		})
 
 		c.Env = append(c.Env, corev1.EnvVar{
@@ -1018,12 +1018,13 @@ const (
 )
 
 type AzureParameters struct {
-	ResourceGroupName string
-	SubscriptionID    string
-	TenantID          string
-	ResourceGroup     string
-	ClientID          string
-	ClientSecret      string
+	ResourceGroupName     string
+	SubscriptionID        string
+	DerivedSubscriptionID string
+	TenantID              string
+	ResourceGroup         string
+	ClientID              string
+	ClientSecret          string
 }
 
 type InstallParameters struct {

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -78,6 +78,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.Azure.ResourceGroupName, "azure-resource-group", "", "Azure resource group name the cluster is in")
 	cmd.Flags().StringVar(&params.Azure.TenantID, "azure-tenant-id", "", "Azure tenant ID")
 	cmd.Flags().StringVar(&params.Azure.ClientID, "azure-client-id", "", "Azure client (application) ID")
+	cmd.Flags().StringVar(&params.Azure.SubscriptionID, "azure-subscription-id", "", "Azure subscription ID")
 	cmd.Flags().StringVar(&params.Azure.ClientSecret, "azure-client-secret", "", "Azure client secret")
 
 	return cmd


### PR DESCRIPTION
In some cases, e.g. when working with the `cilium-dev` subscription,
leading, Cilium installation fails with the derived subscription ID:
    
```
$ cilium install --version 1.9.5 --azure-resource-group "${NAME}" --azure-tenant-id $(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant') --azure-client-id "${APP_ID}" --azure-client-secret $(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')
🔮 Auto-detected Kubernetes kind: AKS
✨ Running "AKS" validation checks
✅ Detected az binary
🔮 Auto-detected cluster name: tklauser-test-12960
🔮 Auto-detected IPAM mode: azure
🔮 Auto-detected datapath mode: azure
✅ Using manually configured principal for cilium operator with App ID <redacted> and tenant ID <redacted>
✅ Derived Azure subscription id <redacted>
Error: Unable to install Cilium: unable to execute "az aks show --resource-group foo-test-12960 --name dwifootklauser-test-12960": exit status 3   
```
    
Fix this by allowing to override the subscription ID using the
`--azure-subscription-id` command line flag and pass its value to the
`az aks show` command. Keep using the derived subscription ID for
`AZURE_SUBSCRIPTION_ID` though.