### PR TITLE
.github: Cancel outdated PR and push workflows

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,5 +1,6 @@
 name: AKS
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
@@ -7,6 +8,10 @@ on:
       - master
   schedule:
     - cron:  '0 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 env:
   clusterName: cilium-cli-ci-${{ github.run_number }}

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -1,5 +1,6 @@
 name: EKS (tunnel)
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
@@ -7,6 +8,10 @@ on:
       - master
   schedule:
     - cron:  '50 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 env:
   clusterName: cilium-cli-ci-eks-tunnel-${{ github.run_number }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,5 +1,6 @@
 name: EKS (ENI)
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
@@ -7,6 +8,10 @@ on:
       - master
   schedule:
     - cron:  '10 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 env:
   clusterName: cilium-cli-ci-eks-eni-${{ github.run_number }}

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -1,5 +1,6 @@
 name: External Workloads
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
@@ -7,6 +8,10 @@ on:
       - master
   schedule:
     - cron:  '55 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 env:
   zone: us-west2-a

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,5 +1,6 @@
 name: GKE
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request_target: {}
   push:
@@ -7,6 +8,10 @@ on:
       - master
   schedule:
     - cron:  '20 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 env:
   clusterName: cilium-cli-ci-${{ github.run_number }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,10 +1,15 @@
 name: Go
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,5 +1,6 @@
 name: Image CI Build
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request_target:
     types:
@@ -9,6 +10,10 @@ on:
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 jobs:
   build-and-push-prs:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -1,5 +1,6 @@
 name: Kind
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
@@ -7,6 +8,10 @@ on:
       - master
   schedule:
     - cron:  '30 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 env:
   KIND_VERSION: v0.9.0

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -1,5 +1,6 @@
 name: Multicluster
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
@@ -7,6 +8,10 @@ on:
       - master
   schedule:
     - cron:  '40 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  cancel-in-progress: true
 
 env:
   clusterName1: cilium-cli-ci-multicluster-1-${{ github.run_number }}


### PR DESCRIPTION
When updating a pull request, workflows associated with the previous version continue to run. A way to prevent that and cancel outdated workflows is to use concurrency groups.

This commit handles workflows triggered by pull requests and pushes. We define each concurrency group such that they are unique to the pull request (via PR number) if triggered by event pull_request or to the commit (via SHA) if triggered by event push.

Related: https://github.com/cilium/cilium/pull/16199.