### PR TITLE
feat: print out user datapath model

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -157,6 +157,10 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		}
 	}
 
+	if k.params.DatapathMode != "" {
+		k.Log("🔮 Custom datapath mode: %s", k.params.DatapathMode)
+	}
+
 	if strings.Contains(k.params.ClusterName, ".") {
 		k.Log("❌ Cluster name %q cannot contain dots", k.params.ClusterName)
 		return fmt.Errorf("invalid cluster name, dots are not allowed")


### PR DESCRIPTION
Fix: https://github.com/cilium/cilium-cli/issues/179

Datapath model only printed if auto-detected: https://github.com/cilium/cilium-cli/blob/c098e6d3878b6e29646ffb019cc45dec509a109b/install/autodetect.go#L156