### PR TITLE
sysdump: support collecting eks-specific data

### DIFF
--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -19,14 +19,18 @@ import (
 	"context"
 	"time"
 
+	"github.com/cilium/cilium-cli/internal/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type KubernetesClient interface {
+	AutodetectFlavor(ctx context.Context) (f k8s.Flavor, err error)
 	ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error)
 	ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error)
 	GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error)
@@ -36,15 +40,16 @@ type KubernetesClient interface {
 	GetPodsTable(ctx context.Context) (*metav1.Table, error)
 	GetSecret(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Secret, error)
 	GetVersion(ctx context.Context) (string, error)
-	ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error)
-	ListServices(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.ServiceList, error)
 	ListCiliumClusterwideNetworkPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumClusterwideNetworkPolicyList, error)
 	ListCiliumIdentities(ctx context.Context) (*ciliumv2.CiliumIdentityList, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 	ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error)
 	ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeList, error)
-	ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error)
-	ListNamespaces(ctx context.Context, o metav1.ListOptions) (*corev1.NamespaceList, error)
-	ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error)
 	ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error)
+	ListNamespaces(ctx context.Context, o metav1.ListOptions) (*corev1.NamespaceList, error)
+	ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error)
+	ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error)
+	ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error)
+	ListServices(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.ServiceList, error)
+	ListUnstructured(ctx context.Context, gvr schema.GroupVersionResource, namespace *string, o metav1.ListOptions) (*unstructured.UnstructuredList, error)
 }

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -16,9 +16,13 @@ package sysdump
 
 import (
 	"regexp"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
+	awsNodeDaemonSetName         = "aws-node"
+	awsNodeDaemonSetNamespace    = "kube-system"
 	ciliumAgentContainerName     = "cilium-agent"
 	ciliumConfigConfigMapName    = "cilium-config"
 	ciliumDaemonSetName          = "cilium"
@@ -33,6 +37,7 @@ const (
 )
 
 const (
+	awsNodeDaemonSetFileName                 = "aws-node-daemonset-<ts>.yaml"
 	ciliumBugtoolFileName                    = "cilium-bugtool-%s-<ts>.tar"
 	ciliumClusterWideNetworkPoliciesFileName = "ciliumclusterwidenetworkpolicies-<ts>.yaml"
 	ciliumConfigMapFileName                  = "cilium-config-configmap-<ts>.yaml"
@@ -45,6 +50,7 @@ const (
 	ciliumNetworkPoliciesFileName            = "ciliumnetworkpolicies-<ts>.yaml"
 	ciliumNodesFileName                      = "ciliumnodes-<ts>.yaml"
 	ciliumOperatorDeploymentFileName         = "cilium-operator-deployment-<ts>.yaml"
+	eniconfigsFileName                       = "aws-eniconfigs-<ts>.yaml"
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
 	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"
 	hubbleRelayDeploymentFileName            = "hubble-relay-deployment-<ts>.yaml"
@@ -57,24 +63,35 @@ const (
 	kubernetesPodsSummaryFileName            = "k8s-pods-<ts>.txt"
 	kubernetesServicesFileName               = "k8s-services-<ts>.yaml"
 	kubernetesVersionInfoFileName            = "k8s-version-<ts>.txt"
+	securityGroupPoliciesFileName            = "aws-securitygrouppolicies-<ts>.yaml"
 	timestampPlaceholderFileName             = "<ts>"
 )
 
 const (
-	dirMode    = 0700
-	fileMode   = 0600
-	timeFormat = "20060102-150405"
+	ciliumBugtoolCommand = "cilium-bugtool"
+	dirMode              = 0700
+	fileMode             = 0600
+	gopsCommand          = "/bin/gops"
+	gopsPID              = "1"
+	rmCommand            = "rm"
+	timeFormat           = "20060102-150405"
 )
 
 var (
+	awsENIConfigsGVR = schema.GroupVersionResource{
+		Group:    "crd.k8s.amazonaws.com",
+		Resource: "eniconfigs",
+		Version:  "v1alpha1",
+	}
+	awsSecurityGroupPoliciesGVR = schema.GroupVersionResource{
+		Group:    "vpcresources.k8s.aws",
+		Resource: "securitygrouppolicies",
+		Version:  "v1beta1",
+	}
 	ciliumBugtoolFileNameRegex = regexp.MustCompile("ARCHIVE at (.*)\n")
-	ciliumBugtoolCommand       = "cilium-bugtool"
-	gopsCommand                = "/bin/gops"
-	gopsPID                    = "1"
 	gopsStats                  = []string{
 		"memstats",
 		"stack",
 		"stats",
 	}
-	rmCommand = "rm"
 )


### PR DESCRIPTION
Adds support for collecting EKS-specific data — namely the `kube-system/aws-node` `DaemonSet`, if present, and any `eniconfigs` and `securitygrouppolicies` that may be present as well. Useful when Cilium is running in chaining mode. Also includes some cleaning-up bits.