### PR TITLE
test: Add DNS continuity test for Cilium restarts

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -131,7 +131,7 @@ jobs:
         run: |
           kubectl logs -n kube-system job/cilium-cli
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
-          gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium"
+          gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -134,6 +134,7 @@ func (a *Action) Destination() TestPeer {
 // This method is to be called from a Scenario implementation.
 func (a *Action) Run(f func(*Action)) {
 	a.Logf("[.] Action [%s]", a)
+	a.Progress()
 
 	// Execute the given test function.
 	// Might call Fatal().

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -152,7 +152,7 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 	}
 	pod := a.src
 
-	a.Debug("Executing command", cmd)
+	a.Debugf("%s: Executing command %s", a.started.UTC(), cmd)
 
 	// Warning: ExecInPod* does not use ctx, command cannot be cancelled.
 	stdout, stderr, err := pod.K8sClient.ExecInPodWithStderr(context.TODO(),

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -316,8 +316,8 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 		dstIP = ""
 	}
 
-	ipResponse := filters.IP(dstIP, srcIP)
 	ipRequest := filters.IP(srcIP, dstIP)
+	ipResponse := filters.IP(dstIP, srcIP)
 
 	switch p.Protocol {
 	case ICMP:
@@ -402,16 +402,24 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 	reqs = append(reqs, egress)
 
 	if p.DNSRequired || a.expEgress.DNSProxy {
+		// Override to allow for any DNS server
+		ipRequest := filters.IP(srcIP, "")
+		ipResponse := filters.IP("", srcIP)
+
 		dnsRequest := filters.Or(filters.UDP(0, 53), filters.TCP(0, 53))
 		dnsResponse := filters.Or(filters.UDP(53, 0), filters.TCP(53, 0))
 
 		dns := filters.FlowSetRequirement{First: filters.FlowRequirement{Filter: filters.And(ipRequest, dnsRequest), Msg: "DNS request"}}
 		if a.expEgress.DNSProxy {
+			qname := a.dst.FQDN() + "."
 			dns.Middle = []filters.FlowRequirement{{Filter: filters.And(ipResponse, dnsResponse), Msg: "DNS response"}}
-			dns.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(a.dst.Address()+".", 0)), Msg: "DNS proxy"}
+			dns.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(qname, 0)), Msg: "DNS proxy"}
+			// 5 is the default rcode returned on error such as policy deny
+			dns.Except = []filters.FlowRequirement{{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(qname, 5)), Msg: "DNS proxy DROP"}}
 		} else {
 			dns.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, dnsResponse), Msg: "DNS response"}
 		}
+
 		reqs = append(reqs, dns)
 	}
 

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -525,13 +525,17 @@ retry:
 		goto retry
 	}
 	res := FlowRequirementResults{FirstMatch: -1, LastMatch: -1}
+	resFail := FlowRequirementResults{FirstMatch: -1, LastMatch: -1}
 	for i, req := range reqs {
 		offset := 0
 		var r FlowRequirementResults
 		for offset < len(flows) {
 			r = a.matchFlowRequirements(ctx, flows, offset, pod, &req)
-			// Check if fully matched or no match for the first flow
-			if !r.NeedMoreFlows || r.FirstMatch == -1 {
+			if r.Failures > 0 {
+				resFail.Merge(&r)
+			}
+			// Check if successfully fully matched or no match for the first flow
+			if (!r.NeedMoreFlows && r.Failures == 0) || r.FirstMatch == -1 {
 				break
 			}
 			// Try if some other flow instance would find both first and last required flows
@@ -545,7 +549,13 @@ retry:
 			}
 		}
 		// Merge results
-		res.Merge(&r)
+		if r.Failures > 0 {
+			// on Failure merge all tries to see what flows matched
+			res.Merge(&resFail)
+		} else {
+			// on Success only merge the successfully matched filters
+			res.Merge(&r)
+		}
 		a.Debugf("Merged flow validation results #%d: %v", i, res)
 	}
 	a.flows[pod] = flows

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -459,7 +459,7 @@ func (a *Action) GetIngressRequirements(p FlowParameters) []filters.FlowSetRequi
 				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
 				Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
 				Except: []filters.FlowRequirement{
-					{Filter: filters.Drop(), Msg: "Drop"},
+					{Filter: filters.And(ipRequest, icmpRequest, filters.Drop()), Msg: "Drop"},
 				},
 			}
 		}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -107,6 +107,9 @@ func (r *FlowRequirementResults) Merge(from *FlowRequirementResults) {
 	if r.FirstMatch < 0 || from.FirstMatch >= 0 && from.FirstMatch < r.FirstMatch {
 		r.FirstMatch = from.FirstMatch
 	}
+	if from.FirstMatch > r.LastMatch {
+		r.LastMatch = from.FirstMatch
+	}
 	if from.LastMatch > r.LastMatch {
 		r.LastMatch = from.LastMatch
 	}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -45,6 +45,7 @@ type Parameters struct {
 	Verbose               bool
 	Debug                 bool
 	PauseOnFail           bool
+	RunQuarantined        bool
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -472,7 +472,47 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
+	// Set the timeout for all DNS lookup retries
+	dnsCtx, cancel := context.WithTimeout(ctx, ct.params.ipCacheTimeout())
+	defer cancel()
+	for _, cp := range ct.clientPods {
+		err := ct.waitForDNS(dnsCtx, cp)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// Validate that kube-dns responds and knows about cluster services
+func (ct *ConnectivityTest) waitForDNS(ctx context.Context, pod Pod) error {
+	ct.Logf("⌛ [%s] Waiting for pod %s to reach kube-dns service...", ct.client.ClusterName(), pod.Name())
+
+	for {
+		// Don't retry lookups more often than once per second.
+		r := time.After(time.Second)
+
+		target := fmt.Sprintf("kube-dns.%s.svc.cluster.local", ct.params.CiliumNamespace)
+		// Warning: ExecInPod ignores ctx. Don't pass it here so we don't
+		// falsely expect the function to be able to be cancelled.
+		stdout, _, err := pod.K8sClient.ExecInPodWithStderr(context.TODO(), pod.Pod.Namespace, pod.Pod.Name,
+			"", []string{"nslookup", target})
+		if err == nil {
+			return nil
+		}
+
+		ct.Debugf("Error looking up %s from pod %s: %s", target, pod.Name(), stdout.String())
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout reached waiting lookup for %s from pod %s to succeed", target, pod.Name())
+		default:
+		}
+
+		// Wait for the pace timer to avoid busy polling.
+		<-r
+	}
 }
 
 func (ct *ConnectivityTest) waitForIPCache(ctx context.Context, pod Pod) error {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -48,6 +48,7 @@ type deploymentParameters struct {
 	Affinity       *corev1.Affinity
 	ReadinessProbe *corev1.Probe
 	Labels         map[string]string
+	Annotations    map[string]string
 }
 
 func newDeployment(p deploymentParameters) *appsv1.Deployment {
@@ -103,6 +104,12 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 
 	for k, v := range p.Labels {
 		dep.Spec.Template.ObjectMeta.Labels[k] = v
+	}
+	if len(p.Annotations) > 0 {
+		dep.Spec.Template.ObjectMeta.Annotations = make(map[string]string, len(p.Annotations))
+		for k, v := range p.Annotations {
+			dep.Spec.Template.ObjectMeta.Annotations[k] = v
+		}
 	}
 
 	return dep
@@ -310,6 +317,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					},
 				},
 				ReadinessProbe: newLocalReadinessProbe(8080, "/"),
+				Annotations:    map[string]string{"io.cilium.proxy-visibility": "<Ingress/8080/TCP/HTTP>"},
 			})
 
 			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeployment, metav1.CreateOptions{})

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -247,11 +247,12 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:    ClientDeploymentName,
-			Kind:    kindClientName,
-			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
+			Name:        ClientDeploymentName,
+			Kind:        kindClientName,
+			Port:        8080,
+			Image:       defaults.ConnectivityCheckAlpineCurlImage,
+			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
+			Annotations: map[string]string{"io.cilium.proxy-visibility": "<Egress/53/ANY/DNS>"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
@@ -264,12 +265,13 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client2 deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:    Client2DeploymentName,
-			Kind:    kindClientName,
-			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
-			Labels:  map[string]string{"other": "client"},
+			Name:        Client2DeploymentName,
+			Kind:        kindClientName,
+			Port:        8080,
+			Image:       defaults.ConnectivityCheckAlpineCurlImage,
+			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
+			Labels:      map[string]string{"other": "client"},
+			Annotations: map[string]string{"io.cilium.proxy-visibility": "<Egress/53/ANY/DNS>"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -128,6 +128,14 @@ func (ct *ConnectivityTest) Fatalf(format string, a ...interface{}) {
 // should always call the methods implemented on Test.
 //
 
+// Progress adds a progress indicator if logging is buffered
+func (t *Test) Progress() {
+	// Print progress if logging is buffered
+	if t.logBuf != nil {
+		t.ctx.params.Writer.Write([]byte{'.'})
+	}
+}
+
 // log takes out a read lock and logs a message to the Test's internal buffer.
 // If the internal log buffer is nil, write to user-specified writer instead.
 // Prefix is an optional prefix to the message.
@@ -175,6 +183,9 @@ func (t *Test) flush() {
 	if t.logBuf == nil {
 		return
 	}
+
+	// Terminate progress so far
+	t.ctx.params.Writer.Write([]byte{'\n'})
 
 	// Flush internal buffer to user-specified writer.
 	if _, err := io.Copy(t.ctx.params.Writer, t.logBuf); err != nil {
@@ -293,6 +304,11 @@ func (t *Test) Fatalf(format string, a ...interface{}) {
 //
 // Output methods on an Action scope.
 //
+
+// Progress adds a progress indicator if logging is buffered
+func (a *Action) Progress() {
+	a.test.Progress()
+}
 
 // Log logs a message.
 func (a *Action) Log(s ...interface{}) {

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -22,7 +22,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium-cli/defaults"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Test struct {
@@ -227,6 +229,17 @@ func (t *Test) WithScenarios(sl ...Scenario) *Test {
 	}
 
 	return t
+}
+
+// RestartCiliumPods restarts all Cilium pods in the cluster of the
+// given 'pod', which need not be a Cilium pod.
+func (t *Test) RestartCiliumPods(pod Pod) {
+	if err := pod.K8sClient.DeletePodCollection(context.Background(), t.ctx.params.CiliumNamespace,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.CiliumPodSelector}); err != nil {
+		t.Fatalf("Unable to restart Cilium pods: %v", err)
+	} else {
+		t.Info("Restarted Cilium pods")
+	}
 }
 
 // NewAction creates a new Action. s must be the Scenario the Action is created

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -37,6 +37,9 @@ type Test struct {
 	// True if the Test is marked as skipped.
 	skipped bool
 
+	// True if the Test is marked as quarantined.
+	quarantined bool
+
 	// True if the Test is marked as failed.
 	failed bool
 
@@ -67,6 +70,15 @@ type Test struct {
 
 	// List of functions to be called when Run() returns.
 	finalizers []func() error
+}
+
+func (t *Test) Quarantine() *Test {
+	t.quarantined = true
+	return t
+}
+
+func (t *Test) Quarantined() bool {
+	return t.quarantined
 }
 
 func (t *Test) String() string {
@@ -112,6 +124,11 @@ func (t *Test) skip(s Scenario) {
 // willRun returns false if all of the Test's Scenarios will be skipped.
 func (t *Test) willRun() bool {
 	var sc int
+
+	// Check if the test is quarantined
+	if !(t.Quarantined() == t.Context().params.RunQuarantined) {
+		return false
+	}
 
 	for s := range t.scenarios {
 		if !t.Context().params.testEnabled(t.scenarioName(s)) {

--- a/connectivity/manifests/client-dns-visibility.yaml
+++ b/connectivity/manifests/client-dns-visibility.yaml
@@ -1,0 +1,23 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-dns-visibility
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toEntities:
+    - all
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -46,9 +46,20 @@ var (
 
 	//go:embed manifests/client-egress-to-cidr-1111.yaml
 	clientEgressToCIDR1111PolicyYAML string
+
+	//go:embed manifests/client-dns-visibility.yaml
+	clientDNSVisibilityPolicyYAML string
 )
 
 func Run(ctx context.Context, ct *check.ConnectivityTest) error {
+	// Run all tests without any policies in place.
+	ct.NewTest("restart").WithPolicy(clientDNSVisibilityPolicyYAML).WithScenarios(
+		tests.RestartDNS(""),
+	).WithExpectations(
+		func(a *check.Action) (egress check.Result, ingress check.Result) {
+			return check.ResultDNSOK, check.ResultNone
+		}).Quarantine()
+
 	// Run all tests without any policies in place.
 	ct.NewTest("no-policies").WithScenarios(
 		tests.PodToPod(""),

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -21,18 +21,28 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 )
 
-func curl(peer check.TestPeer) []string {
-	return []string{"curl",
-		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}",
-		"--silent", "--fail", "--show-error",
-		"--connect-timeout", "5",
-		"--output", "/dev/null",
-		fmt.Sprintf("%s://%s",
-			peer.Scheme(),
-			net.JoinHostPort(peer.Address(), fmt.Sprint(peer.Port()))),
-	}
+var curlCmd = []string{"curl",
+	"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}",
+	"--silent", "--fail", "--show-error",
+	"--connect-timeout", "5",
+	"--output", "/dev/null"}
+
+func curl(peer check.TestPeer, args ...string) []string {
+	return append(append(curlCmd,
+		fmt.Sprintf("%s://%s", peer.Scheme(), net.JoinHostPort(peer.Address(), fmt.Sprint(peer.Port())))),
+		args...)
+}
+
+func curlName(peer check.TestPeer, args ...string) []string {
+	return append(append(curlCmd,
+		fmt.Sprintf("%s://%s", peer.Scheme(), net.JoinHostPort(peer.FQDN(), fmt.Sprint(peer.Port())))),
+		args...)
 }
 
 func ping(peer check.TestPeer) []string {
 	return []string{"ping", "-w", "3", "-c", "1", peer.Address()}
+}
+
+func pingName(peer check.TestPeer) []string {
+	return []string{"ping", "-w", "3", "-c", "1", peer.FQDN()}
 }

--- a/connectivity/tests/dns-restart.go
+++ b/connectivity/tests/dns-restart.go
@@ -1,0 +1,120 @@
+// Copyright 2020-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+)
+
+// RestartDNS sends multiple HTTP requests from a randomly selected client Pod
+// to all Services in the test context. Cilium agent restart on the client's node
+// is executed while the test is ongoing.
+func RestartDNS(name string) check.Scenario {
+	return &restartDNS{
+		name: name,
+	}
+}
+
+// restartDNS implements a Scenario.
+type restartDNS struct {
+	name string
+}
+
+func (s *restartDNS) Name() string {
+	tn := "restart-dns"
+	if s.name == "" {
+		return tn
+	}
+	return fmt.Sprintf("%s:%s", tn, s.name)
+}
+
+func (s *restartDNS) Run(ctx context.Context, t *check.Test) {
+	for _, src := range t.Context().ClientPods() {
+		for _, dst := range t.Context().ClientPods() {
+			if src.Pod.Status.PodIP == dst.Pod.Status.PodIP {
+				// Currently we only get flows once per IP,
+				// skip pings to self.
+				continue
+			}
+			ping := func(i int, maxFail int) (success bool) {
+				t.NewAction(s, fmt.Sprintf("ping-%d", i), &src, &dst).Run(func(a *check.Action) {
+					if i < maxFail {
+						a.AllowFail()
+					}
+					a.ExecInPod(ctx, pingName(dst))
+					success = a.Succeeded()
+					egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+						Protocol:    check.ICMP,
+						DNSRequired: true,
+					})
+					// Do not validate allowed failures
+					if !success && i < maxFail {
+						return
+					}
+					a.ValidateFlows(ctx, src.Name(), src.Address(), egressFlowRequirements)
+				})
+				return success
+			}
+
+			// Run 20 queries before restarting
+			for i := -20; i < 0; i++ {
+				ping(i, 0)
+				time.Sleep(125 * time.Millisecond)
+			}
+
+			// Restart Cilium PODs and keep pinging
+			t.RestartCiliumPods(src)
+
+			end := time.Now().Add(40 * time.Second)
+			maxFail := 10
+			dropped := false
+			failed := false
+			streak := 0
+			// Run loop until Cilium Agents are available again
+			for i := 0; i < 200; i++ {
+				success := ping(i, maxFail)
+				if success {
+					streak++
+					// Do not allow new failures after fails have turned to success
+					if dropped {
+						maxFail = 0
+						// Stop the test after one minute if ping has recovered and Cilium API is up
+						if time.Now().After(end) && streak > 10 && t.CiliumRunning() {
+							break
+						}
+					}
+					time.Sleep(250 * time.Millisecond)
+				} else {
+					dropped = true
+					streak = 0
+					if maxFail == 0 {
+						failed = true
+					}
+				}
+			}
+
+			if dropped && !failed {
+				t.ClearFail()
+			}
+
+			// Run only once
+			return
+		}
+	}
+}

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -49,7 +49,7 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 		for _, svc := range t.Context().EchoServices() {
 
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, curl(svc))
+				a.ExecInPod(ctx, curlName(svc))
 
 				egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -109,6 +109,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages and don't buffer any lines")
 	cmd.Flags().BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
+	cmd.Flags().BoolVar(&params.RunQuarantined, "run-quarantined", false, "Only run quarantined tests")
 
 	return cmd
 }


### PR DESCRIPTION
Add support for Cilium restart tests, where some test actions may be allowed to fail during restart when Cilium agent is rebooting. Use this framework for DNS continuity test. This test fails on all current Cilium releases and is hence quarantined. The test can be run with:

Best reviewed commit by commit. Some of the commits fix problems that may directly relate to this PR.

>  `cilium connectivity test --run-quarantined`
