### PR TITLE
connectivity: toCIDR(Set) Scenario and policy coverage

### DIFF
--- a/connectivity/manifests/client-egress-to-cidr-1111.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-1111.yaml
@@ -1,0 +1,16 @@
+# This policy allows packets towards 1.1.1.1, but not 1.0.0.1.
+# Both addresses are owned by CloudFlare/APNIC.
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-cidr
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toCIDRSet:
+    - cidr: 1.0.0.0/8
+      except:
+      - 1.0.0.1/32

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -56,6 +56,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		tests.PodToWorld(""),
 		tests.PodToHost(""),
 		tests.PodToExternalWorkload(""),
+		tests.PodToCIDR(""),
 	)
 
 	// Test with an allow-all policy.

--- a/connectivity/tests/cidr.go
+++ b/connectivity/tests/cidr.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+)
+
+// PodToCIDR sends an ICMP packet from each client Pod
+// to 1.1.1.1 and 1.0.0.1.
+func PodToCIDR(name string) check.Scenario {
+	return &podToCIDR{
+		name: name,
+	}
+}
+
+// podToCIDR implements a Scenario.
+type podToCIDR struct {
+	name string
+}
+
+func (s *podToCIDR) Name() string {
+	tn := "pod-to-cidr"
+	if s.name == "" {
+		return tn
+	}
+	return fmt.Sprintf("%s:%s", tn, s.name)
+}
+
+func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
+
+	eps := []check.TestPeer{
+		check.HTTPEndpoint("cloudflare-1001", "http://1.0.0.1"),
+		check.HTTPEndpoint("cloudflare-1111", "http://1.1.1.1"),
+	}
+
+	for _, ep := range eps {
+		var i int
+		for _, src := range t.Context().ClientPods() {
+			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, curl(ep))
+
+				a.ValidateFlows(ctx, src.Name(), src.Address(), a.GetEgressRequirements(check.FlowParameters{
+					RSTAllowed: true,
+				}))
+			})
+
+			i++
+		}
+	}
+}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -93,6 +93,7 @@ func newCmdConnectivityTest() *cobra.Command {
 			return nil
 		},
 	}
+
 	cmd.Flags().BoolVar(&params.SingleNode, "single-node", false, "Limit to tests able to run on a single node")
 	cmd.Flags().BoolVar(&params.PrintFlows, "print-flows", false, "Print flow logs for each test")
 	cmd.Flags().DurationVar(&params.PostTestSleepDuration, "post-test-sleep", 0, "Wait time after each test before next test starts")
@@ -103,10 +104,10 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity test in")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
-	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!'")
+	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
 	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
-	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages")
+	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages and don't buffer any lines")
 	cmd.Flags().BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"regexp"
@@ -55,9 +56,17 @@ func newCmdConnectivityTest() *cobra.Command {
 
 			for _, test := range tests {
 				if strings.HasPrefix(test, "!") {
-					params.SkipTests = append(params.SkipTests, regexp.MustCompile(strings.TrimPrefix(test, "!")))
+					rgx, err := regexp.Compile(strings.TrimPrefix(test, "!"))
+					if err != nil {
+						return fmt.Errorf("Test filter: %w", err)
+					}
+					params.SkipTests = append(params.SkipTests, rgx)
 				} else {
-					params.RunTests = append(params.RunTests, regexp.MustCompile(test))
+					rgx, err := regexp.Compile(test)
+					if err != nil {
+						return fmt.Errorf("Test filter: %w", err)
+					}
+					params.RunTests = append(params.RunTests, rgx)
 				}
 			}
 


### PR DESCRIPTION
This PR contains:

- Scenario `PodToCIDR` for HTTP towards 1.1.1.1 and 1.0.0.1
- CNP `client-egress-to-cidr` containing a `toCIDRSet` for positive and negative egress test coverage
- Some CLI fixes for the `-test` argument

cc @b3a-dev 