### PR TITLE
.github: Stop running tests for every push to master

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -3,9 +3,6 @@ name: AKS
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
-  push:
-    branches:
-      - master
   schedule:
     - cron:  '0 */6 * * *'
 

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -3,9 +3,6 @@ name: EKS (tunnel)
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
-  push:
-    branches:
-      - master
   schedule:
     - cron:  '50 */6 * * *'
 

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -3,9 +3,6 @@ name: EKS (ENI)
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
-  push:
-    branches:
-      - master
   schedule:
     - cron:  '10 */6 * * *'
 

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -3,9 +3,6 @@ name: External Workloads
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
-  push:
-    branches:
-      - master
   schedule:
     - cron:  '55 */6 * * *'
 

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -3,9 +3,6 @@ name: GKE
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request_target: {}
-  push:
-    branches:
-      - master
   schedule:
     - cron:  '20 */6 * * *'
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -3,9 +3,6 @@ name: Kind
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
-  push:
-    branches:
-      - master
   schedule:
     - cron:  '30 */6 * * *'
 

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -3,9 +3,6 @@ name: Multicluster
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
-  push:
-    branches:
-      - master
   schedule:
     - cron:  '40 */6 * * *'
 


### PR DESCRIPTION
This pull request changes the triggers of all tests that spin up clusters to only run on pull requests and every 6h. That matches what is done at https://github.com/cilium/cilium and probably enough to catch potential regressions.

We are limited to 20 concurrent GitHub jobs for the entire Cilium organization so we should avoid running long workflows unless strictly necessary.