### PR TITLE
.github: Speed up cluster cleanups

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -91,7 +91,7 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
-          az aks delete --yes --name ${{ env.clusterName }} --resource-group cilium-ci
+          az aks delete --yes --name ${{ env.clusterName }} --resource-group cilium-ci --no-wait
         shell: bash {0}
 
       - name: Upload Artifacts

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -105,7 +105,7 @@ jobs:
           kubectl get cep --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
-          gcloud container clusters delete --quiet ${{ env.clusterName }} --zone ${{ env.zone }}
+          gcloud container clusters delete --quiet ${{ env.clusterName }} --zone ${{ env.zone }} --async
           gcloud compute instances delete --quiet ${{ env.vmName }} --zone ${{ env.zone }}
         shell: bash {0}
 

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Clean up GKE
         if: ${{ always() }}
         run: |
-          gcloud container clusters delete --quiet ${{ env.clusterName }} --zone ${{ env.zone }}
+          gcloud container clusters delete --quiet ${{ env.clusterName }} --zone ${{ env.zone }} --async
 
       - name: Upload Artifacts
         if: ${{ always() }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -131,8 +131,8 @@ jobs:
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
           gcloud compute firewall-rules delete --quiet $GCP_FW_RULE
-          gcloud container clusters delete --quiet ${{ env.clusterName1 }} --zone ${{ env.zone }}
-          gcloud container clusters delete --quiet ${{ env.clusterName2 }} --zone ${{ env.zone }}
+          gcloud container clusters delete --quiet ${{ env.clusterName1 }} --zone ${{ env.zone }} --async
+          gcloud container clusters delete --quiet ${{ env.clusterName2 }} --zone ${{ env.zone }} --async
         shell: bash {0}
 
       - name: Upload Artifacts


### PR DESCRIPTION
With `gcloud` and `az`, when deleting a cluster, we can pass a flag to instruct the CLI to return as soon as the query has been sent, without waiting for completion. That is already the default behavior in `eksctl`'s case.