### PR TITLE
github: Remove `kubectl wait` commands from Kind workflow

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -50,17 +50,9 @@ jobs:
         run: |
           cilium install --config monitor-aggregation=none
 
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
-          # To make sure that cilium CRD is available (default timeout is 5m)
-          # https://github.com/cilium/cilium/blob/master/operator/crd.go#L34
-          kubectl wait --for condition=Established crd/ciliumnetworkpolicies.cilium.io --timeout=5m
-
       - name: Enable Relay
         run: |
           cilium hubble enable --ui
-
-          # This will fail if Hubble UI cannot come up
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
 
       - name: Status
         run: |
@@ -86,8 +78,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable
-
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
 
       - name: Status
         run: |


### PR DESCRIPTION
The Kind workflow was the only one issuing `kubectl wait`
commands. The problem with these after e.g., enabling hubble, is that
kubectl wait can wait for the old instances of the restarted Cilium
pods to become ready, which will fail as these pods will never become
ready. Rely on `cilium status --wait` instead.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>