### PR TITLE
connectivity: egress HTTP and policy w/ toFQDNs

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -195,21 +195,25 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 	cmdName := cmd[0]
 	cmdStr := strings.Join(cmd, " ")
 
-	if stderr.Len() > 0 {
-		a.test.Debugf("%s stderr: %s", cmdName, stderr.String())
-	} else if stdout.Len() > 0 {
-		a.test.Debugf("%s stdout: %s", cmdName, stdout.String())
-	}
-
 	if err != nil || stderr.Len() > 0 {
 		if a.shouldSucceed() {
+			// Command failed unexpectedly, display stderr.
 			a.Failf("command %q failed: %s", cmdStr, err)
+			a.test.Infof("%s stderr:", cmdName)
+			a.test.Log(strings.TrimSpace(stderr.String()))
+			a.test.Log()
 		} else {
 			a.test.Debugf("command %q failed as expected: %s", cmdStr, err)
 		}
 	} else {
 		if !a.shouldSucceed() {
+			// Command succeeded unexpectedly, display stdout. (stderr should be empty)
 			a.Failf("command %q succeeded while it should have failed: %s", cmdStr, stdout.String())
+			if stdout.Len() > 0 {
+				a.test.Infof("%s stdout:", cmdName)
+				a.test.Log(strings.TrimSpace(stdout.String()))
+				a.test.Log()
+			}
 		}
 	}
 }

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -352,7 +352,7 @@ func parsePolicyYAML(policy string) (cnps []*ciliumv2.CiliumNetworkPolicy, err e
 		return nil, nil
 	}
 
-	yamls := strings.Split(policy, "---")
+	yamls := strings.Split(policy, "\n---")
 
 	for _, yaml := range yamls {
 		if strings.TrimSpace(yaml) == "" {
@@ -361,7 +361,7 @@ func parsePolicyYAML(policy string) (cnps []*ciliumv2.CiliumNetworkPolicy, err e
 
 		obj, kind, err := serializer.NewCodecFactory(scheme.Scheme, serializer.EnableStrict).UniversalDeserializer().Decode([]byte(yaml), nil, nil)
 		if err != nil {
-			return nil, fmt.Errorf("decoding policy yaml (%w) in: %s", err, yaml)
+			return nil, fmt.Errorf("decoding policy yaml: %s\nerror: %w", yaml, err)
 		}
 
 		switch policy := obj.(type) {

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -197,11 +197,11 @@ func (t *Test) Run(ctx context.Context) error {
 func (t *Test) WithPolicy(policy string) *Test {
 	pl, err := parsePolicyYAML(policy)
 	if err != nil {
-		t.Fatal("Error parsing policy YAML: %w", err)
+		t.Fatalf("Parsing policy YAML: %s", err)
 	}
 
 	if err := t.addCNPs(pl...); err != nil {
-		t.Fatal("adding CNPs to policy context: %w", err)
+		t.Fatalf("Adding CNPs to policy context: %s", err)
 	}
 	return t
 }

--- a/connectivity/manifests/client-egress-l7-http.yaml
+++ b/connectivity/manifests/client-egress-l7-http.yaml
@@ -1,0 +1,39 @@
+---
+# client2 is allowed to contact cilium.io/ on port 80 and the echo Pod
+# on port 8080. HTTP introspection is enabled for client2.
+# The toFQDNs section relies on DNS introspection being performed by
+# the client-egress-only-dns policy.
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-l7-http
+spec:
+  description: "Allow GET cilium.io:80/ and GET <echo>:8080/ from client2"
+  endpointSelector:
+    matchLabels:
+      other: client
+  egress:
+  # Allow GET / requests towards echo pods.
+  - toEndpoints:
+    - matchLabels:
+        k8s:kind: echo
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/"
+  # Allow GET / requests, only towards cilium.io.
+  - toFQDNs:
+    - matchName: "cilium.io"
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/"

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -12,6 +12,9 @@ spec:
     - ports:
       - port: "53"
         protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
     toEndpoints:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system

--- a/connectivity/manifests/client-egress-to-fqdns-cilium-io.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-cilium-io.yaml
@@ -25,7 +25,6 @@ spec:
       rules:
         dns:
         - matchPattern: "*"
-        - matchPattern: "*.-name.com"
     toEndpoints:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system

--- a/connectivity/manifests/echo-ingress-l7-http.yaml
+++ b/connectivity/manifests/echo-ingress-l7-http.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: echo-ingress-l7-http
+spec:
+  description: "Allow other client to GET / on echo"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+  # Only allow 'other' client to make a GET / request.
+  # Disallow L3 traffic for now, flow matcher doesn't yet support L7 drops.
+  - fromEndpoints:
+    - matchLabels:
+        k8s:other: client
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/"


### PR DESCRIPTION
Best reviewed per commit.

- Added test `client-egress-l7` for HTTP filtering with and without `toFQDNs`. Only client Pod 'other' is allowed to generate HTTP traffic.
- Some fixups to the yaml parser and error reporting.
- Run PodToWorld calls to google.com from all client Pods.
- Execute `connectivity.Run()` inside its own goroutine.
