### PR TITLE
Address all outstanding linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,5 +14,10 @@ linters:
     - varcheck
 
 issues:
-  new: true
-
+  exclude-rules:
+      # Disallows any kind of `fmt.Errorf("%s is too high", bar)`, too opinionated.
+    - linters: [goerr113]
+      text: "do not define dynamic errors, use wrapped static errors instead"
+      # Most exported consts are self-descriptive.
+    - linters: [revive]
+      text: "exported const"

--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -214,18 +214,18 @@ func (k *K8sClusterMesh) installCertificates(ctx context.Context) error {
 	}
 
 	k.Log("🔑 Generating certificates for ClusterMesh...")
+
 	if err := k.createClusterMeshServerCertificate(ctx); err != nil {
 		return err
 	}
+
 	if err := k.createClusterMeshAdminCertificate(ctx); err != nil {
 		return err
 	}
+
 	if err := k.createClusterMeshClientCertificate(ctx); err != nil {
 		return err
 	}
-	if err := k.createClusterMeshExternalWorkloadCertificate(ctx); err != nil {
-		return err
-	}
 
-	return nil
+	return k.createClusterMeshExternalWorkloadCertificate(ctx)
 }

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -158,7 +158,7 @@ func (e ExternalWorkload) HasLabel(name, value string) bool {
 }
 
 // ICMPEndpoint returns a new ICMP endpoint.
-func ICMPEndpoint(name, host string) icmpEndpoint {
+func ICMPEndpoint(name, host string) TestPeer {
 	return icmpEndpoint{
 		name: name,
 		host: host,
@@ -203,7 +203,7 @@ func (ie icmpEndpoint) HasLabel(name, value string) bool {
 
 // HTTPEndpoint returns a new endpoint with the given name and raw URL.
 // Panics if rawurl cannot be parsed.
-func HTTPEndpoint(name, rawurl string) httpEndpoint {
+func HTTPEndpoint(name, rawurl string) TestPeer {
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		panic(err)

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -120,19 +120,19 @@ func deleteCNP(ctx context.Context, client *k8s.Client, cnp *ciliumv2.CiliumNetw
 }
 
 var (
-	// Expect a successful command, don't match any packets.
+	// ResultNone expects a successful command, don't match any packets.
 	ResultNone = Result{None: true}
 
-	// Expect a successful command and a matching flow.
+	// ResultOK expects a successful command and a matching flow.
 	ResultOK = Result{}
 
-	// Expect a successful command, only generating DNS traffic.
+	// ResultDNSOK expects a successful command, only generating DNS traffic.
 	ResultDNSOK = Result{DNSProxy: true}
 
-	// Expect a failed command, generating DNS traffic and a dropped flow.
+	// ResultDNSOKRequestDrop expects a failed command, generating DNS traffic and a dropped flow.
 	ResultDNSOKRequestDrop = Result{DNSProxy: true, Drop: true}
 
-	// Expect a dropped flow and a failed command.
+	// ResultDrop expects a dropped flow and a failed command.
 	ResultDrop = Result{Drop: true}
 )
 
@@ -308,7 +308,7 @@ func (t *Test) deletePolicies(ctx context.Context) error {
 	// Get current policy revisions in all Cilium pods.
 	revs, err := t.Context().getCiliumPolicyRevisions(ctx)
 	if err != nil {
-		return fmt.Errorf("geting policy revisions for Cilium agents: %w", err)
+		return fmt.Errorf("getting policy revisions for Cilium agents: %w", err)
 	}
 	for pod, rev := range revs {
 		t.Debugf("Pod %s's current policy revision: %d", pod.Name(), rev)

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -93,9 +93,8 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		).WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 		if a.Source().HasLabel("other", "client") {
 			return check.ResultOK, check.ResultOK
-		} else {
-			return check.ResultOK, check.ResultDrop
 		}
+		return check.ResultOK, check.ResultDrop
 	})
 
 	// This policy allows ingress to echo only from client with a label 'other:client'.
@@ -108,9 +107,8 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 				// TCP handshake fails both in egress and ingress when
 				// L3(/L4) policy drops at either location.
 				return check.ResultDrop, check.ResultDrop
-			} else {
-				return check.ResultOK, check.ResultOK
 			}
+			return check.ResultOK, check.ResultOK
 		})
 
 	// This policy allows port 8080 from client to echo, so this should succeed

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -93,22 +93,27 @@ const (
 )
 
 var (
+	// OperatorLabels are the labels set on the Cilium operator by default.
 	OperatorLabels = map[string]string{
 		"io.cilium/app": "operator",
 		"name":          "cilium-operator",
 	}
 
+	// RelayDeploymentLabels are the labels set on the Hubble Relay Deployment by default.
 	RelayDeploymentLabels = map[string]string{
 		"k8s-app": "hubble-relay",
 	}
 
+	// HubbleUIDeploymentLabels are the labels set on the Hubble UI Deployment by default.
+	HubbleUIDeploymentLabels = map[string]string{
+		"k8s-app": "hubble-ui",
+	}
+
+	// ClusterMeshDeploymentLabels are the labels set on the clustermesh API server by default.
 	ClusterMeshDeploymentLabels = map[string]string{
 		"k8s-app": "clustermesh-apiserver",
 	}
 
+	// CiliumPodSelector is the pod selector to be used for the Cilium agents.
 	CiliumPodSelector = "k8s-app=cilium"
-
-	HubbleUIDeploymentLabels = map[string]string{
-		"k8s-app": "hubble-ui",
-	}
 )

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -45,7 +45,7 @@ var (
 	clusterNameValidation = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])$`)
 )
 
-func (p InstallParameters) checkDisabled(name string) bool {
+func (p Parameters) checkDisabled(name string) bool {
 	for _, n := range p.DisableChecks {
 		if n == name {
 			return true

--- a/install/install.go
+++ b/install/install.go
@@ -194,7 +194,7 @@ var operatorClusterRole = &rbacv1.ClusterRole{
 		// For cilium-operator running in HA mode.
 		//
 		// Cilium operator running in HA mode requires the use of
-		// ResourceLock for Leader Election between mulitple running
+		// ResourceLock for Leader Election between multiple running
 		// instances.  The preferred way of doing this is to use
 		// LeasesResourceLock as edits to Leases are less common and
 		// fewer objects in the cluster watch "all Leases".  The
@@ -1003,7 +1003,7 @@ type k8sInstallerImplementation interface {
 
 type K8sInstaller struct {
 	client        k8sInstallerImplementation
-	params        InstallParameters
+	params        Parameters
 	flavor        k8s.Flavor
 	certManager   *certs.CertManager
 	rollbackSteps []rollbackStep
@@ -1028,7 +1028,7 @@ type AzureParameters struct {
 	ClientSecret          string
 }
 
-type InstallParameters struct {
+type Parameters struct {
 	Namespace            string
 	Writer               io.Writer
 	ClusterName          string
@@ -1055,7 +1055,7 @@ type InstallParameters struct {
 
 type rollbackStep func(context.Context)
 
-func (p *InstallParameters) validate() error {
+func (p *Parameters) validate() error {
 	p.configOverwrites = map[string]string{}
 	for _, config := range p.ConfigOverwrites {
 		t := strings.SplitN(config, "=", 2)
@@ -1125,7 +1125,7 @@ func (k *K8sInstaller) operatorCommand() []string {
 	return []string{"cilium-operator-generic"}
 }
 
-func NewK8sInstaller(client k8sInstallerImplementation, p InstallParameters) (*K8sInstaller, error) {
+func NewK8sInstaller(client k8sInstallerImplementation, p Parameters) (*K8sInstaller, error) {
 	if err := (&p).validate(); err != nil {
 		return nil, fmt.Errorf("invalid parameters: %w", err)
 	}

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -71,7 +71,7 @@ cilium hubble enable
 # Perform a connectivity test
 cilium connectivity test`,
 		SilenceErrors: true, // this is being handled in main, no need to duplicate error messages
-		SilenceUsage:  true, // avoid showing help when usage is correct but an error occured
+		SilenceUsage:  true, // avoid showing help when usage is correct but an error occurred
 	}
 
 	cmd.AddCommand(

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -77,19 +77,18 @@ func newCmdConnectivityTest() *cobra.Command {
 				return err
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			s := make(chan os.Signal)
-			signal.Notify(s, os.Interrupt, syscall.SIGTERM)
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
 
 			go func() {
-				<-s
+				<-ctx.Done()
 				cc.Log("Interrupt received, cancelling tests...")
-				cancel()
 			}()
 
 			if err := connectivity.Run(ctx, cc); err != nil {
 				fatalf("Connectivity test failed: %s", err)
 			}
+
 			return nil
 		},
 	}

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -27,7 +27,7 @@ import (
 )
 
 func newCmdInstall() *cobra.Command {
-	var params = install.InstallParameters{Writer: os.Stdout}
+	var params = install.Parameters{Writer: os.Stdout}
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -116,7 +116,7 @@ func newCmdUninstall() *cobra.Command {
 }
 
 func newCmdUpgrade() *cobra.Command {
-	var params = install.InstallParameters{Writer: os.Stdout}
+	var params = install.Parameters{Writer: os.Stdout}
 
 	cmd := &cobra.Command{
 		Use:   "upgrade",

--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -38,7 +38,7 @@ func newCmdStatus() *cobra.Command {
 			}
 
 			s, err := collector.Status(context.Background())
-			// Report the most recent status even if an error occured
+			// Report the most recent status even if an error occurred.
 			if s != nil {
 				fmt.Println(s.Format())
 			}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -38,9 +38,11 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	// Register all auth providers (azure, gcp, oidc, openstack, ..).
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 type Client struct {

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -105,6 +105,7 @@ retry:
 	return s, err
 }
 
+// ErrClusterMeshStatusNotAvailable is a sentinel.
 var ErrClusterMeshStatusNotAvailable = errors.New("ClusterMesh status is not available")
 
 func (k *K8sStatusCollector) clusterMeshConnectivity(ctx context.Context, ciliumPod string) (*ClusterMeshAgentConnectivityStatus, error) {

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -110,9 +110,9 @@ func (c *k8sStatusMockClient) setDaemonSet(namespace, name, filter string, desir
 				Msg:   "Error1",
 			},
 			Controllers: []*models.ControllerStatus{
-				&models.ControllerStatus{Name: "c1", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 1, LastFailureMsg: "Error1", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-time.Minute))}},
-				&models.ControllerStatus{Name: "c2", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 4, LastFailureMsg: "Error2", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-2 * time.Minute))}},
-				&models.ControllerStatus{Name: "c3", Status: &models.ControllerStatusStatus{LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-3 * time.Minute))}},
+				{Name: "c1", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 1, LastFailureMsg: "Error1", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-time.Minute))}},
+				{Name: "c2", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 4, LastFailureMsg: "Error2", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-2 * time.Minute))}},
+				{Name: "c3", Status: &models.ControllerStatusStatus{LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-3 * time.Minute))}},
 			},
 		}
 	}
@@ -126,9 +126,9 @@ func (c *k8sStatusMockClient) setDaemonSet(namespace, name, filter string, desir
 				Msg:   "Error1",
 			},
 			Controllers: []*models.ControllerStatus{
-				&models.ControllerStatus{Name: "c1", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 1, LastFailureMsg: "Error1", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-time.Minute))}},
-				&models.ControllerStatus{Name: "c2", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 4, LastFailureMsg: "Error2", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-2 * time.Minute))}},
-				&models.ControllerStatus{Name: "c3", Status: &models.ControllerStatusStatus{LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-3 * time.Minute))}},
+				{Name: "c1", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 1, LastFailureMsg: "Error1", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-time.Minute))}},
+				{Name: "c2", Status: &models.ControllerStatusStatus{ConsecutiveFailureCount: 4, LastFailureMsg: "Error2", LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-2 * time.Minute))}},
+				{Name: "c3", Status: &models.ControllerStatusStatus{LastFailureTimestamp: strfmt.DateTime(time.Now().Add(-3 * time.Minute))}},
 			},
 		}
 	}

--- a/status/status.go
+++ b/status/status.go
@@ -36,7 +36,7 @@ const (
 	Reset   = "\033[0m"
 )
 
-// MapCount is a map to count number of occurences of a string
+// MapCount is a map to count number of occurrences of a string
 type MapCount map[string]int
 
 // MapMapCount is a map of MapCount indexed by string

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -46,6 +46,9 @@ const (
 )
 
 var (
+	// DefaultWorkerCount is initialized to the machine's available CPUs.
 	DefaultWorkerCount = runtime.NumCPU()
-	DefaultWriter      = os.Stdout //Log to stdout by default
+
+	// DefaultWriter points to os.Stdout by default.
+	DefaultWriter = os.Stdout
 )


### PR DESCRIPTION
It came to my attention that `golangci-lint` was enabled in 'new' mode, which ignores all existing linter errors present in the codebase. This PR addresses that issue.

Also allowed exported consts without docstrings, as well as dynamic errors. Sentinels are really not required everywhere.