### PR TITLE
install: require BPF masq to enable --install-no-conntrack-iptables-rules

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -1356,6 +1356,10 @@ func (k *K8sInstaller) generateConfigMap() (*corev1.ConfigMap, error) {
 			return nil, fmt.Errorf("--install-no-conntrack-iptables-rules requires kube-proxy replacement to be enabled")
 		}
 
+		if m.Data["enable-bpf-masquerade"] != "true" {
+			return nil, fmt.Errorf("--install-no-conntrack-iptables-rules requires eBPF masquerading to be enabled")
+		}
+
 		if m.Data["cni-chaining-mode"] != "" {
 			return nil, fmt.Errorf("--install-no-conntrack-iptables-rules cannot be enabled with CNI chaining")
 		}


### PR DESCRIPTION
It's currently possible to enable the no CT Iptables rules together with
Iptables masquerading, which results in Iptables failing to masquerade
traffic.

With this commit, when this setup is detected, we return an error.