### PR TITLE
.github: Fix concurrency groups

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '0 */6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '50 */6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request_target.number || github.event.after || 'scheduled' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '10 */6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request_target.number || github.event.after || 'scheduled' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '55 */6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request_target.number || github.event.after || 'scheduled' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '20 */6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request_target.number || github.event.after || 'scheduled' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '30 */6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || 'scheduled' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '40 */6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request_target.number || github.event.after || 'scheduled' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
There's currently a single concurrency group per workflow, `workflow_name-scheduled`, because of a regression in d9957fb ("ci: change all in-cluster test runs to pull_request_target"). This commit started using `github.event.pull_request_target` for the concurrency group, but that variable doesn't exist. As a consequence, scheduled workflows may cancel workflows triggered by pull requests and the other way around.

This pull request also fixes commit f998cca (".github: Stop running tests for every push to master") in which triggers were updated without updating the corresponding concurrency group. That mistake was without consequences, but left unnecessary code.

Fixes: https://github.com/cilium/cilium-cli/pull/212.
Fixes: https://github.com/cilium/cilium-cli/pull/244.