### PR TITLE
CODEOWNERS: Update for cilium/ci-structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,12 @@
 * @cilium/janitors
 /CODEOWNERS @cilium/contributing
 /.github/ @cilium/contributing
+/.github/cilium-cli-test-job-chart/ @cilium/github-sec @cilium/ci-structure
+/.github/gcp-vm-startup.sh @cilium/ci-structure
+/.github/get-kubeconfig.sh @cilium/github-sec @cilium/ci-structure
+/.github/in-cluster-test-scripts/ @cilium/ci-structure
+/.github/kind-config*.yaml @cilium/ci-structure
+/.github/tools/ @cilium/ci-structure
 /.github/workflows/ @cilium/maintainers @cilium/ci-structure
 /cmd/ @cilium/cli
 /connectivity/ @cilium/policy


### PR DESCRIPTION
Update code owners for @cilium/ci-structure to include scripts and manifests in `.github/`.