### PR TITLE
Flow validation fixes

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -464,7 +464,7 @@ func (a *Action) GetIngressRequirements(p FlowParameters) []filters.FlowSetRequi
 				First: filters.FlowRequirement{Filter: filters.And(ipRequest, icmpRequest), Msg: "ICMP request"},
 				Last:  filters.FlowRequirement{Filter: filters.And(ipResponse, icmpResponse), Msg: "ICMP response", SkipOnAggregation: true},
 				Except: []filters.FlowRequirement{
-					{Filter: filters.Drop(), Msg: "Drop"},
+					{Filter: filters.And(ipRequest, icmpRequest, filters.Drop()), Msg: "Drop"},
 				},
 			}
 		}

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -321,8 +321,8 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 		dstIP = ""
 	}
 
-	ipResponse := filters.IP(dstIP, srcIP)
 	ipRequest := filters.IP(srcIP, dstIP)
+	ipResponse := filters.IP(dstIP, srcIP)
 
 	switch p.Protocol {
 	case ICMP:
@@ -407,16 +407,24 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 	reqs = append(reqs, egress)
 
 	if p.DNSRequired || a.expEgress.DNSProxy {
+		// Override to allow for any DNS server
+		ipRequest := filters.IP(srcIP, "")
+		ipResponse := filters.IP("", srcIP)
+
 		dnsRequest := filters.Or(filters.UDP(0, 53), filters.TCP(0, 53))
 		dnsResponse := filters.Or(filters.UDP(53, 0), filters.TCP(53, 0))
 
 		dns := filters.FlowSetRequirement{First: filters.FlowRequirement{Filter: filters.And(ipRequest, dnsRequest), Msg: "DNS request"}}
 		if a.expEgress.DNSProxy {
+			qname := a.dst.Address() + "."
 			dns.Middle = []filters.FlowRequirement{{Filter: filters.And(ipResponse, dnsResponse), Msg: "DNS response"}}
-			dns.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(a.dst.Address()+".", 0)), Msg: "DNS proxy"}
+			dns.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(qname, 0)), Msg: "DNS proxy"}
+			// 5 is the default rcode returned on error such as policy deny
+			dns.Except = []filters.FlowRequirement{{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(qname, 5)), Msg: "DNS proxy DROP"}}
 		} else {
 			dns.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, dnsResponse), Msg: "DNS response"}
 		}
+
 		reqs = append(reqs, dns)
 	}
 

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -543,13 +543,17 @@ retry:
 	a.flows[pod] = flows
 
 	res := FlowRequirementResults{FirstMatch: -1, LastMatch: -1}
+	resFail := FlowRequirementResults{FirstMatch: -1, LastMatch: -1}
 	for i, req := range reqs {
 		offset := 0
 		var r FlowRequirementResults
 		for offset < len(flows) {
 			r = a.matchFlowRequirements(ctx, flows, offset, pod, &req)
-			// Check if fully matched or no match for the first flow
-			if !r.NeedMoreFlows || r.FirstMatch == -1 {
+			if r.Failures > 0 {
+				resFail.Merge(&r)
+			}
+			// Check if successfully fully matched or no match for the first flow
+			if (!r.NeedMoreFlows && r.Failures == 0) || r.FirstMatch == -1 {
 				break
 			}
 			// Try if some other flow instance would find both first and last required flows
@@ -563,7 +567,13 @@ retry:
 			}
 		}
 		// Merge results
-		res.Merge(&r)
+		if r.Failures > 0 {
+			// on Failure merge all tries to see what flows matched
+			res.Merge(&resFail)
+		} else {
+			// on Success only merge the successfully matched filters
+			res.Merge(&r)
+		}
 		a.Debugf("Merged flow validation results #%d: %v", i, res)
 	}
 	a.flowResults[pod] = res

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -107,6 +107,9 @@ func (r *FlowRequirementResults) Merge(from *FlowRequirementResults) {
 	if r.FirstMatch < 0 || from.FirstMatch >= 0 && from.FirstMatch < r.FirstMatch {
 		r.FirstMatch = from.FirstMatch
 	}
+	if from.FirstMatch > r.LastMatch {
+		r.LastMatch = from.FirstMatch
+	}
 	if from.LastMatch > r.LastMatch {
 		r.LastMatch = from.LastMatch
 	}

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -48,6 +48,7 @@ type deploymentParameters struct {
 	Affinity       *corev1.Affinity
 	ReadinessProbe *corev1.Probe
 	Labels         map[string]string
+	Annotations    map[string]string
 }
 
 func newDeployment(p deploymentParameters) *appsv1.Deployment {
@@ -71,6 +72,7 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 						"name": p.Name,
 						"kind": p.Kind,
 					},
+					Annotations: make(map[string]string, len(p.Annotations)),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -103,6 +105,9 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 
 	for k, v := range p.Labels {
 		dep.Spec.Template.ObjectMeta.Labels[k] = v
+	}
+	for k, v := range p.Annotations {
+		dep.Spec.Template.ObjectMeta.Annotations[k] = v
 	}
 
 	return dep
@@ -310,6 +315,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					},
 				},
 				ReadinessProbe: newLocalReadinessProbe(8080, "/"),
+				Annotations:    map[string]string{"io.cilium.proxy-visibility": "<Ingress/8080/TCP/HTTP>"},
 			})
 
 			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeployment, metav1.CreateOptions{})

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -245,11 +245,12 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:    ClientDeploymentName,
-			Kind:    kindClientName,
-			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
+			Name:        ClientDeploymentName,
+			Kind:        kindClientName,
+			Port:        8080,
+			Image:       defaults.ConnectivityCheckAlpineCurlImage,
+			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
+			Annotations: map[string]string{"io.cilium.proxy-visibility": "<Egress/53/ANY/DNS>"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
@@ -262,12 +263,13 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client2 deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:    Client2DeploymentName,
-			Kind:    kindClientName,
-			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
-			Labels:  map[string]string{"other": "client"},
+			Name:        Client2DeploymentName,
+			Kind:        kindClientName,
+			Port:        8080,
+			Image:       defaults.ConnectivityCheckAlpineCurlImage,
+			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
+			Labels:      map[string]string{"other": "client"},
+			Annotations: map[string]string{"io.cilium.proxy-visibility": "<Egress/53/ANY/DNS>"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION
- Only consider ICMP drops for ICMP test
- Show all matched flows on failure
- Add HTTP visibility annotation to `echo-other-node` deployment and DNS visibility annotations to `client` pods. This provides for richer flow validation even without policies being applied
- Fix DNS flow validation
- Expand flow results properly in Merge()