### PR TITLE
test: Add progress indicator when buffering logs

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -123,6 +123,7 @@ func (a *Action) Destination() TestPeer {
 // This method is to be called from a Scenario implementation.
 func (a *Action) Run(f func(*Action)) {
 	a.Logf("[.] Action [%s]", a)
+	a.test.progress()
 
 	// Execute the given test function.
 	// Might call Fatal().


### PR DESCRIPTION
Running tests interactively with the default sparse output is a bit
more interesting with some progress indication.  Add a single '.'
character for each executed action when logging is being buffered.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>