### PR TITLE
github: Add --timestamps to cilium vm logs

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -131,7 +131,7 @@ jobs:
         run: |
           kubectl logs -n kube-system job/cilium-cli
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
-          gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium"
+          gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide


### PR DESCRIPTION
Cilium install in external workloads CI VM times out. Add timestamps
to agent logs to learn more about the timeline.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>