### PR TITLE
Nudge users to upgrade instead of reinstall

### DIFF
--- a/install/certs.go
+++ b/install/certs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -126,6 +127,9 @@ func (k *K8sInstaller) installCerts(ctx context.Context) error {
 
 	k.Log("🔑 Generating certificates for Hubble...")
 	if err := k.createHubbleServerCertificate(ctx); err != nil {
+		if errors.IsAlreadyExists(err) {
+			k.Log("ℹ️  A cilium resource is already present in this cluster. If you are trying to upgrade cilium, please do `cilium upgrade` instead")
+		}
 		return err
 	}
 	k.pushRollbackStep(func(ctx context.Context) {

--- a/install/install.go
+++ b/install/install.go
@@ -1019,13 +1019,13 @@ const (
 )
 
 type AzureParameters struct {
-	ResourceGroupName     string
-	ResourceGroup         string
-	SubscriptionName      string
-	SubscriptionID        string
-	TenantID              string
-	ClientID              string
-	ClientSecret          string
+	ResourceGroupName string
+	ResourceGroup     string
+	SubscriptionName  string
+	SubscriptionID    string
+	TenantID          string
+	ClientID          string
+	ClientSecret      string
 }
 
 type Parameters struct {
@@ -1680,6 +1680,10 @@ func (k *K8sInstaller) pushRollbackStep(step rollbackStep) {
 }
 
 func (k *K8sInstaller) RollbackInstallation(ctx context.Context) {
+	if len(k.rollbackSteps) == 0 {
+		return
+	}
+
 	k.Log("↩️ Rolling back installation...")
 
 	for _, r := range k.rollbackSteps {


### PR DESCRIPTION
This PR checks if the first resource to be installed already
exists in the cluster. If so, it hints users to do a
`cilium upgrade` instead.

Signed-off: Lorenzo Fundaro <lorenzofundaro@gmail.com>