### PR TITLE
.github/workflows: move Go module vendoring check to build checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,12 +23,6 @@ jobs:
       with:
         go-version: 1.16.4
 
-    - name: Build
-      run: make
-
-    - name: Test
-      run: make test
-
     - name: Run static checks
       uses: golangci/golangci-lint-action@v2
       with:
@@ -50,6 +44,19 @@ jobs:
         # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
         skip-build-cache: true
 
+    - name: Check module vendoring
+      run: |
+        go mod tidy
+        go mod vendor
+        go mod verify
+        git diff --exit-code
+
+    - name: Build
+      run: make
+
+    - name: Test
+      run: make test
+
     - name: Send slack notification
       if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}
       uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
@@ -58,30 +65,3 @@ jobs:
         fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  go-mod:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16.4
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Check module vendoring
-        run: |
-          go mod tidy
-          go mod vendor
-          go mod verify
-          git diff --exit-code
-
-      - name: Send slack notification
-        if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}
-        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 # See https://golangci-lint.run/usage/configuration/ for available options.
 # Also https://github.com/cilium/cilium/blob/master/.golangci.yaml as a reference.
+run:
+  timeout: 5m
+
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
Instead of instantiating a separate job checking out its own copy of the
code, move the module vendoring check to the build job which already has
the code checked out.

Also move the static checks and the module vendoring check before the
build and tests steps.