### PR TITLE
clustermesh: Add debug and retries to external workload install

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -23,6 +23,6 @@ cilium clustermesh status --wait
 cilium clustermesh vm create "${VM_NAME}" -n default --ipv4-alloc-cidr 10.192.1.0/30
 cilium clustermesh vm status
 
-# Start installing Cilium on VM
-cilium clustermesh vm install install-external-workload.sh
+# Create install script for VMs
+cilium clustermesh vm install install-external-workload.sh --config debug
 kubectl -n kube-system create cm install-external-workload-script --from-file=script=install-external-workload.sh

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -308,6 +308,7 @@ func newCmdExternalWorkloadInstall() *cobra.Command {
 	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait until status is successful")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Cilium agent config entries (key=value)")
+	cmd.Flags().IntVar(&params.Retries, "retries", 4, "Number of Cilium agent start retries")
 
 	return cmd
 }

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -307,6 +307,7 @@ func newCmdExternalWorkloadInstall() *cobra.Command {
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait until status is successful")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait")
+	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Cilium agent config entries (key=value)")
 
 	return cmd
 }


### PR DESCRIPTION
External workload installs have been mostly "timing out" in CI. Address this on two fronts:

- Add support for and use Cilium agent debug option in external workload install in CI
- Add retries to Cilium agent install in the external workloads, defaulting to 4 times.
