### PR TITLE
ci: wait for Cilium start before enabling clustermesh

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -4,6 +4,7 @@ set -x
 set -e
 
 cilium install --cluster-name "${CLUSTER_NAME}" --restart-unmanaged-pods=false --config monitor-aggregation=none --config tunnel=vxlan --native-routing-cidr="${CLUSTER_CIDR}"
+cilium status --wait
 
 cilium clustermesh enable
 cilium clustermesh status --wait --wait-duration 5m


### PR DESCRIPTION
This change fixes a bug when clustermesh apiserver was created directly
after Cilium pods were created which caused the apiserver pod to not be
managed by Cilium


fixes #224