### PR TITLE
test: Fix flow validation retries

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -248,6 +248,15 @@ func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, offs
 
 		if match {
 			r.Matched[offset+index] = expect
+
+			// Update last match index and timestamp
+			if r.LastMatch < offset+index {
+				r.LastMatch = offset + index
+				flowTimestamp, err := ptypes.Timestamp(flow.Time)
+				if err == nil {
+					r.LastMatchTimestamp = flowTimestamp
+				}
+			}
 		}
 
 		if match != expect {
@@ -288,15 +297,8 @@ func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, offs
 	}
 
 	if !(req.Last.SkipOnAggregation && a.test.ctx.FlowAggregation()) {
-		if index, match, lastFlow := match(true, req.Last, &flowCtx); !match {
+		if _, match, _ := match(true, req.Last, &flowCtx); !match {
 			r.NeedMoreFlows = true
-		} else {
-			r.LastMatch = offset + index
-
-			flowTimestamp, err := ptypes.Timestamp(lastFlow.Time)
-			if err == nil {
-				r.LastMatchTimestamp = flowTimestamp
-			}
 		}
 	}
 

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -150,6 +150,35 @@ type FlowParameters struct {
 
 type flowsSet []*observer.GetFlowsResponse
 
+// lastTime returns the timestamp of the last flow in 'f', if any.
+func (f flowsSet) lastTime() (last time.Time) {
+	if len(f) == 0 {
+		return last
+	}
+	timestamp := f[len(f)-1].GetFlow().GetTime()
+	if timestamp == nil {
+		return last
+	}
+	return timestamp.AsTime()
+}
+
+// append adds any flows in 'from' to 'f', if the flow's timestamp is
+// later than the last one in 'f', returns the combined set.
+func (f flowsSet) append(from flowsSet) flowsSet {
+	last := f.lastTime()
+	if last.IsZero() {
+		return from
+	}
+	// Add all new flows with a later timestamp.
+	for _, flow := range from {
+		timestamp := flow.GetFlow().GetTime()
+		if timestamp == nil || timestamp.AsTime().After(last) {
+			f = append(f, flow)
+		}
+	}
+	return f
+}
+
 func (f flowsSet) Contains(filter filters.FlowFilterImplementation, fc *filters.FlowContext) (int, bool, *flow.Flow) {
 	if f == nil {
 		return 0, false, nil


### PR DESCRIPTION
Retry should be done when Retry() return nil, not when it fails.

Set the warning interval so that we get at least one log for
retries. The default was 10 seconds which was equal to the whole flow
retry timeout, so we never saw any logs for retries.

Fixes: #158
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>