### PR TITLE
Revert "workflows: fix missing CIDRs in multicluster install script"

### DIFF
--- a/.github/cilium-cli-test-job-chart/templates/job.yaml
+++ b/.github/cilium-cli-test-job-chart/templates/job.yaml
@@ -30,12 +30,8 @@ spec:
             value: {{ .Values.vm_name }}
           - name: CLUSTER_NAME_1
             value: {{ .Values.cluster_name_1 }}
-          - name: CLUSTER_CIDR_1
-            value: {{ .Values.cluster_cidr_1 }}
           - name: CLUSTER_NAME_2
             value: {{ .Values.cluster_name_2 }}
-          - name: CLUSTER_CIDR_2
-            value: {{ .Values.cluster_cidr_2 }}
       dnsPolicy: ClusterFirst
       enableServiceLinks: true
       priority: 0

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -13,7 +13,7 @@ cilium install \
   --cluster-name "${CLUSTER_NAME_1}" \
   --cluster-id 1 \
   --config monitor-aggregation=none \
-  --native-routing-cidr="${CLUSTER_CIDR_1}"
+  --native-routing-cidr=10.0.0.0/9
 
 # Install Cilium in cluster2
 cilium install \
@@ -21,7 +21,7 @@ cilium install \
   --cluster-name "${CLUSTER_NAME_2}" \
   --cluster-id 2 \
   --config monitor-aggregation=none \
-  --native-routing-cidr="${CLUSTER_CIDR_2}" \
+  --native-routing-cidr=10.0.0.0/9 \
   --inherit-ca "${CONTEXT1}"
 
 # Enable Relay

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -54,7 +54,6 @@ jobs:
           echo ::set-output name=owner::${OWNER}
 
       - name: Create GKE cluster 2
-        id: cluster2
         run: |
           gcloud container clusters create ${{ env.clusterName2 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
@@ -66,8 +65,6 @@ jobs:
             --disk-size 10GB \
             --preemptible \
             --enable-ip-alias
-          CLUSTER_CIDR=$(gcloud container clusters describe ${{ env.clusterName2 }} --zone ${{ env.zone }} --format="value(clusterIpv4Cidr)")
-          echo ::set-output name=cluster_cidr::${CLUSTER_CIDR}
 
       - name: Get cluster 2 credentials
         run: |
@@ -79,7 +76,6 @@ jobs:
           mv kubeconfig kubeconfig-cluster2
 
       - name: Create GKE cluster 1
-        id: cluster1
         run: |
           gcloud container clusters create ${{ env.clusterName1 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
@@ -91,8 +87,6 @@ jobs:
             --disk-size 10GB \
             --preemptible \
             --enable-ip-alias
-          CLUSTER_CIDR=$(gcloud container clusters describe ${{ env.clusterName1 }} --zone ${{ env.zone }} --format="value(clusterIpv4Cidr)")
-          echo ::set-output name=cluster_cidr::${CLUSTER_CIDR}
 
       - name: Get cluster 1 credentials
         run: |
@@ -128,9 +122,7 @@ jobs:
             --set job_name=cilium-cli \
             --set test_script_cm=cilium-cli-test-script \
             --set cluster_name_1=${{ env.clusterName1 }} \
-            --set cluster_cidr_1=${{ steps.cluster1.outputs.cluster_cidr }} \
             --set cluster_name_2=${{ env.clusterName2 }} \
-            --set cluster_cidr_2=${{ steps.cluster2.outputs.cluster_cidr }}
 
       - name: Wait for test job
         run: |


### PR DESCRIPTION
This reverts commit dec9f4fd47cd27f7b40bfee7c88820908d98f61a.

Native routing CIDR in Cilium config in the multicluster setup must
cover all the clusters. Otherwise cross-cluster traffic will be
masqueraded to the source node and ingress policy enforcement in the
destination cluster will drop allowed traffic.

"10.0.0.0/9" is an educated guess that currently works. We probably
should compute the longest possible common prefix from the actual
cluster CIDRs.

Note that since the workflow trigger is `pull_request_target` this will only
take effect once merged to master. This was tested with `pull_request`
trigger prior to pushing this PR.

Fixes: #286
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>