### PR TITLE
workflows: use the native sysdump

### DIFF
--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -3,6 +3,10 @@
 set -x
 set -e
 
+# Create a FIFO through which we'll pipe the sysdump before the job terminates.
+# NOTE: This MUST be the first step in the script.
+mkfifo /tmp/cilium-sysdump-out
+
 # Enable Relay
 cilium hubble enable
 
@@ -18,3 +22,10 @@ cilium connectivity test --all-flows
 
 # Retrieve Cilium  status
 cilium status
+
+# Grab a sysdump
+cilium sysdump --output-filename=cilium-sysdump-out
+
+# Wait for the sysdump to be read.
+# NOTE: This MUST be the last step in the script.
+cat cilium-sysdump-out >> /tmp/cilium-sysdump-out

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -3,6 +3,10 @@
 set -x
 set -e
 
+# Create a FIFO through which we'll pipe the sysdump before the job terminates.
+# NOTE: This MUST be the first step in the script.
+mkfifo /tmp/cilium-sysdump-out
+
 # Enable Relay
 cilium hubble enable
 
@@ -18,3 +22,10 @@ cilium connectivity test --test '!/pod-to-local-nodeport' --all-flows
 
 # Retrieve Cilium  status
 cilium status
+
+# Grab a sysdump
+cilium sysdump --output-filename=cilium-sysdump-out
+
+# Wait for the sysdump to be read.
+# NOTE: This MUST be the last step in the script.
+cat cilium-sysdump-out >> /tmp/cilium-sysdump-out

--- a/.github/in-cluster-test-scripts/external-workloads.sh
+++ b/.github/in-cluster-test-scripts/external-workloads.sh
@@ -3,6 +3,10 @@
 set -x
 set -e
 
+# Create a FIFO through which we'll pipe the sysdump before the job terminates.
+# NOTE: This MUST be the first step in the script.
+mkfifo /tmp/cilium-sysdump-out
+
 # Run connectivity test
 cilium connectivity test --all-flows
 
@@ -10,3 +14,10 @@ cilium connectivity test --all-flows
 cilium status
 cilium clustermesh status
 cilium clustermesh vm status
+
+# Grab a sysdump
+cilium sysdump --output-filename=cilium-sysdump-out
+
+# Wait for the sysdump to be read.
+# NOTE: This MUST be the last step in the script.
+cat cilium-sysdump-out >> /tmp/cilium-sysdump-out

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -3,6 +3,10 @@
 set -x
 set -e
 
+# Create a FIFO through which we'll pipe the sysdump before the job terminates.
+# NOTE: This MUST be the first step in the script.
+mkfifo /tmp/cilium-sysdump-out
+
 # Install Cilium
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
@@ -24,3 +28,10 @@ cilium connectivity test --all-flows
 
 # Retrieve Cilium status
 cilium status
+
+# Grab a sysdump
+cilium sysdump --output-filename=cilium-sysdump-out
+
+# Wait for the sysdump to be read.
+# NOTE: This MUST be the last step in the script.
+cat cilium-sysdump-out >> /tmp/cilium-sysdump-out

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -122,8 +122,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -102,8 +102,9 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }}
 
-      - name: Wait for test job
+      - name: Wait for and copy the sysdump in the background and wait for job termination
         run: |
+          kubectl -n kube-system exec job/cilium-cli -- cat /tmp/cilium-sysdump-out > cilium-sysdump-out.zip &
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
       - name: Post-test information gathering
@@ -112,8 +113,6 @@ jobs:
           kubectl logs -n kube-system job/cilium-cli-install
           kubectl logs -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -102,8 +102,9 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }}
 
-      - name: Wait for test job
+      - name: Wait for and copy the sysdump in the background and wait for job termination
         run: |
+          kubectl -n kube-system exec job/cilium-cli -- cat /tmp/cilium-sysdump-out > cilium-sysdump-out.zip &
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
       - name: Post-test information gathering
@@ -112,8 +113,6 @@ jobs:
           kubectl logs -n kube-system job/cilium-cli-install
           kubectl logs -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -147,8 +147,9 @@ jobs:
             --set job_name=cilium-cli \
             --set test_script_cm=cilium-cli-test-script
 
-      - name: Wait for test job
+      - name: Wait for and copy the sysdump in the background and wait for job termination
         run: |
+          kubectl -n kube-system exec job/cilium-cli -- cat /tmp/cilium-sysdump-out > cilium-sysdump-out.zip &
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
       - name: Post-test installation logs
@@ -165,8 +166,6 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -88,8 +88,9 @@ jobs:
             --set cluster_name=${{ env.clusterName }} \
             --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }}
 
-      - name: Wait for job
+      - name: Wait for and copy the sysdump in the background and wait for job termination
         run: |
+          kubectl -n kube-system exec job/cilium-cli -- cat /tmp/cilium-sysdump-out > cilium-sysdump-out.zip &
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=15m
 
       - name: Post-test information gathering
@@ -98,8 +99,6 @@ jobs:
           kubectl logs -n kube-system job/cilium-cli
           kubectl exec -n kube-system job/cilium-cli -- cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -96,8 +96,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload Artifacts

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -132,8 +132,10 @@ jobs:
             --set cluster_name_2=${{ env.clusterName2 }} \
             --set cluster_cidr_2=${{ steps.cluster2.outputs.cluster_cidr }}
 
-      - name: Wait for test job
+      - name: Wait for and copy the sysdump in the background and wait for job termination
         run: |
+          kubectl -n kube-system exec job/cilium-cli -- cat /tmp/cilium-sysdump-out-1 > cilium-sysdump-out-1.zip &
+          kubectl -n kube-system exec job/cilium-cli -- cat /tmp/cilium-sysdump-out-2 > cilium-sysdump-out-2.zip &
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=20m
 
       - name: Post-test information gathering
@@ -141,8 +143,6 @@ jobs:
         run: |
           kubectl logs -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE
@@ -153,12 +153,20 @@ jobs:
           gcloud container clusters delete ${{ env.clusterName2 }} --zone ${{ env.zone }} --quiet --async
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
-      - name: Upload artifacts
+      - name: Upload artifacts (1)
         if: ${{ failure() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
-          name: cilium-sysdump-out.zip
-          path: cilium-sysdump-out.zip
+          name: cilium-sysdump-out-1.zip
+          path: cilium-sysdump-out-1.zip
+          retention-days: 5
+
+      - name: Upload artifacts (2)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
+        with:
+          name: cilium-sysdump-out-2.zip
+          path: cilium-sysdump-out-2.zip
           retention-days: 5
 
       - name: Send slack notification


### PR DESCRIPTION
Moves workflows from using `cilium-sysdump.zip` to using the new, native implementation. As it is impossible to copy files from terminated pods without resorting to using PVs (or some sort of base64-encoding and log parsing voodoo), I am proposing we use FIFOs to copy the sysdump from the pods while they're still running, which should lead to graceful job termination once read from.

I am not entirely sure this will work as expected, though, and for that reason I am marking it as draft :)