### PR TITLE
workflows: use the native sysdump

### DIFF
--- a/.github/cilium-cli-output/.helmignore
+++ b/.github/cilium-cli-output/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/.github/cilium-cli-output/Chart.yaml
+++ b/.github/cilium-cli-output/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cilium-cli-output
+description: cilium-cli-output
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/.github/cilium-cli-output/templates/pod.yaml
+++ b/.github/cilium-cli-output/templates/pod.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Values.pod.name }}
+  namespace: kube-system
+spec:
+  containers:
+  - args:
+    - sleep
+    - 900
+    image: quay.io/cilium/cilium-cli-ci:{{ .Values.tag }}
+    imagePullPolicy: Always
+    name: test
+    volumeMounts:
+      - name: output
+        mountPath: /output
+  tolerations:
+  - operator: Exists
+  volumes:
+  - name: output
+    persistentVolumeClaim:
+      claimName: {{ .Values.pvc.name }}

--- a/.github/cilium-cli-output/values.yaml
+++ b/.github/cilium-cli-output/values.yaml
@@ -1,0 +1,5 @@
+pod:
+  name: cilium-cli-output
+pvc:
+  name: cilium-cli-output
+tag: latest

--- a/.github/cilium-cli-test-job-chart/templates/job.yaml
+++ b/.github/cilium-cli-test-job-chart/templates/job.yaml
@@ -19,6 +19,10 @@ spec:
             mountPath: /root/.kube
           - name: test-script
             mountPath: /root/test
+          {{- if .Values.output.enabled }}
+          - name: output
+            mountPath: /output
+          {{- end }}
         env:
           - name: KUBECONFIG
             value: /root/.kube/config
@@ -52,3 +56,8 @@ spec:
       - name: test-script
         configMap:
           name: {{ .Values.test_script_cm }}
+      {{- if .Values.output.enabled }}
+      - name: output
+        persistentVolumeClaim:
+          claimName: {{ .Values.output.pvc.name }}
+      {{- end }}

--- a/.github/cilium-cli-test-job-chart/templates/pvc.yaml
+++ b/.github/cilium-cli-test-job-chart/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.output.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.output.pvc.name }}
+  namespace: kube-system
+spec:
+  {{- if .Values.output.pvc.storageClassName }}
+  storageClassName: {{ .Values.output.pvc.storageClassName }}
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.output.pvc.size }}
+{{- end }}

--- a/.github/cilium-cli-test-job-chart/values.yaml
+++ b/.github/cilium-cli-test-job-chart/values.yaml
@@ -7,6 +7,12 @@ cluster_name: test
 cluster_cidr: 10.4.0.0/14
 test_script_cm: cilium-cli-test-script
 job_name: cilium-cli
+output:
+  enabled: true
+  pvc:
+    name: cilium-cli-output
+    size: 1G
+    storageClassName: ""
 vm_name: ""
 cluster_name_1: ""
 cluster_cidr_1: ""

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -3,6 +3,7 @@
 set -x
 set -e
 
+
 # Enable Relay
 cilium hubble enable
 
@@ -18,3 +19,7 @@ cilium connectivity test --all-flows
 
 # Retrieve Cilium  status
 cilium status
+
+# Grab a sysdump and move it to the persistent volume.
+cilium sysdump --output-filename cilium-sysdump-out
+mv cilium-sysdump-out.zip /output/cilium-sysdump-out.zip

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -18,3 +18,7 @@ cilium connectivity test --all-flows
 
 # Retrieve Cilium  status
 cilium status
+
+# Grab a sysdump and move it to the persistent volume.
+cilium sysdump --output-filename cilium-sysdump-out
+mv cilium-sysdump-out.zip /output/cilium-sysdump-out.zip

--- a/.github/in-cluster-test-scripts/external-workloads.sh
+++ b/.github/in-cluster-test-scripts/external-workloads.sh
@@ -10,3 +10,7 @@ cilium connectivity test --all-flows
 cilium status
 cilium clustermesh status
 cilium clustermesh vm status
+
+# Grab a sysdump and move it to the persistent volume.
+cilium sysdump --output-filename cilium-sysdump-out
+mv cilium-sysdump-out.zip /output/cilium-sysdump-out.zip

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -24,3 +24,7 @@ cilium connectivity test --all-flows
 
 # Retrieve Cilium status
 cilium status
+
+# Grab a sysdump and move it to the persistent volume.
+cilium sysdump --output-filename cilium-sysdump-out
+mv cilium-sysdump-out.zip /output/cilium-sysdump-out.zip

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -59,3 +59,9 @@ cilium --context "${CONTEXT1}" status
 cilium --context "${CONTEXT1}" clustermesh status
 cilium --context "${CONTEXT2}" status
 cilium --context "${CONTEXT2}" clustermesh status
+
+# Grab a sysdump and move it to the persistent volume.
+cilium --context "${CONTEXT1}" sysdump --output-filename cilium-sysdump-out-1
+mv cilium-sysdump-out-1.zip /output/cilium-sysdump-out-1.zip
+cilium --context "${CONTEXT2}" sysdump --output-filename cilium-sysdump-out-2
+mv cilium-sysdump-out-2.zip /output/cilium-sysdump-out-2.zip

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -120,8 +120,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -78,7 +78,8 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }} \
             --set job_name=cilium-cli-install \
-            --set test_script_cm=cilium-cli-test-script-install
+            --set test_script_cm=cilium-cli-test-script-install \
+            --set output.enabled=false
 
       - name: Add managed spot nodegroup
         run: |
@@ -107,9 +108,17 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }}
 
-      - name: Wait for test job
+      - name: Ensure that the job terminates successfully
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
+
+      - name: Copy the sysdump
+        run: |
+          helm install .github/cilium-cli-output \
+            --generate-name \
+            --set tag=${{ steps.vars.outputs.sha }}
+          kubectl wait pod/cilium-cli-output --for=condition=Ready --timeout 5m
+          kubectp cp pod/cilium-cli-output:/output/cilium-sysdump-out.zip cilium-sysdump-out.zip
 
       - name: Post-test information gathering
         if: ${{ failure() }}
@@ -117,8 +126,6 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -2,6 +2,7 @@ name: EKS (tunnel)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {}
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Ensure that the job terminates successfully
         run: |
-          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
+          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=15m
 
       - name: Copy the sysdump
         run: |
@@ -126,6 +126,7 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
+          kubectl get pvc --all-namespaces -o wide
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -130,6 +130,7 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
+          kubectl get pvc --all-namespaces -o wide
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -78,7 +78,8 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }} \
             --set job_name=cilium-cli-install \
-            --set test_script_cm=cilium-cli-test-script-install
+            --set test_script_cm=cilium-cli-test-script-install \
+            --set output.enabled=false
 
       - name: Add managed spot nodegroup
         run: |
@@ -107,9 +108,21 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }}
 
-      - name: Wait for test job
+      - name: Ensure that the job terminates successfully
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
+
+      - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
+        run: |
+          [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
+
+      - name: Copy the sysdump
+        run: |
+          helm install .github/cilium-cli-output \
+            --generate-name \
+            --set tag=${{ steps.vars.outputs.sha }}
+          kubectl wait pod/cilium-cli-output --for=condition=Ready --timeout 5m
+          kubectp cp pod/cilium-cli-output:/output/cilium-sysdump-out.zip cilium-sysdump-out.zip
 
       - name: Post-test information gathering
         if: ${{ failure() }}
@@ -117,8 +130,6 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -2,6 +2,7 @@ name: EKS (ENI)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {}
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Ensure that the job terminates successfully
         run: |
-          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
+          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=15m
 
       - name: Copy the sysdump
         run: |
@@ -175,6 +175,7 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide
+          kubectl get pvc --all-namespaces -o wide
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -2,6 +2,7 @@ name: External Workloads
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {}
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -106,7 +106,8 @@ jobs:
             --set job_name=cilium-cli-install \
             --set test_script_cm=cilium-cli-test-script-install \
             --set vm_name=${{ env.vmName }} \
-            --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }}
+            --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }} \
+            --set output.enabled=false
 
       - name: Wait for install job
         run: |
@@ -148,9 +149,17 @@ jobs:
             --set job_name=cilium-cli \
             --set test_script_cm=cilium-cli-test-script
 
-      - name: Wait for test job
+      - name: Ensure that the job terminates successfully
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
+
+      - name: Copy the sysdump
+        run: |
+          helm install .github/cilium-cli-output \
+            --generate-name \
+            --set tag=${{ steps.vars.outputs.sha }}
+          kubectl wait pod/cilium-cli-output --for=condition=Ready --timeout 5m
+          kubectp cp pod/cilium-cli-output:/output/cilium-sysdump-out.zip cilium-sysdump-out.zip
 
       - name: Post-test installation logs
         if: ${{ failure() }}
@@ -166,8 +175,6 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -89,9 +89,17 @@ jobs:
             --set cluster_name=${{ env.clusterName }} \
             --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }}
 
-      - name: Wait for job
+      - name: Ensure that the job terminates successfully
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=15m
+
+      - name: Copy the sysdump
+        run: |
+          helm install .github/cilium-cli-output \
+            --generate-name \
+            --set tag=${{ steps.vars.outputs.sha }}
+          kubectl wait pod/cilium-cli-output --for=condition=Ready --timeout 5m
+          kubectp cp pod/cilium-cli-output:/output/cilium-sysdump-out.zip cilium-sysdump-out.zip
 
       - name: Post-test information gathering
         if: ${{ failure() }}
@@ -99,8 +107,6 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl exec -n kube-system job/cilium-cli -- cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Ensure that the job terminates successfully
         run: |
-          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=15m
+          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=20m
 
       - name: Copy the sysdump
         run: |
@@ -107,6 +107,7 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl exec -n kube-system job/cilium-cli -- cilium status
           kubectl get pods --all-namespaces -o wide
+          kubectl get pvc --all-namespaces -o wide
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -2,6 +2,7 @@ name: GKE
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {}
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -98,8 +98,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload Artifacts

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Ensure that the job terminates successfully
         run: |
-          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=20m
+          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=25m
 
       - name: Copy the sysdump
         run: |
@@ -142,6 +142,7 @@ jobs:
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
+          kubectl get pvc --all-namespaces -o wide
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -2,6 +2,7 @@ name: Multicluster
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {}
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -124,23 +124,24 @@ jobs:
             --set cluster_name_1=${{ env.clusterName1 }} \
             --set cluster_name_2=${{ env.clusterName2 }} \
 
-      - name: Wait for test job
+      - name: Ensure that the job terminates successfully
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=20m
+
+      - name: Copy the sysdump
+        run: |
+          helm install .github/cilium-cli-output \
+            --generate-name \
+            --set tag=${{ steps.vars.outputs.sha }}
+          kubectl wait pod/cilium-cli-output --for=condition=Ready --timeout 5m
+          kubectp cp pod/cilium-cli-output:/output/cilium-sysdump-out-1.zip cilium-sysdump-out-1.zip
+          kubectp cp pod/cilium-cli-output:/output/cilium-sysdump-out-2.zip cilium-sysdump-out-2.zip
 
       - name: Post-test information gathering
         if: ${{ failure() }}
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli
-
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          export KUBECONFIG=kubeconfig-cluster1
           kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-cluster1
-
-          export KUBECONFIG=kubeconfig-cluster2
-          kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-cluster2
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE
@@ -151,14 +152,20 @@ jobs:
           gcloud container clusters delete ${{ env.clusterName2 }} --zone ${{ env.zone }} --quiet --async
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
-      - name: Upload artifacts
+      - name: Upload artifacts (1)
         if: ${{ failure() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
-          name: cilium-sysdump-out.zip
-          path: |
-            cilium-sysdump-cluster1.zip
-            cilium-sysdump-cluster2.zip
+          name: cilium-sysdump-out-1.zip
+          path: cilium-sysdump-out-1.zip
+          retention-days: 5
+
+      - name: Upload artifacts (2)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
+        with:
+          name: cilium-sysdump-out-2.zip
+          path: cilium-sysdump-out-2.zip
           retention-days: 5
 
       - name: Send slack notification


### PR DESCRIPTION
Moves workflows from using cilium-sysdump.zip to using the new, native implementation. ~As it is impossible to copy files from terminated pods without resorting to using PVs, I am proposing we use FIFOs to copy the sysdump from the pods while they're still running, which should lead to graceful job termination once read from.~

I am not entirely sure this will work as expected, though, and for that reason I am marking it as draft.