### PR TITLE
getFlows: support deadline flow returns

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -627,7 +627,7 @@ func (a *Action) getFlows(ctx context.Context, hubbleClient observer.ObserverCli
 	for {
 		res, err := b.Recv()
 		switch err {
-		case io.EOF, context.Canceled:
+		case io.EOF, context.Canceled, context.DeadlineExceeded:
 			return set, nil
 		case nil:
 		default:


### PR DESCRIPTION
previous to this commit an error would be returned
with no flows if a Deadline context was provided
to the target method.

so follow the same logic as a Cancel context being passed
in, the switch statement is updated to also return flows
if a Deadline is exceeded.

in this new case all flows received before the Deadline
will be returned.

Signed-off-by: ldelossa <louis.delos@isovalent.com>