### PR TITLE
test: Add cilium monitor support

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -156,8 +156,7 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 
 	a.Debug("Executing command", cmd)
 
-	// Warning: ExecInPod* does not use ctx, command cannot be cancelled.
-	stdout, stderr, err := pod.K8sClient.ExecInPodWithStderr(context.TODO(),
+	stdout, stderr, err := pod.K8sClient.ExecInPodWithStderr(ctx,
 		pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Labels["name"], cmd)
 
 	cmdName := cmd[0]

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -107,6 +107,9 @@ func (r *FlowRequirementResults) Merge(from *FlowRequirementResults) {
 	if r.FirstMatch < 0 || from.FirstMatch >= 0 && from.FirstMatch < r.FirstMatch {
 		r.FirstMatch = from.FirstMatch
 	}
+	if from.FirstMatch > r.LastMatch {
+		r.LastMatch = from.FirstMatch
+	}
 	if from.LastMatch > r.LastMatch {
 		r.LastMatch = from.LastMatch
 	}

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -489,9 +489,7 @@ func (ct *ConnectivityTest) waitForDNS(ctx context.Context, pod Pod) error {
 		r := time.After(time.Second)
 
 		target := "kube-dns.kube-system.svc.cluster.local"
-		// Warning: ExecInPod ignores ctx. Don't pass it here so we don't
-		// falsely expect the function to be able to be cancelled.
-		stdout, _, err := pod.K8sClient.ExecInPodWithStderr(context.TODO(), pod.Pod.Namespace, pod.Pod.Name,
+		stdout, _, err := pod.K8sClient.ExecInPodWithStderr(ctx, pod.Pod.Namespace, pod.Pod.Name,
 			"", []string{"nslookup", target})
 		if err == nil {
 			return nil
@@ -517,9 +515,7 @@ func (ct *ConnectivityTest) waitForIPCache(ctx context.Context, pod Pod) error {
 		// Don't retry lookups more often than once per second.
 		r := time.After(time.Second)
 
-		// Warning: ExecInPod ignores ctx. Don't pass it here so we don't
-		// falsely expect the function to be able to be cancelled.
-		stdout, err := pod.K8sClient.ExecInPod(context.TODO(), pod.Pod.Namespace, pod.Pod.Name,
+		stdout, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name,
 			"cilium-agent", []string{"cilium", "bpf", "ipcache", "list", "-o", "json"})
 		if err == nil {
 			var ic ipCache
@@ -599,9 +595,7 @@ func (ct *ConnectivityTest) waitForService(ctx context.Context, service Service)
 		// Don't retry lookups more often than once per second.
 		r := time.After(time.Second)
 
-		// Warning: ExecInPodWithStderr ignores ctx. Don't pass it here so we don't
-		// falsely expect the function to be able to be cancelled.
-		_, e, err := ct.client.ExecInPodWithStderr(context.TODO(),
+		_, e, err := ct.client.ExecInPodWithStderr(ctx,
 			pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Labels["name"],
 			[]string{"nslookup", service.Service.Name}) // BusyBox nslookup doesn't support any arguments.
 

--- a/connectivity/check/monitor.go
+++ b/connectivity/check/monitor.go
@@ -1,0 +1,114 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/internal/utils"
+)
+
+// Monitor keeps state about one Cilium Monitor instance.
+type Monitor struct {
+	name    string
+	greeted bool
+	done    chan struct{}
+	stdin   *utils.CtrlCReader
+	stdout  *utils.SyncBuffer
+	err     error
+	*Action // unnamed for logging convenience
+}
+
+// NewMonitor starts a new monitor command in background.
+func (a *Action) NewMonitor(pod Pod, opts ...string) *Monitor {
+	m := &Monitor{
+		Action: a,
+		name:   pod.Name(),
+		done:   make(chan struct{}, 1),
+		stdin:  utils.NewCtrlCReader(),
+		stdout: utils.NewSyncBuffer(),
+	}
+
+	cmd := append([]string{"cilium", "monitor"}, opts...)
+
+	go func() {
+		defer close(m.done)
+		m.err = pod.K8sClient.ExecInPodWithTTY(context.TODO(), pod.Pod.Namespace, pod.Pod.Name,
+			"cilium-agent", cmd, m.stdin, m.stdout)
+	}()
+
+	return m
+}
+
+// Wait waits until the monitor has started executing or until the 5
+// second timeout is exceeded.
+func (m *Monitor) Wait() {
+	// Return immediately if greeting has already been received
+	if m.greeted {
+		return
+	}
+
+	// Process initial monitor output
+	done := m.stdout.ReadUntilLine([]byte("Press Ctrl-C to quit"))
+
+	// Wait until Cilium monitor starts
+	ticker := time.NewTicker(defaults.MonitorStartGracePeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				m.Debugf("Cilium monitor for %s did not start properly: %s", m.name, err)
+				m.Stop()
+			} else {
+				m.Debugf("Cilium monitor for %s successfully started", m.name)
+				m.greeted = true
+			}
+			return
+		case <-m.done:
+			m.Warnf("Cilium monitor for %s exited before starting.", m.name)
+			return
+		case <-ticker.C:
+			m.Warnf("Cilium monitor for %s failed to start within %s.", m.name, defaults.MonitorStartGracePeriod)
+			m.Stop()
+			return
+		}
+	}
+}
+
+// Stop tells the monitor to stop execution.
+func (m *Monitor) Stop() {
+	m.stdin.Close()
+}
+
+// Output returns the monitor output after first waiting that the
+// monitor has stopped.
+func (m *Monitor) Output() (string, error) {
+	// Wait for the monitor to have stopped.
+	select {
+	case <-m.done:
+		return m.stdout.String(), m.err
+	case <-time.After(5 * time.Second):
+		return m.stdout.String(), fmt.Errorf("Timed out waiting for monitor to close, monitor is left running on the Cilium pod")
+	}
+}
+
+// Name returns the name of the Cilium pod this monitor is running on.
+func (m *Monitor) Name() string {
+	return m.name
+}

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -69,9 +69,9 @@ func getCiliumPolicyRevision(ctx context.Context, pod Pod) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	revision, err := strconv.Atoi(strings.Trim(stdout.String(), "'\n"))
+	revision, err := strconv.Atoi(strings.Trim(stdout.String(), "'\r\n"))
 	if err != nil {
-		return 0, fmt.Errorf("revision '%s' is not valid: %w", stdout.String(), err)
+		return 0, fmt.Errorf("revision %q is not valid: %w", stdout.String(), err)
 	}
 	return revision, nil
 }

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -80,6 +80,8 @@ const (
 
 	TunnelType = "vxlan"
 
+	ExecCloseTimeout = 2 * time.Second
+
 	WaitRetryInterval   = 2 * time.Second
 	WaitWarningInterval = 10 * time.Second
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -80,7 +80,8 @@ const (
 
 	TunnelType = "vxlan"
 
-	ExecCloseTimeout = 2 * time.Second
+	ExecCloseTimeout        = 2 * time.Second
+	MonitorStartGracePeriod = 5 * time.Second
 
 	WaitRetryInterval   = 2 * time.Second
 	WaitWarningInterval = 10 * time.Second

--- a/internal/utils/ctrlcreader.go
+++ b/internal/utils/ctrlcreader.go
@@ -1,0 +1,62 @@
+// Copyright 2020-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"io"
+	"sync"
+)
+
+// CtrlCReader implements a simple Reader/Closer that returns Ctrl-C and EOF
+// on Read() after it has been closed, and nothing before it.
+type CtrlCReader struct {
+	once sync.Once
+	done chan struct{}
+}
+
+// NewCtrlCReader returns a new CtrlCReader instance
+func NewCtrlCReader() *CtrlCReader {
+	return &CtrlCReader{
+		done: make(chan struct{}),
+	}
+}
+
+// Read implements io.Reader.
+// Blocks until we are done.
+func (cc *CtrlCReader) Read(p []byte) (n int, err error) {
+	select {
+	case <-cc.done:
+		if len(p) > 0 {
+			p[0] = byte(3) // Ctrl-C
+			if len(p) == 1 {
+				return 1, io.EOF
+			}
+			// Add Ctrl-D for the case Ctrl-C alone is ineffective.
+			// We skip this in the odd case where the buffer is too small
+			p[1] = byte(4) // Ctrl-D
+			return 2, io.EOF
+		}
+	}
+	return 0, nil
+}
+
+// Close implements io.Closer. Note that we do not return an error on
+// second close, not do we wait for the close to have any effect.
+func (cc *CtrlCReader) Close() error {
+	cc.once.Do(func() {
+		close(cc.done)
+	})
+	return nil
+}

--- a/internal/utils/syncbuffer.go
+++ b/internal/utils/syncbuffer.go
@@ -1,0 +1,123 @@
+// Copyright 2020-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+// SyncBuffer is a concurrency safe buffered Reader/Writer.  This is
+// needed as we are reading the initial lines concurrently with the
+// monitor execution.
+type SyncBuffer struct {
+	sync.Mutex
+	readReady *sync.Cond
+	buffer    bytes.Buffer
+	closed    bool
+}
+
+// NewSyncBuffer returns a new SyncBuffer instance
+func NewSyncBuffer() *SyncBuffer {
+	sb := &SyncBuffer{}
+	sb.readReady = sync.NewCond(&sb.Mutex)
+	return sb
+}
+
+// Read implements io.Reader.
+func (b *SyncBuffer) Read(p []byte) (n int, err error) {
+	b.Lock()
+	defer b.Unlock()
+	for !b.closed && b.buffer.Len() == 0 {
+		// Blocks but releases Mutex for the duration of the Wait
+		b.readReady.Wait()
+	}
+	l := b.buffer.Len()
+	if l == 0 && b.closed {
+		return 0, io.EOF
+	}
+	if l > len(p) {
+		l = len(p)
+	}
+	// Quaranteed to not block since we limit the buffer to the available length
+	return b.buffer.Read(p[:l])
+}
+
+// ReadBytes wraps bytes.Buffer.ReadBytes.
+func (b *SyncBuffer) ReadBytes(delim byte) (line []byte, err error) {
+	b.Lock()
+	defer b.Unlock()
+	// Wait without holding the mutex until buffer contains delim
+	for !b.closed && !bytes.Contains(b.buffer.Bytes(), []byte{delim}) {
+		// Blocks but releases Mutex for the duration of the Wait
+		b.readReady.Wait()
+
+		l := b.buffer.Len()
+		if l == 0 && b.closed {
+			return []byte{}, io.EOF
+		}
+	}
+	// Quaranteed to not block since we know buffer contains 'delim'
+	return b.buffer.ReadBytes(delim)
+}
+
+// Write implements io.Writer.
+func (b *SyncBuffer) Write(p []byte) (n int, err error) {
+	// Writer can expand the buffer so it should never block, so holding the lock is safe.
+	b.Lock()
+	defer b.Unlock()
+	defer b.readReady.Signal()
+	return b.buffer.Write(p)
+}
+
+// Close implements io.Closer.
+func (b *SyncBuffer) Close() error {
+	b.Lock()
+	b.closed = true
+	b.Unlock()
+	return nil
+}
+
+// String implements fmt.Stringer.
+func (b *SyncBuffer) String() string {
+	b.Lock()
+	defer b.Unlock()
+	return b.buffer.String()
+}
+
+// ReadUntilLine consumes lines from the buffer line at at a time, and
+// stops only after receiving a line starting with the 'greeting'.
+// Must read data byte at a time to not consume any data after
+func (b *SyncBuffer) ReadUntilLine(greeting []byte) (done chan error) {
+	done = make(chan error, 1)
+	go func() {
+		for {
+			// Read next line
+			line, err := b.ReadBytes('\n')
+			if bytes.HasPrefix(line, greeting) {
+				close(done)
+				return
+			}
+			if err != nil {
+				done <- err
+				close(done)
+				return
+			}
+		}
+	}()
+
+	return done
+}


### PR DESCRIPTION
Add `cilium monitor` for each `action.Run()` to gain some ground truth for analyzing flow validation failures, where some flows seem to be missing from Hubble.

Start cilium monitors on each Cilium node right before each action
run, and stop the monitors right after. Print the monitor output if
any warnings or fails were logged during the action execution.

The monitor output is currently very verbose, as it includes all flows from the node for the duration of the test. We will need to add filtering going forward, but there are caveats:
- filtering on IP could hide flows that have been incorrectly masqueraded
- filtering on the port number would hide DNS, and also NodePort etc flows
- There is background health check traffic that adds to the verbosity, but sometimes health checks use the same port as the tests, so it's hard to filter it all out.
