### PR TITLE
gke: Bump up gke timeout to 30 minutes

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   installation-and-connectivity:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
We do `kubectl wait` for 15 minutes, and we don't get sysdump if the
workflow gets cancelled.

Ref: https://github.com/cilium/cilium-cli/runs/2816183763?check_suite_focus=true

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>