### PR TITLE
Test failure output improvements

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -739,6 +739,11 @@ r:
 		// Attempt to validate all flows received during the Action so far,
 		// once per validation interval.
 		case <-interval.C:
+			if len(a.flows) == 0 {
+				// Suppress output like 'Validating 0 flows against 2 requirements'
+				// as it is futile to validate requirements when there are no flows yet.
+				continue r
+			}
 			a.Debugf("Validating %d flows against %d requirements", len(a.flows), len(reqs))
 
 			res = a.matchAllFlowRequirements(ctx, reqs)

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -157,6 +157,10 @@ func (a *Action) Run(f func(*Action)) {
 		a.printFlows(a.Source())
 		a.printFlows(a.Destination())
 	}
+	if a.failed && a.test.ctx.params.PauseOnFail {
+		a.Log("Pausing after action failure, press the Enter key to continue:")
+		fmt.Scanln()
+	}
 }
 
 // fail marks the Action as failed.

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -109,11 +109,6 @@ func (t *Test) willRun() bool {
 // finalize runs all the Test's registered finalizers.
 // Failures encountered executing finalizers will fail the Test.
 func (t *Test) finalize() {
-	if t.failed && t.Context().params.PauseOnFail {
-		t.Log("Pausing after test failure, press the Enter key to continue:")
-		fmt.Scanln()
-	}
-
 	t.Debug("Finalizing Test", t.Name())
 
 	for _, f := range t.finalizers {


### PR DESCRIPTION
- Move pause from test to action so that new no test traffic will be generated after the failing action
- Suppress logs for 0 flows received
