### PR TITLE
test: validate exit code and add HTTP drop testing

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -361,7 +361,14 @@ func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, req 
 			if f.SkipOnAggregation && a.test.ctx.FlowAggregation() {
 				continue
 			}
-			match(true, f, &flowCtx)
+			// "middle" flows can appear out of order due to e.g.,
+			// L7 flows being delivered from a proxy vs. SYN/FIN
+			// being delivered from the datapath. Allow for this
+			// by requesting more flows also when any of the
+			// "middle" matches fail.
+			if _, match, _ := match(true, f, &flowCtx); !match {
+				r.NeedMoreFlows = true
+			}
 		}
 
 		if !(req.Last.SkipOnAggregation && a.test.ctx.FlowAggregation()) {
@@ -436,7 +443,8 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 			tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
 		}
 
-		if a.expEgress.Drop {
+		if a.expEgress.Drop && !a.expEgress.L7Proxy {
+			// L3/L4 drop
 			egress = filters.FlowSetRequirement{
 				First: filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.SYN()), Msg: "SYN"},
 				Last:  filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.Drop()), Msg: "Drop"},
@@ -454,15 +462,19 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 				// Either side may FIN first
 				Last: filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.FIN()), Msg: "FIN"},
 				Except: []filters.FlowRequirement{
-					{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.Drop()), Msg: "Drop"},
+					{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.Drop()), Msg: "L3/L4 Drop"},
 				},
+			}
+			if a.expEgress.Drop {
+				// L7 drop
+				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.L7Drop()), Msg: "L7 Drop"})
 			}
 			if a.expEgress.HTTP.Status != "" || a.expEgress.HTTP.Method != "" || a.expEgress.HTTP.URL != "" {
 				code := uint32(math.MaxUint32)
 				if s, err := strconv.Atoi(a.expEgress.HTTP.Status); err == nil {
 					code = uint32(s)
 				}
-				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.HTTP(code, a.expEgress.HTTP.Method, a.expEgress.HTTP.URL), Msg: "HTTP"})
+				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.HTTP(code, a.expEgress.HTTP.Method, a.expEgress.HTTP.URL)), Msg: "HTTP"})
 			}
 			if p.RSTAllowed {
 				// For the connection termination, we will either see:

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -184,16 +185,25 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 	cmdStr := strings.Join(cmd, " ")
 
 	showOutput := false
+	expectedExitCode := a.expectedExitCode()
 	if err != nil {
-		if a.shouldSucceed() {
+		if expectedExitCode == 0 {
 			// Command failed unexpectedly, display output.
 			a.Failf("command %q failed: %s", cmdStr, err)
 			showOutput = true
 		} else {
-			a.test.Debugf("command %q failed as expected: %s", cmdStr, err)
+			exitCode, extractErr := a.extractExitCode(err)
+			if extractErr != nil {
+				a.test.Info(extractErr.Error())
+			}
+			if expectedExitCode == ExitAnyError || exitCode == expectedExitCode {
+				a.test.Debugf("command %q failed as expected: %s", cmdStr, err)
+			} else {
+				a.Failf("command %q failed with unexpected exit code: %s (expected %d, found %d)", cmdStr, err, expectedExitCode, exitCode)
+			}
 		}
 	} else {
-		if !a.shouldSucceed() {
+		if expectedExitCode != 0 {
 			// Command succeeded unexpectedly, display output.
 			a.Failf("command %q succeeded while it should have failed: %s", cmdStr, output.String())
 			showOutput = true
@@ -206,9 +216,36 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 	}
 }
 
-// shouldSucceed returns true if no drops are expected in either direction.
-func (a *Action) shouldSucceed() bool {
-	return !a.expEgress.Drop && !a.expIngress.Drop
+var exitCodeRegex = regexp.MustCompile("exit code ([0-9]+)")
+
+// extractExitCode extracts command exit code from ExecInPod() error output
+func (a *Action) extractExitCode(err error) (ExitCode, error) {
+	// Extract exit code from 'err'
+	m := exitCodeRegex.FindStringSubmatch(err.Error())
+	if len(m) != 2 || len(m[1]) == 0 {
+		return ExitInvalidCode, fmt.Errorf("Unable to extract exit code from error: %s", err.Error())
+	}
+	i, err := strconv.Atoi(m[1])
+	if err != nil {
+		return ExitInvalidCode, fmt.Errorf("Invalid exit code %q in error %s", m[1], err.Error())
+	}
+	if i < 0 || i > 255 {
+		return ExitInvalidCode, fmt.Errorf("Exit code %q out of range [0-255] in error %s", m[1], err.Error())
+	}
+	return ExitCode(i), nil
+}
+
+// expectedExitCode returns the expected shell exit code, or ExitAnyError for any value between 1-255.
+func (a *Action) expectedExitCode() ExitCode {
+	if a.expEgress.ExitCode == 0 && a.expIngress.ExitCode == 0 {
+		return 0 // success
+	}
+	// If egress and ingress expect the command to fail in different
+	// ways egress enforcement will cause the command to fail first.
+	if a.expEgress.ExitCode != 0 {
+		return a.expEgress.ExitCode
+	}
+	return a.expIngress.ExitCode
 }
 
 func (a *Action) printFlows(peer TestPeer) {

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -23,6 +23,10 @@ type TestPeer interface {
 	// to connect to this peer, e.g. 'http' or 'https'. Can be an empty string.
 	Scheme() string
 
+	// Path must return the path in the URL used, if any. Can be an empty
+	// string. Must include the leading '/' when not empty.
+	Path() string
+
 	// Address must return the network address of the peer. This can be a
 	// DNS name or an IP address.
 	Address() string
@@ -46,6 +50,10 @@ type Pod struct {
 	// (e.g. 'http')
 	scheme string
 
+	// Path to be used to connect to the service running in the Pod.
+	// (e.g. '/')
+	path string
+
 	// Port the Pods is listening on for connectivity tests.
 	port uint32
 }
@@ -61,6 +69,10 @@ func (p Pod) Name() string {
 
 func (p Pod) Scheme() string {
 	return p.scheme
+}
+
+func (p Pod) Path() string {
+	return p.path
 }
 
 // Address returns the network address of the Pod.
@@ -97,6 +109,12 @@ func (s Service) Scheme() string {
 	return "http"
 }
 
+// Path returns the string '/'.
+func (s Service) Path() string {
+	// No support for paths yet.
+	return ""
+}
+
 // Address returns the network address of the Service.
 func (s Service) Address() string {
 	return s.Service.Name
@@ -127,6 +145,11 @@ func (e ExternalWorkload) Name() string {
 
 // Scheme returns an empty string.
 func (e ExternalWorkload) Scheme() string {
+	return ""
+}
+
+// Path returns an empty string.
+func (e ExternalWorkload) Path() string {
 	return ""
 }
 
@@ -177,6 +200,9 @@ func (ie icmpEndpoint) Scheme() string {
 	return ""
 }
 
+func (ie icmpEndpoint) Path() string {
+	return ""
+}
 func (ie icmpEndpoint) Address() string {
 	return ie.host
 }
@@ -223,6 +249,10 @@ func (he httpEndpoint) Name() string {
 
 func (he httpEndpoint) Scheme() string {
 	return he.url.Scheme
+}
+
+func (he httpEndpoint) Path() string {
+	return he.url.Path
 }
 
 func (he httpEndpoint) Address() string {

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -163,6 +163,7 @@ var (
 	// ResultDNSOKDropCurlHTTPError expects a failed command, generating DNS traffic and a dropped flow.
 	ResultDNSOKDropCurlHTTPError = Result{
 		DNSProxy: true,
+		L7Proxy:  true,
 		Drop:     true,
 		ExitCode: ExitCurlHTTPError,
 	}
@@ -181,6 +182,7 @@ var (
 
 	// ResultDropCurlHTTPError expects a dropped flow and a failed command.
 	ResultDropCurlHTTPError = Result{
+		L7Proxy:  true,
 		Drop:     true,
 		ExitCode: ExitCurlHTTPError,
 	}
@@ -261,7 +263,7 @@ func (t *Test) WithExpectations(f ExpectationsFunc) *Test {
 	return nil
 }
 
-// getExpectations returns the expected results for a specific Action.
+// expectations returns the expected results for a specific Action.
 func (t *Test) expectations(a *Action) (egress, ingress Result) {
 	// Default to success.
 	if t.expectFunc == nil {

--- a/connectivity/filters/filters.go
+++ b/connectivity/filters/filters.go
@@ -124,6 +124,25 @@ func Drop() FlowFilterImplementation {
 	return &dropFilter{}
 }
 
+type l7DropFilter struct{}
+
+func (d *l7DropFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+	l7 := flow.GetL7()
+	if l7 == nil {
+		return false
+	}
+	return flow.GetVerdict() == flowpb.Verdict_DROPPED
+}
+
+func (d *l7DropFilter) String(fc *FlowContext) string {
+	return "l7 drop"
+}
+
+// L7Drop matches on drops reported by L7 proxied
+func L7Drop() FlowFilterImplementation {
+	return &l7DropFilter{}
+}
+
 type icmpFilter struct {
 	typ uint32
 }

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -78,7 +78,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		).
 		WithExpectations(
 			func(a *check.Action) (egress check.Result, ingress check.Result) {
-				return check.ResultDrop, check.ResultNone
+				return check.ResultDropCurlTimeout, check.ResultNone
 			})
 
 	// This policy only allows ingress into client from client2.
@@ -101,7 +101,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 			if a.Destination().HasLabel("kind", "echo") && !a.Source().HasLabel("other", "client") {
 				// TCP handshake fails both in egress and ingress when
 				// L3(/L4) policy drops at either location.
-				return check.ResultDrop, check.ResultDrop
+				return check.ResultDropCurlTimeout, check.ResultDropCurlTimeout
 			}
 			return check.ResultOK, check.ResultOK
 		})
@@ -126,8 +126,8 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 			}
 			return egress, check.ResultNone
 		}
-
-		return check.ResultDNSOKRequestDrop, check.ResultNone
+		// No HTTP proxy on other ports
+		return check.ResultDNSOKDropCurlTimeout, check.ResultNone
 	})
 
 	// This policy allows UDP to kube-dns and port 80 TCP to all 'world' endpoints.
@@ -141,7 +141,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 				return check.ResultOK, check.ResultNone
 			}
 			// PodToWorld traffic to port 443 will be dropped by the policy
-			return check.ResultDrop, check.ResultNone
+			return check.ResultDropCurlTimeout, check.ResultNone
 		})
 
 	// This policy allows L3 traffic to 1.0.0.0/24 (including 1.1.1.1), with the
@@ -154,7 +154,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address() == "1.0.0.1" {
 				// Expect packets for 1.0.0.1 to be dropped.
-				return check.ResultDrop, check.ResultNone
+				return check.ResultDropCurlTimeout, check.ResultNone
 			}
 			return check.ResultOK, check.ResultNone
 		})

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -16,9 +16,10 @@ func curl(peer check.TestPeer) []string {
 		"--silent", "--fail", "--show-error",
 		"--connect-timeout", "5",
 		"--output", "/dev/null",
-		fmt.Sprintf("%s://%s",
+		fmt.Sprintf("%s://%s%s",
 			peer.Scheme(),
-			net.JoinHostPort(peer.Address(), fmt.Sprint(peer.Port()))),
+			net.JoinHostPort(peer.Address(), fmt.Sprint(peer.Port())),
+			peer.Path()),
 	}
 }
 

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -140,7 +140,7 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 
 	// Manually construct an HTTP endpoint to override the destination IP
 	// and port of the request.
-	ep := check.HTTPEndpoint(name, fmt.Sprintf("%s://%s:%d", svc.Scheme(), node.Pod.Status.HostIP, np))
+	ep := check.HTTPEndpoint(name, fmt.Sprintf("%s://%s:%d%s", svc.Scheme(), node.Pod.Status.HostIP, np, svc.Path()))
 
 	// Create the Action with the original svc as this will influence what the
 	// flow matcher looks for in the flow logs.

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -34,6 +34,7 @@ func (s *podToWorld) Name() string {
 func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	chttp := check.HTTPEndpoint("cilium-io-http", "http://cilium.io")
 	chttps := check.HTTPEndpoint("cilium-io-https", "https://cilium.io")
+	chttpindex := check.HTTPEndpoint("cilium-io-http-index", "http://cilium.io/index.html")
 	jhttp := check.HTTPEndpoint("jenkins-cilium-io-http", "http://jenkins.cilium.io")
 
 	fp := check.FlowParameters{
@@ -53,6 +54,12 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		// With http, over port 80.
 		t.NewAction(s, fmt.Sprintf("http-to-cilium-io-%d", i), &client, chttp).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, curl(chttp))
+			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
+		})
+
+		// With http, over port 80, index.html
+		t.NewAction(s, fmt.Sprintf("http-to-cilium-io-index-%d", i), &client, chttpindex).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, curl(chttpindex))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 


### PR DESCRIPTION
Add support for validating test command exit code. This is useful for
separating different kind of error conditions, like HTTP errors
vs. connect or DNS timeouts.

L3/L4 policy drops cause curl timeouts (exit code 28). It looks like
we do not yet have any tests that actually get drops from the HTTP
proxy, which would be classified as an HTTP error (exit code 22).

Expose URL path to policy expectation logic. This helps returning
expected test outcomes when an HTTP policy filters by path.
    
Add filter for L7 drops.
    
Add new action to tests "pod-to-world" scenario where the target is
"google.com/index.html". Without policies this should work, but in
"to-fqdns" test case this is not allowed by the egress policy.
