### PR TITLE
Stream flows from Hubble instead of repeatedly polling ring buffer

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -151,36 +151,7 @@ type FlowParameters struct {
 	NodePort uint32
 }
 
-type flowsSet []*observer.GetFlowsResponse
-
-// lastTime returns the timestamp of the last flow in 'f', if any.
-func (f flowsSet) lastTime() (last time.Time) {
-	if len(f) == 0 {
-		return last
-	}
-	timestamp := f[len(f)-1].GetFlow().GetTime()
-	if timestamp == nil {
-		return last
-	}
-	return timestamp.AsTime()
-}
-
-// append adds any flows in 'from' to 'f', if the flow's timestamp is
-// later than the last one in 'f', returns the combined set.
-func (f flowsSet) append(from flowsSet) flowsSet {
-	last := f.lastTime()
-	if last.IsZero() {
-		return from
-	}
-	// Add all new flows with a later timestamp.
-	for _, flow := range from {
-		timestamp := flow.GetFlow().GetTime()
-		if timestamp == nil || timestamp.AsTime().After(last) {
-			f = append(f, flow)
-		}
-	}
-	return f
-}
+type flowsSet []*observer.GetFlowsResponse_Flow
 
 func (f flowsSet) Contains(filter filters.FlowFilterImplementation, fc *filters.FlowContext) (int, bool, *flow.Flow) {
 	if f == nil {
@@ -188,7 +159,7 @@ func (f flowsSet) Contains(filter filters.FlowFilterImplementation, fc *filters.
 	}
 
 	for i, res := range f {
-		flow := res.GetFlow()
+		flow := res.Flow
 		if filter.Match(flow, fc) {
 			return i, true, flow
 		}

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -469,14 +469,6 @@ func (ct *ConnectivityTest) ExternalWorkloads() map[string]ExternalWorkload {
 	return ct.externalWorkloads
 }
 
-func (ct *ConnectivityTest) StoreLastTimestamp(pod string, t time.Time) {
-	ct.lastFlowTimestamps[pod] = t
-}
-
-func (ct *ConnectivityTest) LoadLastTimestamp(pod string) time.Time {
-	return ct.lastFlowTimestamps[pod]
-}
-
 func (ct *ConnectivityTest) HubbleClient() observer.ObserverClient {
 	return ct.hubbleClient
 }

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -387,5 +387,5 @@ func (a *Action) Fatal(s ...interface{}) {
 // Fatalf must be called when an irrecoverable error was encountered during the Action.
 func (a *Action) Fatalf(format string, s ...interface{}) {
 	a.fail()
-	a.test.Fatalf(format, s)
+	a.test.Fatalf(format, s...)
 }

--- a/connectivity/tests/cidr.go
+++ b/connectivity/tests/cidr.go
@@ -55,7 +55,7 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, curl(ep))
 
-				a.ValidateFlows(ctx, src.Name(), src.Address(), a.GetEgressRequirements(check.FlowParameters{
+				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
 					RSTAllowed: true,
 				}))
 			})

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -56,17 +56,13 @@ func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &src, &dst).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ping(dst))
 
-				a.ValidateFlows(ctx, src.Name(), src.Pod.Status.PodIP, a.GetEgressRequirements(check.FlowParameters{
+				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,
 				}))
 
-				ingressFlowRequirements := a.GetIngressRequirements(check.FlowParameters{
+				a.ValidateFlows(ctx, dst, a.GetIngressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,
-				})
-
-				if ingressFlowRequirements != nil {
-					a.ValidateFlows(ctx, dst.Name(), dst.Pod.Status.PodIP, ingressFlowRequirements)
-				}
+				}))
 			})
 
 			i++

--- a/connectivity/tests/externalworkload.go
+++ b/connectivity/tests/externalworkload.go
@@ -48,17 +48,13 @@ func (s *podToExternalWorkload) Run(ctx context.Context, t *check.Test) {
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, wl).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ping(wl))
 
-				egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,
-				})
+				}))
 
-				a.ValidateFlows(ctx, pod.Name(), pod.Pod.Status.PodIP, egressFlowRequirements)
-				ingressFlowRequirements := a.GetIngressRequirements(check.FlowParameters{
+				a.ValidateFlows(ctx, wl, a.GetIngressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,
-				})
-				if ingressFlowRequirements != nil {
-					a.ValidateFlows(ctx, wl.Name(), wl.Address(), ingressFlowRequirements)
-				}
+				}))
 			})
 
 			i++

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -63,10 +63,10 @@ func (s *podToHost) Run(ctx context.Context, t *check.Test) {
 
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, node).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ping(node))
-				egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+
+				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,
-				})
-				a.ValidateFlows(ctx, pod.Name(), pod.Pod.Status.PodIP, egressFlowRequirements)
+				}))
 			})
 
 			i++

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -52,13 +52,8 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, echo).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, curl(echo))
 
-				egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{})
-				a.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
-
-				ingressFlowRequirements := a.GetIngressRequirements(check.FlowParameters{})
-				if ingressFlowRequirements != nil {
-					a.ValidateFlows(ctx, echo.Name(), echo.Pod.Status.PodIP, ingressFlowRequirements)
-				}
+				a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
+				a.ValidateFlows(ctx, echo, a.GetIngressRequirements(check.FlowParameters{}))
 			})
 
 			i++

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -51,11 +51,10 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, curl(svc))
 
-				egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
 					NodePort:    svc.Port(),
-				})
-				a.ValidateFlows(ctx, pod.Name(), pod.Address(), egressFlowRequirements)
+				}))
 			})
 
 			i++
@@ -159,12 +158,11 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 	t.NewAction(s, name, pod, svc).Run(func(a *check.Action) {
 		a.ExecInPod(ctx, curl(ep))
 
-		egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+		a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 			// The fact that curl is hitting the NodePort instead of the
 			// backend Pod's port is specified here. This will cause the matcher
 			// to accept both the NodePort and the ClusterIP (container) port.
 			NodePort: np,
-		})
-		a.ValidateFlows(ctx, pod.Name(), pod.Address(), egressFlowRequirements)
+		}))
 	})
 }

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -54,11 +54,10 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		t.NewAction(s, "https-to-google", client, ghttps).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, cmd)
 
-			egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
 				DNSRequired: true,
 				RSTAllowed:  true,
-			})
-			a.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
+			}))
 		})
 	}
 
@@ -69,11 +68,10 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		t.NewAction(s, "http-to-google", client, ghttp).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, cmd)
 
-			egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
 				DNSRequired: true,
 				RSTAllowed:  true,
-			})
-			a.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
+			}))
 		})
 	}
 
@@ -84,11 +82,10 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		t.NewAction(s, "http-to-www-google", client, wwwghttp).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, cmd)
 
-			egressFlowRequirements := a.GetEgressRequirements(check.FlowParameters{
+			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
 				DNSRequired: true,
 				RSTAllowed:  true,
-			})
-			a.ValidateFlows(ctx, client.Name(), client.Pod.Status.PodIP, egressFlowRequirements)
+			}))
 		})
 	}
 }


### PR DESCRIPTION
[@ti-mo]

This PR swaps out polling the Hubble ring buffer for flow streaming, which does not risk losing out on flows in between polls. On high-traffic clusters, the Hubble ring might get completely flushed out by the time a second poll comes in. Many workarounds for this have been merged in past weeks, but it was a bit of a losing battle.

This approach doesn't execute as quickly (since Hubble Relay buffers flows to re-order them) but we might be able to improve things over time there. We might be able to get away with completely disabling event re-ordering, but it's currently not possible to do without redeploying Hubble, which the connectivity test suite can't do.

Worth noting: the Hubble flow filter is now configured to only capture traffic related to the Pod executing the test. This will exclude health check traffic to echo pods, which seemed to have been an issue in the past.

Further improvements (will be spun out into smaller issues):
- Refactor the flow matcher to be testable, and add tests. I suspect there might be a few bugs here. It's complex and mostly undocumented. This PR initially included a unit test that created a full `ConnectivityTest` object, but I think it ended up testing a false negative, and I couldn't get it to pass anymore after moving some stuff around. Either way, the matcher should be able to provide a verdict given a single list of flows and a single list of requirements. Having to merge results and track offsets between matching rounds is going to be a source of bugs (although it might've been necessary in the previous implementation).
- When the above is in place, streaming log matching can be implemented. As soon as we've seen the flows that satisfy the test, abort the `ExecInPod` invocation and move on to the next test. (combo with #324)
- Add tests for the `ConnectivityTest` (the 'harness') itself. I'd included a dummy Scenario in the initial implementation, but this would be better hosted in an actual test suite where it won't rot.
- Move the matcher stuff out of `action.go`. It's just hard to navigate.