### PR TITLE
CODEOWNERS: Assign /connectivity to @cilium/cli

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@
 /.github/tools/ @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /cmd/ @cilium/cli
-/connectivity/ @cilium/policy
+/connectivity/ @cilium/cli
 /hubble/ @cilium/hubble
 /install/azure.go @cilium/azure
 /internal/cli/ @cilium/cli


### PR DESCRIPTION
Most of the code under /connectivity doesn't require knowledge about
the policy engine. Re-assign it to @cilium/cli so that the review
responsibility is a bit more distributed.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>