### PR TITLE
cicd: guard scheduled jobs from running on forks

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
adds the necessary if guards to all schededuled CICD
jobs to stop them from running on forks.

Signed-off-by: ldelossa <louis.delos@isovalent.com>