### PR TITLE
connectivity: use the right test namespace in cnps

### DIFF
--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -49,7 +49,7 @@ func (k *K8sUninstaller) Uninstall(ctx context.Context) error {
 		return err
 	}
 
-	k.Log("🔥 Deleting cilium-test namespace...")
+	k.Log("🔥 Deleting %s namespace...", k.params.TestNamespace)
 	k.client.DeleteNamespace(ctx, k.params.TestNamespace, metav1.DeleteOptions{})
 
 	k.Log("🔥 Deleting Service accounts...")


### PR DESCRIPTION
Previously, the CNPs created during the connectivity test referenced `cilium-test` in `matchLabels` as opposed to the user-specified namespace. This commit addresses that by looking up potential matches and doing the proper replacement.