### PR TITLE
hubble: Wait for Cilium to start before deploying relay/ui

### DIFF
--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/hubble"
@@ -67,6 +68,8 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().BoolVar(&params.UI, "ui", false, "Enable Hubble UI")
 	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", false, "Automatically create CA if needed")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
+		"Timeout for Cilium to become ready before deploying Hubble components")
 
 	return cmd
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -216,6 +216,26 @@ func (c *Client) DeploymentIsReady(ctx context.Context, namespace, deployment st
 	return nil
 }
 
+// CheckDaemonSetStatus returns nil if the daemonset is ready, or a non-nil error otherwise.
+// This function considers a daemonset ready if all the pods in the daemonset is in ready
+// state.
+func (c *Client) CheckDaemonSetStatus(ctx context.Context, namespace, daemonset string) error {
+	d, err := c.GetDaemonSet(ctx, namespace, daemonset, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if d == nil {
+		return fmt.Errorf("daemonset is not available")
+	}
+
+	if d.Status.DesiredNumberScheduled != d.Status.NumberReady {
+		return fmt.Errorf("not all pods ready: desired %d ready %d", d.Status.DesiredNumberScheduled, d.Status.NumberReady)
+	}
+
+	return nil
+}
+
 func (c *Client) CreateNamespace(ctx context.Context, namespace string, opts metav1.CreateOptions) (*corev1.Namespace, error) {
 	return c.Clientset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, opts)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -24,10 +24,10 @@ import (
 	"github.com/cilium/cilium-cli/defaults"
 )
 
-var check = regexp.MustCompile(`^([v]|0|[1-9][0-9]*\.)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`).MatchString
+var versionRegexp = regexp.MustCompile(`^([v]|0|[1-9][0-9]*\.)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*\.*(0|[1-9][0-9]*)?`).MatchString
 
 func CheckVersion(version string) bool {
-	return check(version)
+	return versionRegexp(version)
 }
 
 func BuildImagePath(userImage, defaultImage, userVersion, defaultVersion string) string {


### PR DESCRIPTION
Hubble Relay and UI do not function properly if they are not managed by
Cilium. This commit modifies `cilium hubble enable` command to wait for
Cilium pods to become ready after the restart before deploying them.

Fixes #334

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>