### PR TITLE
workflows: invert external workloads setup

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -55,6 +55,20 @@ jobs:
           echo ::set-output name=sha::${SHA}
           echo ::set-output name=owner::${OWNER}
 
+      - name: Create GCP VM
+        run: |
+          gcloud compute instances create ${{ env.vmName }} \
+            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --zone ${{ env.zone }} \
+            --machine-type e2-custom-2-4096 \
+            --boot-disk-type pd-standard \
+            --boot-disk-size 10GB \
+            --preemptible \
+            --image-project ubuntu-os-cloud \
+            --image-family ubuntu-2010 \
+            --metadata hostname=${{ env.vmName }} \
+            --metadata-from-file startup-script=${{ env.vmStartupScript}}
+
       - name: Create GKE cluster
         id: cluster
         run: |
@@ -73,20 +87,6 @@ jobs:
       - name: Get cluster credentials
         run: |
           gcloud container clusters get-credentials ${{ env.clusterName }} --zone ${{ env.zone }}
-
-      - name: Create GCP VM
-        run: |
-          gcloud compute instances create ${{ env.vmName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-            --zone ${{ env.zone }} \
-            --machine-type e2-custom-2-4096 \
-            --boot-disk-type pd-standard \
-            --boot-disk-size 10GB \
-            --preemptible \
-            --image-project ubuntu-os-cloud \
-            --image-family ubuntu-2010 \
-            --metadata hostname=${{ env.vmName }} \
-            --metadata-from-file startup-script=${{ env.vmStartupScript}}
 
       - name: Create gcloud-free kubeconfig and load it in configmap
         run: |


### PR DESCRIPTION
We are sometimes hitting the following failure when creating the GCP VM:
```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - The resource 'projects/***/regions/us-west2/subnetworks/default' is not ready
```

From GCP documentation, this comes from simultaneous resource operations: https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-vm-creation

Since the GKE cluster creation is asynchronous, I suspect it is conflicting with the GCP VM creation. Reversing setup order.

PR for testing workflow changes: #377