### PR TITLE
install: wait until Cilium DS is up and running before restarting pods

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -76,6 +76,8 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Set ConfigMap entries (key=value)")
 	cmd.Flags().StringVar(&params.AgentImage, "agent-image", "", "Image path to use for Cilium agent")
 	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", "", "Image path to use for Cilium operator")
+	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
+		"Timeout for Cilium to become ready before restarting unmanaged pods")
 
 	cmd.Flags().StringVar(&params.Azure.ResourceGroupName, "azure-resource-group", "", "Azure resource group name the cluster is in (required)")
 	cmd.Flags().StringVar(&params.Azure.SubscriptionName, "azure-subscription", "", "Azure subscription name the cluster is in (default `az account show`)")


### PR DESCRIPTION
When a CNI binary plugin is not available, kubelet will use the next one
to setup thc container's networking. Due this behavior, cilium-cli
should wait until cilium-agent containers are up and running to
guarantee that Cilium's CNI binary and configuration are deployed in the
host. Thenceforth cilium-cli can safely restart the pods managed by other
CNI plugins which will cause kubernetes to schedule a new pod and that pod
will be managed by Cilium.

Signed-off-by: André Martins <andre@cilium.io>