### PR TITLE
connectivity: remove Warn(f) from Test and Action

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -74,9 +74,6 @@ type Action struct {
 
 	// failed is true when Fail was called on the Action
 	failed bool
-
-	// warned is true when Warn was called on the Action
-	warned bool
 }
 
 func newAction(t *Test, name string, s Scenario, src *Pod, dst TestPeer) *Action {
@@ -168,7 +165,7 @@ func (a *Action) Run(f func(*Action)) {
 	// Print flow buffer if any failures or warnings occurred.
 	// TODO(timo): printFlows is a misnomer, this function actually prints
 	// the verdict annotated over the list of flows.
-	if a.test.ctx.PrintFlows() || a.failed || a.warned {
+	if a.test.ctx.PrintFlows() || a.failed {
 		a.printFlows(a.Source())
 		a.printFlows(a.Destination())
 	}

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -134,17 +134,6 @@ func (ct *ConnectivityTest) failedActions() []*Action {
 	return out
 }
 
-// warnings returns the total amount of warnings across all Tests.
-func (ct *ConnectivityTest) warnings() uint {
-	var out uint
-
-	for _, t := range ct.tests {
-		out = out + t.warnings
-	}
-
-	return out
-}
-
 // NewConnectivityTest returns a new ConnectivityTest.
 func NewConnectivityTest(client *k8s.Client, p Parameters) (*ConnectivityTest, error) {
 	if err := p.validate(); err != nil {
@@ -288,7 +277,6 @@ func (ct *ConnectivityTest) report() error {
 	nst := len(skippedTests)
 	nss := len(skippedScenarios)
 	nf := len(failed)
-	nw := ct.warnings()
 
 	if nf > 0 {
 		ct.Header("📋 Test Report")
@@ -296,7 +284,7 @@ func (ct *ConnectivityTest) report() error {
 		// There are failed tests, fetch all failed actions.
 		fa := len(ct.failedActions())
 
-		ct.Failf("%d/%d tests failed (%d/%d actions), %d warnings, %d tests skipped, %d scenarios skipped:", nf, nt-nst, fa, na, nw, nst, nss)
+		ct.Failf("%d/%d tests failed (%d/%d actions), %d tests skipped, %d scenarios skipped:", nf, nt-nst, fa, na, nst, nss)
 
 		// List all failed actions by test.
 		for _, t := range failed {
@@ -309,7 +297,7 @@ func (ct *ConnectivityTest) report() error {
 		return fmt.Errorf("%d tests failed", nf)
 	}
 
-	ct.Headerf("✅ All %d tests (%d actions) successful, %d warnings, %d tests skipped, %d scenarios skipped.", nt-nst, na, nw, nst, nss)
+	ct.Headerf("✅ All %d tests (%d actions) successful, %d tests skipped, %d scenarios skipped.", nt-nst, na, nst, nss)
 
 	return nil
 }

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -201,17 +201,6 @@ func (t *Test) flush() {
 	t.logBuf = nil
 }
 
-// flushWarnings displays the warnings encountered during the Test.
-func (t *Test) flushWarnings() {
-	if t.warnBuf.Len() > 0 {
-		t.Headerf("Warnings encountered during %s:", t.Name())
-
-		if _, err := io.Copy(t.ctx.params.Writer, t.warnBuf); err != nil {
-			panic(err)
-		}
-	}
-}
-
 // Headerf prints a formatted, indented header inside the test log scope.
 // Headers are not internally buffered.
 func (t *Test) Headerf(format string, a ...interface{}) {
@@ -250,22 +239,6 @@ func (t *Test) Info(a ...interface{}) {
 // Infof logs a formatted informational message.
 func (t *Test) Infof(format string, a ...interface{}) {
 	t.logf(info+" "+format, a...)
-}
-
-// Warn logs a warning message. Warnings are written to a separate warning
-// buffer and shown at the end of the test.
-func (t *Test) Warn(a ...interface{}) {
-	t.warn()
-	fmt.Fprint(t.warnBuf, testPrefix+warn+" ")
-	fmt.Fprintln(t.warnBuf, a...)
-}
-
-// Warnf logs a formatted warning message. Warnings are written to a separate
-// warning buffer and shown at the end of the test.
-func (t *Test) Warnf(format string, a ...interface{}) {
-	t.warn()
-	fmt.Fprint(t.warnBuf, testPrefix+warn+" ")
-	fmt.Fprintf(t.warnBuf, format+"\n", a...)
 }
 
 // Fail marks the Test as failed and logs a failure message.
@@ -342,28 +315,6 @@ func (a *Action) Info(s ...interface{}) {
 // Infof logs a formatted debug message.
 func (a *Action) Infof(format string, s ...interface{}) {
 	a.test.Infof(format, s...)
-}
-
-// Warn must be called when a warning is detected performing the Action.
-//
-// Action name is prepended to the warning as they are displayed separately
-// at the end of a Test.
-func (a *Action) Warn(s ...interface{}) {
-	a.warned = true
-
-	p := []interface{}{fmt.Sprintf("[%s]", a.String())}
-	p = append(p, s...)
-
-	a.test.Warn(p...)
-}
-
-// Warnf must be called when a warning is detected performing the Action.
-//
-// Action name is prepended to the warning as they are displayed separately
-// at the end of a Test.
-func (a *Action) Warnf(format string, s ...interface{}) {
-	a.warned = true
-	a.test.Warnf(fmt.Sprintf("[%s] ", a.String())+format, s...)
 }
 
 // Fail must be called when the Action is unsuccessful.

--- a/connectivity/tests/dummy.go
+++ b/connectivity/tests/dummy.go
@@ -31,12 +31,10 @@ func (s *dummy) Run(ctx context.Context, t *check.Test) {
 		a.Log("logging")
 		a.Debug("debugging")
 		a.Info("informing")
-		a.Warn("warning")
 	})
 
 	t.NewAction(s, "action-2", nil, nil).Run(func(a *check.Action) {
 		a.Log("logging")
-		a.Warn("warning")
 		a.Fatal("killing :(")
 		a.Fail("failing (this should not be printed)")
 	})


### PR DESCRIPTION
This proved a bit difficult to use in practice. With output of successful test runs now being hidden in CI, things need to fail to pop up. We cannot have things failing and throwing warnings without anyone noticing.

Failed finalizers will now cause an error. Finalizers are not supposed to fail, at least not silently.

Errors polling the Hubble buffer now also fail the test, but this behaviour is already being removed in the open Hubble streaming PR. (#319)

Note: `ConnectivityTest` still has `Warn(f)`, but it's purely cosmetical and not integrated into the rest of the test suite.

This is an alternative proposal to #327.