### PR TITLE
ci: fix the go vendoring check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
         go mod tidy
         go mod vendor
         go mod verify
-        git diff --exit-code
+        test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
 
     - name: Build
       run: make


### PR DESCRIPTION
Before this patch, git diff was used to ensure that Go modules were properly vendored. While it could catch a failure to update a vendored module, it would not fail when a module was not vendored (untracked).

This patch uses git status instead of git diff, effectively catching untracked vendored modules as well.