### PR TITLE
install: re-enable version validation for non-default images

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -1070,7 +1070,7 @@ func (p *Parameters) validate() error {
 
 		p.configOverwrites[t[0]] = t[1]
 	}
-	if p.AgentImage != "" || p.OperatorImage != "" {
+	if p.AgentImage != defaults.AgentImage || p.OperatorImage != defaults.OperatorImage {
 		return nil
 	} else if !utils.CheckVersion(p.Version) && p.Version != "" {
 		return fmt.Errorf("invalid syntax %q for image tag", p.Version)


### PR DESCRIPTION
After commit 03bbc81da1c1 ("install: set the default images at the cli
flag level") the command `cilium install --version foobar` would no
longer hit the version check, while previously such a version would be
rejected (unless a custom agent/operator image was specified):

```
invalid parameters: invalid syntax "foobar" for image tag
```

Re-enabled the version tag check for the default image.

Fixes: 03bbc81da1c1 ("install: set the default images at the cli flag level")