### PR TITLE
Revert "install: set the default images at the cli flag level"

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -74,8 +74,8 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.Encryption, "encryption", "disabled", "Enable encryption of all workloads traffic { disabled | ipsec | wireguard }")
 	cmd.Flags().BoolVar(&params.NodeEncryption, "node-encryption", false, "Enable encryption of all node to node traffic")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Set ConfigMap entries (key=value)")
-	cmd.Flags().StringVar(&params.AgentImage, "agent-image", defaults.AgentImage, "Image path to use for Cilium agent")
-	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", defaults.OperatorImage, "Image path to use for Cilium operator")
+	cmd.Flags().StringVar(&params.AgentImage, "agent-image", "", "Image path to use for Cilium agent")
+	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", "", "Image path to use for Cilium operator")
 	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
 		"Timeout for Cilium to become ready before restarting unmanaged pods")
 
@@ -150,8 +150,8 @@ cilium upgrade --version v1.9.8
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait for status")
-	cmd.Flags().StringVar(&params.AgentImage, "agent-image", defaults.AgentImage, "Image path to use for Cilium agent")
-	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", defaults.OperatorImage, "Image path to use for Cilium operator")
+	cmd.Flags().StringVar(&params.AgentImage, "agent-image", "", "Image path to use for Cilium agent")
+	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", "", "Image path to use for Cilium operator")
 
 	return cmd
 }


### PR DESCRIPTION
This reverts commit 03bbc81da1c161b045ed195d0f62c362d142d1b6.

fqOperatorImage() sets the default image based on k.params.DatapathMode
so that utils.BuildImagePath() uses the correct default operator image.

With the commit being reverted, however, the install command never uses
the default operator image because k.params.OperatorImage is always set
to quay.io/cilium/operator-generic.

Ref: https://github.com/cilium/cilium-cli/blob/03bbc81da1c161b045ed195d0f62c362d142d1b6/install/install.go#L1115

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>