### PR TITLE
Partially Revert #277

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -49,7 +49,6 @@ type deploymentParameters struct {
 	Affinity       *corev1.Affinity
 	ReadinessProbe *corev1.Probe
 	Labels         map[string]string
-	Annotations    map[string]string
 }
 
 func newDeployment(p deploymentParameters) *appsv1.Deployment {
@@ -73,7 +72,6 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 						"name": p.Name,
 						"kind": p.Kind,
 					},
-					Annotations: make(map[string]string, len(p.Annotations)),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -111,9 +109,6 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 
 	for k, v := range p.Labels {
 		dep.Spec.Template.ObjectMeta.Labels[k] = v
-	}
-	for k, v := range p.Annotations {
-		dep.Spec.Template.ObjectMeta.Annotations[k] = v
 	}
 
 	return dep
@@ -321,7 +316,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					},
 				},
 				ReadinessProbe: newLocalReadinessProbe(8080, "/"),
-				Annotations:    map[string]string{"io.cilium.proxy-visibility": "<Ingress/8080/TCP/HTTP>"},
 			})
 
 			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeployment, metav1.CreateOptions{})

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -251,12 +251,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:        ClientDeploymentName,
-			Kind:        kindClientName,
-			Port:        8080,
-			Image:       defaults.ConnectivityCheckAlpineCurlImage,
-			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
-			Annotations: map[string]string{"io.cilium.proxy-visibility": "<Egress/53/ANY/DNS>"},
+			Name:    ClientDeploymentName,
+			Kind:    kindClientName,
+			Port:    8080,
+			Image:   defaults.ConnectivityCheckAlpineCurlImage,
+			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
@@ -269,13 +268,12 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client2 deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:        Client2DeploymentName,
-			Kind:        kindClientName,
-			Port:        8080,
-			Image:       defaults.ConnectivityCheckAlpineCurlImage,
-			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
-			Labels:      map[string]string{"other": "client"},
-			Annotations: map[string]string{"io.cilium.proxy-visibility": "<Egress/53/ANY/DNS>"},
+			Name:    Client2DeploymentName,
+			Kind:    kindClientName,
+			Port:    8080,
+			Image:   defaults.ConnectivityCheckAlpineCurlImage,
+			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
+			Labels:  map[string]string{"other": "client"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION
this PR partially reverts https://github.com/cilium/cilium-cli/pull/277. there is no issue in the PR itself, but looks like there is a potential cilium bug with nodeport when used with http visibility annotation in eks. 

i'll follow up with more details about the nodeport issue in https://github.com/cilium/cilium-cli/issues/355

all the recent failures seem to be hitting the same issue: https://github.com/cilium/cilium-cli/actions/workflows/eks.yaml?query=event%3Aschedule