### PR TITLE
install: rename `DeploymentIsReady` to `CheckDeploymentStatus`

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -411,7 +411,7 @@ type k8sClusterMeshImplementation interface {
 	CreateDeployment(ctx context.Context, namespace string, deployment *appsv1.Deployment, opts metav1.CreateOptions) (*appsv1.Deployment, error)
 	GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error)
 	DeleteDeployment(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
-	DeploymentIsReady(ctx context.Context, namespace, deployment string) error
+	CheckDeploymentStatus(ctx context.Context, namespace, deployment string) error
 	CreateService(ctx context.Context, namespace string, service *corev1.Service, opts metav1.CreateOptions) (*corev1.Service, error)
 	DeleteService(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	GetService(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Service, error)
@@ -1008,9 +1008,9 @@ retry:
 }
 
 func (k *K8sClusterMesh) waitForDeployment(ctx context.Context) error {
-	k.Log("⌛ [%s] Waiting deployment %s to become ready...", k.client.ClusterName(), defaults.ClusterMeshDeploymentName)
+	k.Log("⌛ [%s] Waiting for deployment %s to become ready...", k.client.ClusterName(), defaults.ClusterMeshDeploymentName)
 
-	for k.client.DeploymentIsReady(ctx, k.params.Namespace, defaults.ClusterMeshDeploymentName) != nil {
+	for k.client.CheckDeploymentStatus(ctx, k.params.Namespace, defaults.ClusterMeshDeploymentName) != nil {
 		select {
 		case <-time.After(time.Second):
 		case <-ctx.Done():

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -577,7 +577,7 @@ func (ct *ConnectivityTest) waitForDeployments(ctx context.Context, client *k8s.
 	ctx, cancel := context.WithTimeout(ctx, ct.params.podReadyTimeout())
 	defer cancel()
 	for _, name := range deployments {
-		for client.DeploymentIsReady(ctx, ct.params.TestNamespace, name) != nil {
+		for client.CheckDeploymentStatus(ctx, ct.params.TestNamespace, name) != nil {
 			select {
 			case <-time.After(time.Second):
 			case <-ctx.Done():

--- a/install/install.go
+++ b/install/install.go
@@ -983,7 +983,7 @@ type k8sInstallerImplementation interface {
 	CreateDeployment(ctx context.Context, namespace string, deployment *appsv1.Deployment, opts metav1.CreateOptions) (*appsv1.Deployment, error)
 	GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error)
 	PatchDeployment(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.Deployment, error)
-	DeploymentIsReady(ctx context.Context, namespace, deployment string) error
+	CheckDeploymentStatus(ctx context.Context, namespace, deployment string) error
 	DeleteNamespace(ctx context.Context, namespace string, opts metav1.DeleteOptions) error
 	CreateNamespace(ctx context.Context, namespace string, opts metav1.CreateOptions) (*corev1.Namespace, error)
 	GetNamespace(ctx context.Context, namespace string, options metav1.GetOptions) (*corev1.Namespace, error)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -197,7 +197,7 @@ func (c *Client) PatchDeployment(ctx context.Context, namespace, name string, pt
 	return c.Clientset.AppsV1().Deployments(namespace).Patch(ctx, name, pt, data, opts)
 }
 
-func (c *Client) DeploymentIsReady(ctx context.Context, namespace, deployment string) error {
+func (c *Client) CheckDeploymentStatus(ctx context.Context, namespace, deployment string) error {
 	d, err := c.GetDeployment(ctx, namespace, deployment, metav1.GetOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
From the method name alone one might assume it to return a `bool` rather
than an `error`. Rename the method to avoid this confusion.

This is also in line with the `CheckDaemonSetStatus` method which serves
the same purpose for `DaemonSet`s.