### PR TITLE
.github: enable Hubble relay in external workloads test

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -11,6 +11,9 @@ cilium install \
   --kube-proxy-replacement=strict \
   --native-routing-cidr="${CLUSTER_CIDR}"
 
+# Enable Relay
+cilium hubble enable
+
 # Wait for Cilium status to be ready
 cilium status --wait
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GKE](https://github.com/cilium/cilium-cli/workflows/GKE/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AGKE)
 [![AKS](https://github.com/cilium/cilium-cli/workflows/AKS/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AAKS)
 [![Multicluster](https://github.com/cilium/cilium-cli/workflows/Multicluster/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AMulticluster)
+[![External Workloads](https://github.com/cilium/cilium-cli/actions/workflows/externalworkloads.yaml/badge.svg)](https://github.com/cilium/cilium-cli/actions/workflows/externalworkloads.yaml)
 
 ## Installation
 


### PR DESCRIPTION
Currently the external workloads test doesn't use Hubble. Enable it
during installation, which will help to debug failures happening during
the test.