### PR TITLE
Add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+All members of the Cilium community must abide by the [Cilium Community Code of
+Conduct](https://github.com/cilium/cilium/blob/master/CODE_OF_CONDUCT.md). Only
+by respecting each other can we develop a productive, collaborative community.
+If you would like to report a violation of the code of contact, please contact
+any of the maintainers or our mediator, Beatriz Martinez <beatriz@cilium.io>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to Cilium CLI
+
+## Contribution workflow
+
+Cilium CLI uses GitHub for collaborative development. Please use GitHub issues
+to discuss proposals and use pull requests to suggest changes. For more
+information see the [Cilium Development
+Guide](https://docs.cilium.io/en/latest/contributing/development/).
+
+## Slack
+
+Most developers are using the [Cilium & eBPF
+Slack](https://docs.cilium.io/en/latest/community/#slack) to communicate
+outside of GitHub.
+
+## Code of conduct
+
+All members of the Cilium community must abide by the [Cilium Community Code of
+Conduct](https://github.com/cilium/cilium/blob/master/CODE_OF_CONDUCT.md). Only
+by respecting each other can we develop a productive, collaborative community.
+If you would like to report a violation of the code of contact, please contact
+any of the maintainers or our mediator, Beatriz Martinez <beatriz@cilium.io>.


### PR DESCRIPTION
`CONTRIBUTING.md` is based on https://github.com/cilium/hubble/blob/master/CONTRIBUTING.md
Use the same code of conduct as the main Cilium repo.