### PR TITLE
status: Do not ignore warnings by default

### DIFF
--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -48,10 +48,10 @@ func newCmdStatus() *cobra.Command {
 			return err
 		},
 	}
-
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
-	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait for status to report success (no errors)")
+	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait for status to report success (no errors and warnings)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait for status")
+	cmd.Flags().BoolVar(&params.IgnoreWarnings, "ignore-warnings", false, "Ignore warnings when waiting for status to report success")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 
 	return cmd

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -153,11 +153,11 @@ func (k *K8sStatusCollector) deploymentStatus(ctx context.Context, status *Statu
 
 	notReady := stateCount.Desired - stateCount.Ready
 	if notReady > 0 {
-		status.AddAggregatedError(name, name, fmt.Errorf("%d pods of DaemonSet %s are not ready", notReady, name))
+		status.AddAggregatedError(name, name, fmt.Errorf("%d pods of Deployment %s are not ready", notReady, name))
 	}
 
 	if unavailable := stateCount.Unavailable - notReady; unavailable > 0 {
-		status.AddAggregatedWarning(name, name, fmt.Errorf("%d pods of DaemonSet %s are not available", unavailable, name))
+		status.AddAggregatedWarning(name, name, fmt.Errorf("%d pods of Deployment %s are not available", unavailable, name))
 	}
 
 	return false, nil

--- a/status/status.go
+++ b/status/status.go
@@ -160,6 +160,15 @@ func (s *Status) totalErrors() (total int) {
 	return total
 }
 
+func (s *Status) totalWarnings() (total int) {
+	for _, pods := range s.Errors {
+		for _, pod := range pods {
+			total += len(pod.Warnings)
+		}
+	}
+	return total
+}
+
 func (s *Status) parseCiliumSubsystemStatus(deployment, podName, subsystem string, status *models.Status) {
 	if status != nil {
 		s.parseCiliumSubsystemState(deployment, podName, subsystem, status.State, status.Msg)


### PR DESCRIPTION
This is an attempt to fix cilium/cilium#16636 - in the linked issue, `cilium status --wait` did continue even though there were still Hubble related warnings as the server was still initializing:


```
Run cilium status --wait
    /¯¯\
 /¯¯\__/¯¯\    Cilium:         1 warnings
 \__/¯¯\__/    Operator:       OK
 /¯¯\__/¯¯\    Hubble:         1 warnings
 \__/¯¯\__/    ClusterMesh:    disabled
    \__/

DaemonSet         cilium             Desired: 2, Ready: 2/2, Available: 2/2
Deployment        cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
Deployment        hubble-relay       Unavailable: 1/0
Containers:       cilium             Running: 2
                  cilium-operator    Running: 1
                  hubble-relay       
Image versions    cilium             quay.io/cilium/cilium-ci:7f20b3abd6837913f0deff225c301bcc11d3da3f: 2
                  cilium-operator    quay.io/cilium/operator-generic-ci:7f20b3abd6837913f0deff225c301bcc11d3da3f: 1
Warnings:         cilium             cilium-gnjq2    Hubble: Server not initialized
                  hubble-relay       hubble-relay    1 pods of DaemonSet hubble-relay are not available
```

This caused issues later on in the CI run, as Hubble Relay was clearly not ready.

This PR adds therefore adds a new **disabled-by-default** CLI flags to `cilium status`:

- `--ignore-warnings` which requires that there are no warnings before `cilium status --wait` returns.

This flags should help us to not continue a CI run if there are warnings (such as e.g. Hubble not being ready yet).

If users want to restore the old behavior, they can use `cilium status --wait --ignore-warnings`, which will return even if there are warnings. 

There is also a drive by fix to avoid calling the `hubble-relay` Deployment wrongly a DaemonSet.