### PR TITLE
workflows: Add `--timestamps` to `kubectl logs`

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -110,8 +110,8 @@ jobs:
       - name: Post-test information gathering
         if: ${{ failure() }}
         run: |
-          kubectl logs -n kube-system job/cilium-cli-install
-          kubectl logs -n kube-system job/cilium-cli
+          kubectl logs --timestamps -n kube-system job/cilium-cli-install
+          kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -114,8 +114,8 @@ jobs:
       - name: Post-test information gathering
         if: ${{ failure() }}
         run: |
-          kubectl logs -n kube-system job/cilium-cli-install
-          kubectl logs -n kube-system job/cilium-cli
+          kubectl logs --timestamps -n kube-system job/cilium-cli-install
+          kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -155,12 +155,12 @@ jobs:
       - name: Post-test installation logs
         if: ${{ failure() }}
         run: |
-          kubectl logs -n kube-system job/cilium-cli-install
+          kubectl logs --timestamps -n kube-system job/cilium-cli-install
 
       - name: Post-test information gathering
         if: ${{ failure() }}
         run: |
-          kubectl logs -n kube-system job/cilium-cli
+          kubectl logs --timestamps -n kube-system job/cilium-cli
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
           kubectl get pods --all-namespaces -o wide

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Post-test information gathering
         if: ${{ failure() }}
         run: |
-          kubectl logs -n kube-system job/cilium-cli
+          kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl exec -n kube-system job/cilium-cli -- cilium status
           kubectl get pods --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -132,7 +132,7 @@ jobs:
       - name: Post-test information gathering
         if: ${{ failure() }}
         run: |
-          kubectl logs -n kube-system job/cilium-cli
+          kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out


### PR DESCRIPTION
Timestamps are very useful when investigating a unknown CI failure. An
example where timestamps would yield us more information is for example
when a job runs into a timeout, such as e.g.
https://github.com/cilium/cilium-cli/runs/2904654177 where we suspect
that it might have run a bit longer than usual, but it's hard to tell.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>