### PR TITLE
Add helpful success message to select subcommands

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -544,6 +544,8 @@ func (k *K8sClusterMesh) Disable(ctx context.Context) error {
 
 	k.deleteCertificates(ctx)
 
+	k.Log("✅ ClusterMesh disabled.")
+
 	return nil
 }
 
@@ -613,6 +615,8 @@ func (k *K8sClusterMesh) Enable(ctx context.Context) error {
 	if _, err := k.client.CreateService(ctx, k.params.Namespace, svc, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+
+	k.Log("✅ ClusterMesh enabled!")
 
 	return nil
 }
@@ -909,7 +913,13 @@ func (k *K8sClusterMesh) Connect(ctx context.Context) error {
 	}
 
 	k.Log("✨ Connecting cluster %s -> %s...", remoteCluster.ClusterName(), k.client.ClusterName())
-	return k.patchConfig(ctx, remoteCluster, aiLocal)
+	if err := k.patchConfig(ctx, remoteCluster, aiLocal); err != nil {
+		return err
+	}
+
+	k.Log("✅ Connected cluster %s and %s!", k.client.ClusterName(), remoteCluster.ClusterName())
+
+	return nil
 }
 
 func (k *K8sClusterMesh) disconnectCluster(ctx context.Context, src, dst k8sClusterMeshImplementation) error {
@@ -956,7 +966,13 @@ func (k *K8sClusterMesh) Disconnect(ctx context.Context) error {
 		return err
 	}
 
-	return k.disconnectCluster(ctx, remoteCluster, k.client)
+	if err := k.disconnectCluster(ctx, remoteCluster, k.client); err != nil {
+		return err
+	}
+
+	k.Log("✅ Disconnected cluster %s and %s.", k.client.ClusterName(), remoteCluster.ClusterName())
+
+	return nil
 }
 
 type Status struct {
@@ -1318,6 +1334,8 @@ func (k *K8sClusterMesh) DeleteExternalWorkload(ctx context.Context, names []str
 	}
 	if count > 0 {
 		k.Log("✅ Removed %d external workload resources.", count)
+	} else {
+		k.Log("ℹ️ No external workload resources to remove.")
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, ", "))

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -207,7 +207,13 @@ func (k *K8sHubble) Disable(ctx context.Context) error {
 		return err
 	}
 
-	return k.disableHubble(ctx)
+	if err := k.disableHubble(ctx); err != nil {
+		return err
+	}
+
+	k.Log("✅ Hubble was successfully disabled.")
+
+	return nil
 }
 
 func (k *K8sHubble) enableHubble(ctx context.Context) error {
@@ -292,6 +298,8 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 			return err
 		}
 	}
+
+	k.Log("✅ Hubble was successfully enabled!")
 
 	return nil
 }

--- a/install/install.go
+++ b/install/install.go
@@ -1702,6 +1702,8 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 		}
 	}
 
+	k.Log("✅ Cilium was successfully installed! Run 'cilium status' to view installation health")
+
 	return nil
 }
 

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -117,5 +117,7 @@ func (k *K8sUninstaller) Uninstall(ctx context.Context) error {
 		}
 	}
 
+	k.Log("✅ Cilium was successfully uninstalled.")
+
 	return nil
 }

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -298,7 +298,7 @@ func newCmdExternalWorkloadInstall() *cobra.Command {
 				writer = os.Stdout
 			}
 			if err := cm.WriteExternalWorkloadInstallScript(context.Background(), writer); err != nil {
-				fatalf("Unable to create external worload install script: %s", err)
+				fatalf("Unable to create external workload install script: %s", err)
 			}
 			return nil
 		},


### PR DESCRIPTION
This PR fixes a fairly minor aesthetic issue when running some `cilium` sub-commands; there is no explicit confirmation that an operation finished successfully. In some cases, one may safely assume a successful operation in the absence of any error messages, but I think this makes it more obvious, and gives the opportunity to indicate a next step, especially for the more common operations like `install`.

I perused the `cilium` help output and identified a few candidates where a message like this might be helpful. I left some out because I felt it wasn't necessary (those that shell out to `kubectl port-forward` for example) but if a reviewer feels this list is incomplete, I'm happy to add to it. Same applies to any call to actions I may have missed an opportunity to include.

- [x] `cilium install/uninstall`
- [x] `cilium hubble enable/disable`
- [x] `cilium clustermesh enable/disable/connect/disconnect`
- [x] `cilium clustermesh external-workload create/delete`

I also fixed a typo in `newCmdExternalWorkloadInstall()` because I was there, and I saw it. :smile: 