### PR TITLE
uninstall: Wait for the test namespace to be terminated

### DIFF
--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -115,6 +115,16 @@ func (k *K8sUninstaller) Uninstall(ctx context.Context) error {
 			time.Sleep(retryInterval)
 			goto retry
 		}
+
+		k.Log("⌛ Waiting for %s namespace to be terminated...", k.params.TestNamespace)
+	retryNamespace:
+		// Wait for the test namespace to be terminated. Subsequent connectivity checks would fail
+		// if the test namespace is in Terminating state.
+		_, err = k.client.GetNamespace(ctx, k.params.TestNamespace, metav1.GetOptions{})
+		if err == nil {
+			time.Sleep(retryInterval)
+			goto retryNamespace
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Wait for the test namespace to be terminated when the `--wait` flag is
specified to avoid the situation where the next connectivity check fails
to deploy resources because the test namespace is in Terminating state.

Ref: #370

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>