### PR TITLE
check: Replace [www.]google.com with [jenkins.]cilium.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ To install Cilium while automatically detected:
     -------------------------------------------------------------------------------------------
     🔌 Validating from pod cilium-test/client-9f579495f-b2pcq to outside of cluster...
     -------------------------------------------------------------------------------------------
-    ✅ client pod client-9f579495f-b2pcq was able to communicate with google.com
+    ✅ client pod client-9f579495f-b2pcq was able to communicate with cilium.io
     -------------------------------------------------------------------------------------------
     🔌 Validating from pod cilium-test/client-9f579495f-b2pcq to local host...
     -------------------------------------------------------------------------------------------
@@ -191,7 +191,7 @@ To install Cilium while automatically detected:
     Jan  6 13:41:22.096: 10.0.0.11:45040 -> 172.217.168.46:443 to-stack FORWARDED (TCP Flags: ACK, RST)
     Jan  6 13:41:22.097: 172.217.168.46:443 -> 10.0.0.11:45040 to-endpoint FORWARDED (TCP Flags: ACK, FIN)
     Jan  6 13:41:22.097: 10.0.0.11:45040 -> 172.217.168.46:443 to-stack FORWARDED (TCP Flags: RST)
-    ✅ client pod client-9f579495f-b2pcq was able to communicate with google.com
+    ✅ client pod client-9f579495f-b2pcq was able to communicate with cilium.io
     -------------------------------------------------------------------------------------------
     🔌 Validating from pod cilium-test/client-9f579495f-b2pcq to local host...
     -------------------------------------------------------------------------------------------

--- a/connectivity/manifests/client-egress-to-fqdns-cilium-io.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-cilium-io.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   namespace: cilium-test
-  name: client-egress-to-fqdns-google
+  name: client-egress-to-fqdns-cilium-io
 spec:
   endpointSelector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
         - method: "GET"
           path: "/"
     toFQDNs:
-    - matchName: "google.com"
+    - matchName: "cilium.io"
   - toPorts:
     - ports:
       - port: "53"

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -35,8 +35,8 @@ var (
 	//go:embed manifests/client-ingress-from-client2.yaml
 	clientIngressFromClient2PolicyYAML string
 
-	//go:embed manifests/client-egress-to-fqdns-google.yaml
-	clientEgressToFQDNsGooglePolicyYAML string
+	//go:embed manifests/client-egress-to-fqdns-cilium-io.yaml
+	clientEgressToFQDNsCiliumIOPolicyYAML string
 
 	//go:embed manifests/echo-ingress-from-other-client.yaml
 	echoIngressFromOtherClientPolicyYAML string
@@ -79,7 +79,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	ct.NewTest("dns-only").WithPolicy(clientEgressOnlyDNSPolicyYAML).
 		WithScenarios(
 			tests.PodToPod(""),   // connects to other Pods directly, no DNS
-			tests.PodToWorld(""), // resolves google.com
+			tests.PodToWorld(""), // resolves cilium.io
 		).
 		WithExpectations(
 			func(a *check.Action) (egress check.Result, ingress check.Result) {
@@ -117,17 +117,17 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 			tests.PodToPod(""),
 		)
 
-	// This policy only allows port 80 to "google.com". DNS proxy enabled.
-	ct.NewTest("to-fqdns").WithPolicy(clientEgressToFQDNsGooglePolicyYAML).
+	// This policy only allows port 80 to "cilium.io". DNS proxy enabled.
+	ct.NewTest("to-fqdns").WithPolicy(clientEgressToFQDNsCiliumIOPolicyYAML).
 		WithScenarios(
 			tests.PodToWorld(""),
 		).WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 
-		if a.Destination().Port() == 80 && a.Destination().Address() == "google.com" {
+		if a.Destination().Port() == 80 && a.Destination().Address() == "cilium.io" {
 			egress = check.ResultDNSOK
 			egress.HTTP = check.HTTP{
 				Method: "GET",
-				URL:    "http://google.com/",
+				URL:    "http://cilium.io/",
 			}
 			return egress, check.ResultNone
 		}

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 )
 
-// PodToWorld sends multiple HTTP(S) requests to google.com
+// PodToWorld sends multiple HTTP(S) requests to cilium.io
 // from random client Pods.
 func PodToWorld(name string) check.Scenario {
 	return &podToWorld{
@@ -43,15 +43,15 @@ func (s *podToWorld) Name() string {
 }
 
 func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
-	ghttp := check.HTTPEndpoint("google-http", "http://google.com")
-	ghttps := check.HTTPEndpoint("google-https", "https://google.com")
-	wwwghttp := check.HTTPEndpoint("www-google-http", "http://www.google.com")
+	chttp := check.HTTPEndpoint("cilium-io-http", "http://cilium.io")
+	chttps := check.HTTPEndpoint("cilium-io-https", "https://cilium.io")
+	jhttp := check.HTTPEndpoint("jenkins-cilium-io-http", "http://jenkins.cilium.io")
 
 	// With https, over port 443.
 	if client := t.Context().RandomClientPod(); client != nil {
-		cmd := curl(ghttps)
+		cmd := curl(chttps)
 
-		t.NewAction(s, "https-to-google", client, ghttps).Run(func(a *check.Action) {
+		t.NewAction(s, "https-to-cilium-io", client, chttps).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, cmd)
 
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
@@ -63,9 +63,9 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 
 	// With http, over port 80.
 	if client := t.Context().RandomClientPod(); client != nil {
-		cmd := curl(ghttp)
+		cmd := curl(chttp)
 
-		t.NewAction(s, "http-to-google", client, ghttp).Run(func(a *check.Action) {
+		t.NewAction(s, "http-to-cilium-io", client, chttp).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, cmd)
 
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
@@ -75,11 +75,11 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		})
 	}
 
-	// With http to www.google.com.
+	// With http to jenkins.cilium.io
 	if client := t.Context().RandomClientPod(); client != nil {
-		cmd := curl(wwwghttp)
+		cmd := curl(jhttp)
 
-		t.NewAction(s, "http-to-www-google", client, wwwghttp).Run(func(a *check.Action) {
+		t.NewAction(s, "http-to-jenkins-cilium", client, jhttp).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, cmd)
 
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{


### PR DESCRIPTION
Use [jenkins.]cilium.io for FQDN tests to reduce external dependencies.

Ref: #367

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>