### PR TITLE
clustermesh: remove always true `(*K8sClusterMesh).Status log bool` parameter

### DIFF
--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -162,7 +162,7 @@ func newCmdClusterMeshStatus() *cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
-			if _, err := cm.Status(context.Background(), true); err != nil {
+			if _, err := cm.Status(context.Background()); err != nil {
 				fatalf("Unable to determine status:  %s", err)
 			}
 			return nil


### PR DESCRIPTION
`(*K8sClusterMesh).Status` is only called from `newCmdClusterMeshStatus`
which sets `log bool` to `true`. Remove the parameter, also from the called
methods where appropriate.
