### PR TITLE
install: Fix incorrect use of az command

### DIFF
--- a/install/azure.go
+++ b/install/azure.go
@@ -101,7 +101,7 @@ func (k *K8sInstaller) azureRetrieveSubscriptionID(ctx context.Context) error {
 // derives it from the user-given resource group and cluster name using
 // `az aks show`.
 func (k *K8sInstaller) azureRetrieveAKSNodeResourceGroup(ctx context.Context) error {
-	bytes, err := k.Exec("az", "aks", "show", "--subscription", k.params.Azure.SubscriptionID, "--resource-group", k.params.Azure.ResourceGroupName, "--name", k.params.ClusterName)
+	bytes, err := k.azExec("aks", "show", "--subscription", k.params.Azure.SubscriptionID, "--resource-group", k.params.Azure.ResourceGroupName, "--name", k.params.ClusterName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Without using the `k.azExec` helper, the user may have the az binary
configured to output to a different format other than `json`, which will
cause unmarshalling errors.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
