### PR TITLE
clustermesh: only wait for apiserver deployment if `--wait` is specified

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1205,9 +1205,11 @@ func (k *K8sClusterMesh) Status(ctx context.Context) (*Status, error) {
 		}
 	}
 
-	err = k.waitForDeployment(ctx)
-	if err != nil {
-		return nil, err
+	if k.params.Wait {
+		err = k.waitForDeployment(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	s.Connectivity, err = k.statusConnectivity(ctx)


### PR DESCRIPTION
Fixes: #384
Fixes: c171080ef434 ("clustermesh: Wait for deployment to be ready")