### PR TITLE
workflows: do not wait when installing on Kind

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -45,13 +45,15 @@ jobs:
 
       - name: Install Cilium
         run: |
-          cilium install --config monitor-aggregation=none
+          cilium install \
+            --wait=false \
+            --config monitor-aggregation=none
 
       - name: Enable Relay
         run: |
           cilium hubble enable --ui
 
-      - name: Status
+      - name: Wait for Cilium status to be ready
         run: |
           cilium status --wait
 


### PR DESCRIPTION
- Unneeded since we enable relay righ after anyway, which already requires waiting for status to be ready afterwards.
- Since by default we auto-rollback on `cilium install` failure once the hitting the wait timeout, this also clashes with the post-test information gathering step in case of error during `cilium install`.
- Consistent with other workflows.
