### PR TITLE
workflows: check status of Relay port-forward

### DIFF
--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -12,6 +12,7 @@ cilium status --wait
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s
+[[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
 cilium connectivity test --all-flows

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -12,6 +12,7 @@ cilium status --wait
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s
+[[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
 cilium connectivity test --all-flows

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -18,6 +18,7 @@ cilium status --wait
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s
+[[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
 cilium connectivity test --all-flows

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -50,6 +50,7 @@ cilium --context "${CONTEXT2}" clustermesh status --wait
 # Port forward Relay
 cilium --context "${CONTEXT1}" hubble port-forward&
 sleep 10s
+[[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
 cilium --context "${CONTEXT1}" connectivity test --multi-cluster "${CONTEXT2}" --test '!/pod-to-.*-nodeport' --all-flows

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -109,7 +109,8 @@ jobs:
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
-          sleep 5s
+          sleep 10s
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -60,7 +60,8 @@ jobs:
       - name: Relay Port Forward
         run: |
           cilium hubble port-forward&
-          sleep 5s
+          sleep 10s
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Connectivity Test
         run: |
@@ -84,10 +85,11 @@ jobs:
 
       - name: Relay Port Forward
         run: |
-          pkill -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           sleep 1s
           cilium hubble port-forward&
-          sleep 5s
+          sleep 10s
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Connectivity test
         run: |


### PR DESCRIPTION
Since we start a background process for port-forwarding Relay, we must check if it actually succeeded or failed before allowing workflows to continue.

We also standardize a 10s allowance time for port-forward to start.

This is a follow-up to the discussion here: https://github.com/cilium/cilium-cli/pull/336#discussion_r659661872