### PR TITLE
workflows: enhance `aws-node` DaemonSet testing

### DIFF
--- a/.github/in-cluster-test-scripts/eks-uninstall.sh
+++ b/.github/in-cluster-test-scripts/eks-uninstall.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -x
+set -e
+
+# Uninstall Cilium
+cilium uninstall --wait

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -92,6 +92,10 @@ jobs:
             --spot \
             --node-private-networking
 
+      - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
+        run: |
+          [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
+
       - name: Load cilium cli script in configmap
         run: |
           kubectl create configmap cilium-cli-test-script -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -116,6 +120,19 @@ jobs:
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+      - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed
+        if: ${{ success() }}
+        run: |
+          kubectl create configmap cilium-cli-test-script-uninstall -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/eks-uninstall.sh
+          helm install .github/cilium-cli-test-job-chart \
+            --generate-name \
+            --set tag=${{ steps.vars.outputs.sha }} \
+            --set cluster_name=${{ env.clusterName }} \
+            --set job_name=cilium-cli-uninstall \
+            --set test_script_cm=cilium-cli-test-script-uninstall
+          kubectl -n kube-system wait job/cilium-cli-uninstall --for=condition=complete --timeout=2m
+          [[ ! $(kubectl -n kube-system get ds/aws-node -o jsonpath="{.spec.template.spec.nodeSelector['io\.cilium/aws-node-enabled']}") ]]
 
       - name: Clean up EKS
         if: ${{ always() }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -92,6 +92,10 @@ jobs:
             --spot \
             --node-private-networking
 
+      - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
+        run: |
+          [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
+
       - name: Load cilium cli script in configmap
         run: |
           kubectl create configmap cilium-cli-test-script -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/eks.sh
@@ -107,10 +111,6 @@ jobs:
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
-      - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
-        run: |
-          [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
-
       - name: Post-test information gathering
         if: ${{ failure() }}
         run: |
@@ -120,6 +120,19 @@ jobs:
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+      - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed
+        if: ${{ success() }}
+        run: |
+          kubectl create configmap cilium-cli-test-script-uninstall -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/eks-uninstall.sh
+          helm install .github/cilium-cli-test-job-chart \
+            --generate-name \
+            --set tag=${{ steps.vars.outputs.sha }} \
+            --set cluster_name=${{ env.clusterName }} \
+            --set job_name=cilium-cli-uninstall \
+            --set test_script_cm=cilium-cli-test-script-uninstall
+          kubectl -n kube-system wait job/cilium-cli-uninstall --for=condition=complete --timeout=2m
+          [[ ! $(kubectl -n kube-system get ds/aws-node -o jsonpath="{.spec.template.spec.nodeSelector['io\.cilium/aws-node-enabled']}") ]]
 
       - name: Clean up EKS
         if: ${{ always() }}


### PR DESCRIPTION
In 619f9d5a7b799e3a43ec6af42ac7a3f3e1d83c8d, we improved the way the CLI handles the `aws-node` DaemonSet by using a node selector to evict its pods, allowing us to simply remove the selector on uninstall for a transparent user experience.

We build upon the existing workflow testing:
- Move up `aws-node` number of pods scheduled check right after install and node group have been created, which should be the earliest point at which we can verify if patching the node selector worked.
- Add an additional test at the end to uninstall Cilium and check that backtracking worked on the node selector patching.
- Add same testing to the `eks-tunnel` workflow. Because why not.

This is a follow-up to #208.