### PR TITLE
.github/workflows: use eksctl 0.54.0

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install eksctl CLI
         run: |
-          curl -LO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
+          curl -LO "https://github.com/weaveworks/eksctl/releases/download/0.54.0/eksctl_$(uname -s)_amd64.tar.gz"
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 
@@ -51,7 +51,7 @@ jobs:
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}
           fi
-          
+
           echo ::set-output name=sha::${SHA}
           echo ::set-output name=owner::${OWNER}
 

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install eksctl CLI
         run: |
-          curl -LO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
+          curl -LO "https://github.com/weaveworks/eksctl/releases/download/0.54.0/eksctl_$(uname -s)_amd64.tar.gz"
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 
@@ -51,7 +51,7 @@ jobs:
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}
           fi
-          
+
           echo ::set-output name=sha::${SHA}
           echo ::set-output name=owner::${OWNER}
 
@@ -106,7 +106,7 @@ jobs:
       - name: Wait for test job
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
-      
+
       - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
         run: |
           [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Go](https://github.com/cilium/cilium-cli/workflows/Go/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AGo)
 [![Kind](https://github.com/cilium/cilium-cli/workflows/Kind/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AKind)
-[![EKS](https://github.com/cilium/cilium-cli/actions/workflows/eks.yaml/badge.svg)](https://github.com/cilium/cilium-cli/actions/workflows/eks.yaml?query=workflow%3AEKS)
+[![EKS (ENI)](https://github.com/cilium/cilium-cli/actions/workflows/eks.yaml/badge.svg)](https://github.com/cilium/cilium-cli/actions/workflows/eks.yaml)
+[![EKS (tunnel)](https://github.com/cilium/cilium-cli/actions/workflows/eks-tunnel.yaml/badge.svg)](https://github.com/cilium/cilium-cli/actions/workflows/eks-tunnel.yaml)
 [![GKE](https://github.com/cilium/cilium-cli/workflows/GKE/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AGKE)
 [![AKS](https://github.com/cilium/cilium-cli/workflows/AKS/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AAKS)
 [![Multicluster](https://github.com/cilium/cilium-cli/workflows/Multicluster/badge.svg)](https://github.com/cilium/cilium-cli/actions?query=workflow%3AMulticluster)


### PR DESCRIPTION
The EKS workflows suddenly started failing with:

    Error: couldn't create node group filter from command line options: --spot is only valid with managed nodegroups (--managed)

On Jul 2 at around 15 CEST
(https://github.com/cilium/cilium-cli/actions/runs/992727965). The
release of eksctl 0.55.0 coincides with this time frame. As we pin the
EKS workflows to the latest eksctl release, it is likely that this
caused the failures.

Pin the eksctl to 0.54.0 for now which doesn't seem to exhibit this
behavior.

Ref: https://github.com/weaveworks/eksctl/issues/3929