### PR TITLE
hubble: Auto-detect Relay version 

### DIFF
--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -246,7 +246,7 @@ disable-server-tls: true
 }
 
 func (k *K8sHubble) relayImage() string {
-	return utils.BuildImagePath(k.params.RelayImage, defaults.RelayImage, k.params.RelayVersion, defaults.Version)
+	return utils.BuildImagePath(k.params.RelayImage, defaults.RelayImage, k.params.RelayVersion, k.ciliumVersion)
 }
 
 func (k *K8sHubble) disableRelay(ctx context.Context) error {

--- a/install/install.go
+++ b/install/install.go
@@ -1001,6 +1001,7 @@ type k8sInstallerImplementation interface {
 	CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 	CheckDaemonSetStatus(ctx context.Context, namespace, daemonset string) error
+	GetRunningCiliumVersion(ctx context.Context, namespace string) (string, error)
 }
 
 type K8sInstaller struct {

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/hubble"
 
 	"github.com/spf13/cobra"
@@ -62,8 +61,8 @@ func newCmdHubbleEnable() *cobra.Command {
 
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
 	cmd.Flags().BoolVar(&params.Relay, "relay", true, "Deploy Hubble Relay")
-	cmd.Flags().StringVar(&params.RelayImage, "relay-image", defaults.RelayImage, "Image path to use for Relay")
-	cmd.Flags().StringVar(&params.RelayVersion, "relay-version", defaults.Version, "Version of Relay to deploy")
+	cmd.Flags().StringVar(&params.RelayImage, "relay-image", "", "Image path to use for Relay")
+	cmd.Flags().StringVar(&params.RelayVersion, "relay-version", "", "Version of Relay to deploy")
 	cmd.Flags().StringVar(&params.RelayServiceType, "relay-service-type", "ClusterIP", "Type of Kubernetes service to expose Hubble Relay")
 	cmd.Flags().BoolVar(&params.UI, "ui", false, "Enable Hubble UI")
 	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", false, "Automatically create CA if needed")


### PR DESCRIPTION
This PR auto-detects the Relay image version when invoking `cilium hubble enable`.
It uses the exact same mechanism as `cilium clustermesh enable`, as both
 `clustermesh-apiserver` and `hubble-relay` share the version number with Cilium.

With this change, users who install a non-default Cilium version via
`cilium install --version v1.x.y` will not have to pass
`--relay-version` to `cilium hubble enable` anymore, as the recommended
version is auto-detected.