### PR TITLE
actions: Use cilium sysdump

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -120,8 +120,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -117,8 +117,7 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -117,8 +117,7 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -166,8 +166,7 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -99,8 +99,7 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl exec -n kube-system job/cilium-cli -- cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -98,8 +98,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload Artifacts

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -133,14 +133,13 @@ jobs:
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           export KUBECONFIG=kubeconfig-cluster1
           kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-cluster1
+          cilium sysdump --output-filename cilium-sysdump-cluster1
 
           export KUBECONFIG=kubeconfig-cluster2
           kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-cluster2
+          cilium sysdump --output-filename cilium-sysdump-cluster2
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -102,7 +102,7 @@ func newCmdSysdump() *cobra.Command {
 		"Whether to enable quick mode (i.e. skip collection of 'cilium-bugtool' output and logs)")
 	cmd.Flags().IntVar(&sysdumpOptions.WorkerCount,
 		"worker-count", sysdump.DefaultWorkerCount,
-		"The number of workers to use")
+		"The number of workers to use\nNOTE: There is a lower bound requirement on the number of workers for the sysdump operation to be effective. Therefore, for low values, the actual number of workers may be adjusted upwards.")
 
 	return cmd
 }


### PR DESCRIPTION
We are deprecating python cilium-sysdump.zip soon.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

—

(@bmcustodio) This PR also contains a fix for sysdump itself: since sysdump tasks can submit subtasks, it may happen for small values of `--worker-count` that at some point all worker goroutines are stuck at `Submit` calls. This addresses that by setting the actual number of worker goroutines to the minimum necessary to `Submit` and still being able to continue processing work.