### PR TITLE
clustermesh: Support --config option

### DIFF
--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -71,6 +71,7 @@ func newCmdClusterMeshEnable() *cobra.Command {
 	cmd.Flags().StringVar(&params.ApiserverVersion, "apiserver-version", "", "Container image version for clustermesh-apiserver")
 	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", false, "Automatically create CA if needed")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "clustermesh-apiserver config entries (key=value)")
 
 	return cmd
 }


### PR DESCRIPTION
Add --config option to pass command line parameters to
clustermesh-apiserver. Useful for turning on --debug, etc.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>