### PR TITLE
k8s: Check observedGeneration in status

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -208,6 +208,11 @@ func (c *Client) CheckDeploymentStatus(ctx context.Context, namespace, deploymen
 		return fmt.Errorf("deployment is not available")
 	}
 
+	if d.Status.ObservedGeneration != d.Generation {
+		return fmt.Errorf("observed generation (%d) is older than generation of the desired state (%d)",
+			d.Status.ObservedGeneration, d.Generation)
+	}
+
 	if d.Status.Replicas == 0 {
 		return fmt.Errorf("replicas count is zero")
 	}
@@ -238,6 +243,11 @@ func (c *Client) CheckDaemonSetStatus(ctx context.Context, namespace, daemonset 
 
 	if d == nil {
 		return fmt.Errorf("daemonset is not available")
+	}
+
+	if d.Status.ObservedGeneration != d.Generation {
+		return fmt.Errorf("observed generation (%d) is older than generation of the desired state (%d)",
+			d.Status.ObservedGeneration, d.Generation)
 	}
 
 	if d.Status.DesiredNumberScheduled != d.Status.NumberReady {


### PR DESCRIPTION
When a DaemonSet or Deployment is updated, it might take a while for the
status field to reflect the status of the updated version. If we check
the status too soon, there is a high chance that we are checking an
outdated status.

Therefore, check the observedGeneration field first, before reading out
the status flag. This ensures that the reported status actually refers
to the most recent desired state.

Recommended reading: https://alenkacz.medium.com/-250728868792

FWIW: I'm not sure we actually have hit this problem in practice. I just noticed it while debugging something else.