### PR TITLE
CI workflows: Build cilium binary

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -24,6 +24,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
+      - name: Set up Go
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
+        with:
+          go-version: 1.16.5
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
+      - name: Build and install cilium CLI binary
+        run: sudo make install
+
       - name: Install eksctl CLI
         run: |
           curl -LO "https://github.com/weaveworks/eksctl/releases/download/0.54.0/eksctl_$(uname -s)_amd64.tar.gz"

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -24,6 +24,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
+      - name: Set up Go
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
+        with:
+          go-version: 1.16.5
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
+      - name: Build and install cilium CLI binary
+        run: sudo make install
+
       - name: Install eksctl CLI
         run: |
           curl -LO "https://github.com/weaveworks/eksctl/releases/download/0.54.0/eksctl_$(uname -s)_amd64.tar.gz"

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -26,6 +26,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
+      - name: Set up Go
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
+        with:
+          go-version: 1.16.5
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
+      - name: Build and install cilium CLI binary
+        run: sudo make install
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba
         with:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -24,6 +24,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
+      - name: Set up Go
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
+        with:
+          go-version: 1.16.5
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
+      - name: Build and install cilium CLI binary
+        run: sudo make install
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba
         with:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -26,6 +26,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
+      - name: Set up Go
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
+        with:
+          go-version: 1.16.5
+
+      - name: Set up Go for root
+        run: |
+          sudo ln -sf `which go` `sudo which go` || true
+          sudo go version
+
+      - name: Build and install cilium CLI binary
+        run: sudo make install
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba
         with:


### PR DESCRIPTION
We need the binary for the sysdump command in case of failure.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>