### PR TITLE
install: Add a hidden --base-version flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 )
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cilium/cilium v1.10.2
 	github.com/cilium/hubble v0.8.0
 	github.com/cilium/workerpool v1.0.0

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver/v4"
+)
+
+func TestK8sInstaller_getCiliumVersion(t *testing.T) {
+	type fields struct{ params Parameters }
+	tests := []struct {
+		name   string
+		fields fields
+		want   semver.Version
+	}{
+		{
+			name:   "default",
+			fields: fields{Parameters{Writer: io.Discard}},
+			want:   semver.Version{Major: 1, Minor: 10, Patch: 0},
+		},
+		{
+			name:   "version",
+			fields: fields{Parameters{Writer: io.Discard, Version: "v1.10.3"}},
+			want:   semver.Version{Major: 1, Minor: 10, Patch: 3},
+		},
+		{
+			name:   "base-version",
+			fields: fields{Parameters{Writer: io.Discard, Version: "random-version-string", BaseVersion: "v1.9.8"}},
+			want:   semver.Version{Major: 1, Minor: 9, Patch: 8},
+		},
+		{
+			name:   "random-version-without-base-version",
+			fields: fields{Parameters{Writer: io.Discard, Version: "random-version-string"}},
+			want:   semver.Version{Major: 1, Minor: 10, Patch: 0},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &K8sInstaller{params: tt.fields.params}
+			if got := k.getCiliumVersion(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getCiliumVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -61,6 +61,9 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.ClusterName, "cluster-name", "", "Name of the cluster")
 	cmd.Flags().StringSliceVar(&params.DisableChecks, "disable-check", []string{}, "Disable a particular validation check")
 	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
+	cmd.Flags().StringVar(&params.BaseVersion, "base-version", "",
+		"Specify the base Cilium version for configuration purpose in case the --version flag doesn't indicate the actual Cilium version")
+	cmd.Flags().MarkHidden("base-version")
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use")
 	cmd.Flags().StringVar(&params.IPAM, "ipam", "", "IP Address Management (IPAM) mode")
 	cmd.Flags().StringVar(&params.NativeRoutingCIDR, "native-routing-cidr", "", "CIDR within which native routing is possible")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -26,6 +26,7 @@ github.com/asaskevich/govalidator
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blang/semver/v4 v4.0.0
+## explicit
 github.com/blang/semver/v4
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2


### PR DESCRIPTION
The --version flag doesn't always maps to a Cilium version. For example,
Cilium CI jobs use commit SHAs as image tags. This flag allows you to
explicitly provide the "base" Cilium version being installed so that the
install command can configure Cilium accordingly.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>