### PR TITLE
.github/workflows: use latest eksctl version

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install eksctl CLI
         run: |
-          curl -LO "https://github.com/weaveworks/eksctl/releases/download/0.54.0/eksctl_$(uname -s)_amd64.tar.gz"
+          curl -LO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install eksctl CLI
         run: |
-          curl -LO "https://github.com/weaveworks/eksctl/releases/download/0.54.0/eksctl_$(uname -s)_amd64.tar.gz"
+          curl -LO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 


### PR DESCRIPTION
Commit 59785a9f9c7c (".github/workflows: use eksctl 0.54.0") pinnned
eksctl to v0.54.0 to work around an issue in eksctl v0.55.0. That issue
was fixed upstream and v0.56.0 released, so revert back to using the
latest eksctl version.

Ref: weaveworks/eksctl#3929