### PR TITLE
workflows: use latest stable CLI in post-test information gathering

### DIFF
--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -15,6 +15,3 @@ sleep 10s
 
 # Run connectivity test
 cilium connectivity test --debug --all-flows
-
-# Retrieve Cilium  status
-cilium status

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -15,6 +15,3 @@ sleep 10s
 
 # Run connectivity test
 cilium connectivity test --debug --all-flows
-
-# Retrieve Cilium  status
-cilium status

--- a/.github/in-cluster-test-scripts/external-workloads.sh
+++ b/.github/in-cluster-test-scripts/external-workloads.sh
@@ -5,8 +5,3 @@ set -e
 
 # Run connectivity test
 cilium connectivity test --debug --all-flows
-
-# Retrieve Cilium status
-cilium status
-cilium clustermesh status
-cilium clustermesh vm status

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -21,6 +21,3 @@ sleep 10s
 
 # Run connectivity test
 cilium connectivity test --debug --all-flows
-
-# Retrieve Cilium status
-cilium status

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -53,9 +53,3 @@ sleep 10s
 
 # Run connectivity test
 cilium --context "${CONTEXT1}" connectivity test --debug --multi-cluster "${CONTEXT2}" --test '!/pod-to-.*-nodeport' --all-flows
-
-# Retrieve Cilium status
-cilium --context "${CONTEXT1}" status
-cilium --context "${CONTEXT1}" clustermesh status
-cilium --context "${CONTEXT2}" status
-cilium --context "${CONTEXT2}" clustermesh status

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -114,9 +114,18 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          echo "=== Retrieve in-cluster jobs logs ==="
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
+
+          echo "\n\n\n=== Install latest stable CLI ==="
+          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz
+
+          echo "\n\n\n=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
+          cilium status
           cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -114,9 +114,18 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          echo "=== Retrieve in-cluster jobs logs ==="
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
+
+          echo "\n\n\n=== Install latest stable CLI ==="
+          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz
+
+          echo "\n\n\n=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
+          cilium status
           cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -152,20 +152,29 @@ jobs:
         run: |
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
-      - name: Post-test installation logs
-        if: ${{ !success() }}
-        run: |
-          kubectl logs --timestamps -n kube-system job/cilium-cli-install
-
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          echo "=== Retrieve in-cluster jobs logs ==="
+          kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
+
+          echo "\n\n\n=== Retrieve VM state ==="
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
+
+          echo "\n\n\n=== Install latest stable CLI ==="
+          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz
+
+          echo "\n\n\n=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide
+          cilium status
+          cilium clustermesh status
+          cilium clustermesh vm status
           cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -96,9 +96,17 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          echo "=== Retrieve in-cluster jobs logs ==="
           kubectl logs --timestamps -n kube-system job/cilium-cli
-          kubectl exec -n kube-system job/cilium-cli -- cilium status
+
+          echo "\n\n\n=== Install latest stable CLI ==="
+          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz
+
+          echo "\n\n\n=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
+          cilium status
           cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -131,14 +131,26 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          echo "=== Retrieve in-cluster jobs logs ==="
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
+          echo "\n\n\n=== Install latest stable CLI ==="
+          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz
+
+          echo "\n\n\n=== Retrieve cluster1 state ==="
           export KUBECONFIG=kubeconfig-cluster1
           kubectl get pods --all-namespaces -o wide
+          cilium status
+          cilium clustermesh status
           cilium sysdump --output-filename cilium-sysdump-cluster1
 
+          echo "\n\n\n=== Retrieve cluster2 state ==="
           export KUBECONFIG=kubeconfig-cluster2
           kubectl get pods --all-namespaces -o wide
+          cilium status
+          cilium clustermesh status
           cilium sysdump --output-filename cilium-sysdump-cluster2
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 


### PR DESCRIPTION
The post-test information gathering steps were previously self-contained and became split between the actual workflow step and in-cluster jobs logs in #212.

In parallel, `sysdump` became a subcommand of the CLI and we switched to using it in post-test information gathering in #405.

However, we explicitly do not want to run PR-built `cilium` in the context of a `pull_request_target`-triggered privileged workflow, as it would allow an attacker to leak the repository's secrets.

Our proposal is to use the latest stable version of the CLI in the post-test information gathering step. This is acceptable as the purpose of this step is retrieving information, not testing the actual `cilium` commands run in the step -- this is done as part of the in-cluster jobs.

Should a workflow developer actually need to check that a PR editing `sysdump` or any other `cilium` command used in this step works as intended with the new changes, they can always switch to `pull_request` testing or edit the in-cluster scripts with additional testing.