### PR TITLE
debug: add dlv makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ RELEASE_GID ?= $(shell id -g)
 GOLANGCILINT_WANT_VERSION = 1.40.1
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
+DLV = $(shell which dlv 2> /dev/null)
+
 $(TARGET):
 	$(GO) build $(if $(GO_TAGS),-tags $(GO_TAGS)) \
 		-ldflags "-w -s \
@@ -71,6 +73,13 @@ test:
 bench:
 	go test -timeout=30s -bench=. $$(go list ./...)
 
+debug:
+ifeq (, $(DLV))
+	@echo "dlv not available"
+else
+	dlv debug ./cmd/cilium -- $(DLV_ARGS)
+endif
+
 ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION),$(GOLANGCILINT_VERSION)))
 check:
 	golangci-lint run
@@ -79,4 +88,4 @@ check:
 	docker run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:v$(GOLANGCILINT_WANT_VERSION) golangci-lint run
 endif
 
-.PHONY: $(TARGET) release local-release install clean test bench check
+.PHONY: $(TARGET) release local-release install clean test bench check debug


### PR DESCRIPTION
this commit adds a simple helper to compile and debug the Cilium CLI
tool.

usage from root of repository:

$ DLV_ARGS="version" make debug
dlv debug ./cmd/cilium -- version
Type 'help' for list of commands.
(dlv) continue
cilium-cli: v compiled with go1.16.4 on linux/amd64
cilium image (default): v1.10.2
cilium image (stable): v1.10.2

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>