### PR TITLE
Run "Post-test information gathering" step on cancellation

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -116,7 +116,7 @@ jobs:
           cilium connectivity test --debug --all-flows
 
       - name: Post-test information gathering
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
@@ -130,7 +130,7 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -112,7 +112,7 @@ jobs:
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
       - name: Post-test information gathering
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
@@ -140,7 +140,7 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -112,7 +112,7 @@ jobs:
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
       - name: Post-test information gathering
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
@@ -140,7 +140,7 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -153,12 +153,12 @@ jobs:
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=10m
 
       - name: Post-test installation logs
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
 
       - name: Post-test information gathering
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
@@ -177,7 +177,7 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -94,7 +94,7 @@ jobs:
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=15m
 
       - name: Post-test information gathering
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli
           kubectl exec -n kube-system job/cilium-cli -- cilium status
@@ -109,7 +109,7 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -102,7 +102,7 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload Artifacts
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -129,7 +129,7 @@ jobs:
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=20m
 
       - name: Post-test information gathering
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         run: |
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
@@ -151,7 +151,7 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts
-        if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip


### PR DESCRIPTION
Otherwise it's difficult to figure out why the connectivity check
timed out.

Ref: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-status-check-functions

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>