### PR TITLE
.github/workflows: verify checksum when installing latest stable CLI

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -130,12 +130,14 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
-          echo "\n\n\n=== Install latest stable CLI ==="
-          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
-          rm cilium-linux-amd64.tar.gz
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-          echo "\n\n\n=== Retrieve cluster state ==="
+          echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status
           cilium sysdump --output-filename cilium-sysdump-out

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -130,12 +130,14 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
-          echo "\n\n\n=== Install latest stable CLI ==="
-          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
-          rm cilium-linux-amd64.tar.gz
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-          echo "\n\n\n=== Retrieve cluster state ==="
+          echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status
           cilium sysdump --output-filename cilium-sysdump-out

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -160,16 +160,18 @@ jobs:
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
-          echo "\n\n\n=== Retrieve VM state ==="
+          echo "=== Retrieve VM state ==="
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
 
-          echo "\n\n\n=== Install latest stable CLI ==="
-          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
-          rm cilium-linux-amd64.tar.gz
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-          echo "\n\n\n=== Retrieve cluster state ==="
+          echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide
           kubectl get cep --all-namespaces -o wide

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -100,12 +100,14 @@ jobs:
           echo "=== Retrieve in-cluster jobs logs ==="
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
-          echo "\n\n\n=== Install latest stable CLI ==="
-          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
-          rm cilium-linux-amd64.tar.gz
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-          echo "\n\n\n=== Retrieve cluster state ==="
+          echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status
           cilium sysdump --output-filename cilium-sysdump-out

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -136,19 +136,21 @@ jobs:
           echo "=== Retrieve in-cluster jobs logs ==="
           kubectl logs --timestamps -n kube-system job/cilium-cli
 
-          echo "\n\n\n=== Install latest stable CLI ==="
-          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
-          rm cilium-linux-amd64.tar.gz
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-          echo "\n\n\n=== Retrieve cluster1 state ==="
+          echo "=== Retrieve cluster1 state ==="
           export KUBECONFIG=kubeconfig-cluster1
           kubectl get pods --all-namespaces -o wide
           cilium status
           cilium clustermesh status
           cilium sysdump --output-filename cilium-sysdump-cluster1
 
-          echo "\n\n\n=== Retrieve cluster2 state ==="
+          echo "=== Retrieve cluster2 state ==="
           export KUBECONFIG=kubeconfig-cluster2
           kubectl get pods --all-namespaces -o wide
           cilium status


### PR DESCRIPTION
Verify the checksum of the downloaded stable CLI tarball in the
post-test information gathering stage.

Also make the curl invocation less verbose and remove ineffective
newlines from log messages while at it.