### PR TITLE
.github/workflows: wait for install job before checking aws-node DaemonSet

### DIFF
--- a/.github/in-cluster-test-scripts/eks-install.sh
+++ b/.github/in-cluster-test-scripts/eks-install.sh
@@ -6,5 +6,4 @@ set -e
 # Install Cilium
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
-  --wait=false \
   --config monitor-aggregation=none

--- a/.github/in-cluster-test-scripts/eks-tunnel-install.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel-install.sh
@@ -6,7 +6,6 @@ set -e
 # Install Cilium
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
-  --wait=false \
   --config monitor-aggregation=none \
   --datapath-mode=tunnel \
   --ipam cluster-pool

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -106,6 +106,7 @@ jobs:
 
       - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
         run: |
+          kubectl -n kube-system wait job/cilium-cli-install --for=condition=complete --timeout=10m
           [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 
       - name: Load cilium cli script in configmap

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -55,7 +55,7 @@ jobs:
           echo ::set-output name=sha::${SHA}
           echo ::set-output name=owner::${OWNER}
 
-      - name: Create EKS cluster nodegroup
+      - name: Create EKS cluster with nodegroup
         run: |
           cat <<EOF > eks-config.yaml
           apiVersion: eksctl.io/v1alpha5
@@ -106,6 +106,7 @@ jobs:
 
       - name: Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
         run: |
+          kubectl -n kube-system wait job/cilium-cli-install --for=condition=complete --timeout=10m
           [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 
       - name: Load cilium cli script in configmap


### PR DESCRIPTION
Wait until the cilium-cli-install job completed and Cilium is installed
before checking the status of the aws-node DaemonSet. Otherwise, we
might fail the check if the aws-node DaemonSet is still terminating.