### PR TITLE
workflows: add warning/explanation for testing workflow changes

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -2,6 +2,20 @@ name: AKS
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
+  ###
   pull_request: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -2,6 +2,20 @@ name: EKS (tunnel)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
+  ###
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -2,6 +2,20 @@ name: EKS (ENI)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
+  ###
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -2,6 +2,20 @@ name: External Workloads
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
+  ###
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -2,6 +2,20 @@ name: GKE
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
+  ###
   pull_request_target: {}
   # Run every 6 hours
   schedule:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -2,6 +2,20 @@ name: Multicluster
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
+  ###
   pull_request_target: {}
   # Run every 6 hours
   schedule:


### PR DESCRIPTION
This should help clarify that any changes to workflow files or workflow scripts should be tested from a PR using the `pull_request` trigger before merging.
