### PR TITLE
k8s: Use TTY to cancel execution

### DIFF
--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -64,14 +64,14 @@ func (t *Test) waitCiliumPolicyRevisions(ctx context.Context, revisions map[Pod]
 
 // getCiliumPolicyRevision returns the current policy revision of a Cilium pod.
 func getCiliumPolicyRevision(ctx context.Context, pod Pod) (int, error) {
-	stdout, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name,
+	stdout, err := pod.K8sClient.ExecInPodWithTTY(ctx, pod.Pod.Namespace, pod.Pod.Name,
 		"cilium-agent", []string{"cilium", "policy", "get", "-o", "jsonpath='{.revision}'"})
 	if err != nil {
 		return 0, err
 	}
 	revision, err := strconv.Atoi(strings.Trim(stdout.String(), "'\n"))
 	if err != nil {
-		return 0, fmt.Errorf("revision '%s' is not valid: %w", stdout.String(), err)
+		return 0, fmt.Errorf("revision %q is not valid: %w", stdout.String(), err)
 	}
 	return revision, nil
 }
@@ -79,7 +79,7 @@ func getCiliumPolicyRevision(ctx context.Context, pod Pod) (int, error) {
 // waitCiliumPolicyRevision waits for a Cilium pod to reach a given policy revision.
 func waitCiliumPolicyRevision(ctx context.Context, pod Pod, rev int, timeout time.Duration) error {
 	timeoutStr := strconv.Itoa(int(timeout.Seconds()))
-	_, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name,
+	_, err := pod.K8sClient.ExecInPodWithTTY(ctx, pod.Pod.Namespace, pod.Pod.Name,
 		"cilium-agent", []string{"cilium", "policy", "wait", strconv.Itoa(rev), "--max-wait-time", timeoutStr})
 	return err
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -351,6 +351,18 @@ func (c *Client) ExecInPodWithStderr(ctx context.Context, namespace, pod, contai
 	return result.Stdout, result.Stderr, err
 }
 
+func (c *Client) ExecInPodWithTTY(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error) {
+	result, err := c.execInPod(ctx, ExecParameters{
+		Namespace: namespace,
+		Pod:       pod,
+		Container: container,
+		Command:   command,
+		TTY:       true,
+	})
+	// Using TTY (for context cancellation support) fuses stderr into stdout
+	return result.Stdout, err
+}
+
 func (c *Client) ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error) {
 	result, err := c.execInPod(ctx, ExecParameters{
 		Namespace: namespace,

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 
+	"github.com/cilium/cilium-cli/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/remotecommand"
@@ -34,6 +36,7 @@ type ExecParameters struct {
 	Pod       string
 	Container string
 	Command   []string
+	TTY       bool // fuses stderr into stdout if 'true', needed for Ctrl-C support
 }
 
 func (c *Client) execInPod(ctx context.Context, p ExecParameters) (*ExecResult, error) {
@@ -49,10 +52,10 @@ func (c *Client) execInPod(ctx context.Context, p ExecParameters) (*ExecResult, 
 	req.VersionedParams(&corev1.PodExecOptions{
 		Command:   p.Command,
 		Container: p.Container,
-		Stdin:     false,
+		Stdin:     p.TTY,
 		Stdout:    true,
 		Stderr:    true,
-		TTY:       false,
+		TTY:       p.TTY,
 	}, parameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(c.Config, "POST", req.URL())
@@ -61,11 +64,27 @@ func (c *Client) execInPod(ctx context.Context, p ExecParameters) (*ExecResult, 
 	}
 	result := &ExecResult{}
 
+	var stdin io.ReadCloser
+	if p.TTY {
+		// CtrlCReader sends Ctrl-C/D sequence if context is cancelled
+		stdin = utils.NewCtrlCReader(ctx)
+		// Graceful close of stdin once we are done, no Ctrl-C is sent
+		// if execution finishes before the context expires.
+		defer stdin.Close()
+	}
+
 	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  nil,
+		Stdin:  stdin,
 		Stdout: &result.Stdout,
 		Stderr: &result.Stderr,
-		Tty:    false,
+		Tty:    p.TTY,
 	})
+
+	// TTY support may introduce "\r\n" sequences as line separators.
+	// Replace them with "\n" to allow callers to not care.
+	if p.TTY && bytes.Contains(result.Stdout.Bytes(), []byte("\r\n")) {
+		result.Stdout = *bytes.NewBuffer(bytes.ReplaceAll(result.Stdout.Bytes(), []byte("\r\n"), []byte("\n")))
+	}
+
 	return result, err
 }

--- a/internal/utils/ctrlcreader.go
+++ b/internal/utils/ctrlcreader.go
@@ -1,0 +1,69 @@
+// Copyright 2020-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+// CtrlCReader implements a simple Reader/Closer that returns Ctrl-C and EOF
+// on Read() after it has been closed, and nothing before it.
+type CtrlCReader struct {
+	ctx       context.Context
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+// NewCtrlCReader returns a new CtrlCReader instance
+func NewCtrlCReader(ctx context.Context) *CtrlCReader {
+	return &CtrlCReader{
+		ctx:    ctx,
+		closed: make(chan struct{}),
+	}
+}
+
+// Read implements io.Reader.
+// Blocks until we are done.
+func (cc *CtrlCReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	select {
+	case <-cc.closed:
+		// Graceful close, EOF without any data
+		return 0, io.EOF
+	case <-cc.ctx.Done():
+		// Context cancelled, send Ctrl-C/Ctrl-D
+		p[0] = byte(3) // Ctrl-C
+		if len(p) > 1 {
+			// Add Ctrl-D for the case Ctrl-C alone is ineffective.
+			// We skip this in the odd case where the buffer is too small.
+			p[1] = byte(4) // Ctrl-D
+			return 2, io.EOF
+		}
+		return 1, io.EOF
+	}
+}
+
+// Close implements io.Closer. Note that we do not return an error on
+// second close, not do we wait for the close to have any effect.
+func (cc *CtrlCReader) Close() error {
+	cc.closeOnce.Do(func() {
+		close(cc.closed)
+	})
+	return nil
+}


### PR DESCRIPTION
Add ExecInPodWithTTY() to cancel command execution when the context is
done, as in a timeout.

TTY support can not be used by default as it fuses stderr into stdout
and some users of ExecInPod()/ExecInPodWithStderr(), most notably
sysdump, do not expect that to be the case.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>