### PR TITLE
test: Add error detail to ipcache check failures

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -550,14 +550,14 @@ func (ct *ConnectivityTest) waitForIPCache(ctx context.Context, pod Pod) error {
 
 			for _, client := range ct.clientPods {
 				if _, err := ic.findPodID(client); err != nil {
-					ct.Debugf("Couldn't find client Pod %v in ipcache, retrying...", client)
+					ct.Debugf("Couldn't find client Pod %v in ipcache (%s), retrying...", client, err)
 					goto retry
 				}
 			}
 
 			for _, echo := range ct.echoPods {
 				if _, err := ic.findPodID(echo); err != nil {
-					ct.Debugf("Couldn't find echo Pod %v in ipcache, retrying...", echo)
+					ct.Debugf("Couldn't find echo Pod %v in ipcache (%s), retrying...", echo, err)
 					goto retry
 				}
 			}


### PR DESCRIPTION
Add error to the debug output for ipcache check failures. This should
help solve #361.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>