### PR TITLE
workflows: add missing Relay port-forward to external workloads testing

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads.sh
+++ b/.github/in-cluster-test-scripts/external-workloads.sh
@@ -3,5 +3,10 @@
 set -x
 set -e
 
+# Port forward Relay
+cilium hubble port-forward&
+sleep 10s
+[[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
+
 # Run connectivity test
 cilium connectivity test --debug --all-flows

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours


### PR DESCRIPTION
We somehow missed that one, resulting in flows not being validated in connectivity test via the external workloads workflow.
