### PR TITLE
workflows: add test exceptions to EKS tunnel workflow

### DIFF
--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -26,4 +26,10 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows
+cilium connectivity test --debug --all-flows \
+  # workaround for nslookup issues in tunnel mode causing tests to fail reliably
+  # TODO: remove once:
+  # - https://github.com/cilium/cilium/issues/16975 is fixed
+  # - fix has been deployed to a stable branch
+  # - cilium-cli default cilium version has been updated to pick up the fix
+  --test '!dns-only,!to-fqdns,!client-egress-l7'


### PR DESCRIPTION
Following merge of #251, testing on EKS in tunnel mode is now reliably broken due to an issue in upstream: cilium/cilium#16975

This type of failure was already happening before #251, but the PR made it very evident as before we were only running checks from a few random pods (which would sometimes work) and are now running checks from all pods, drastically increasing the chance of hitting at least one failure.

Since the test setup is not to blame and this is an actual issue with Cilium in tunnel mode, we disable the failing tests until upstream issue is fixed.
