### PR TITLE
workflows: fix external workloads GCP VM image

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -79,7 +79,7 @@ jobs:
             --boot-disk-size 10GB \
             --preemptible \
             --image-project ubuntu-os-cloud \
-            --image-family ubuntu-2010 \
+            --image-family ubuntu-2004-lts \
             --metadata hostname=${{ env.vmName }} \
             --metadata-from-file startup-script=${{ env.vmStartupScript}}
 


### PR DESCRIPTION
Seems like `ubuntu-2010` got phased out and replaced by `ubuntu-2104`.
Switching to LTS image `ubuntu-2004-lts`.
