### PR TITLE
k8s: Strip image digest from cilium version

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -672,7 +672,11 @@ func (c *Client) GetRunningCiliumVersion(ctx context.Context, namespace string) 
 		if len(version) != 2 {
 			return "", errors.New("unable to extract cilium version from container image")
 		}
-		return version[1], nil
+		v := version[1]
+		if digest := strings.Index(v, "@"); digest > 0 {
+			v = v[:digest]
+		}
+		return v, nil
 	}
 	return "", errors.New("unable to obtain cilium version: no cilium pods found")
 }


### PR DESCRIPTION
We use `GetRunningCiliumVersion` to auto-detect the image tag for the
`hubble-relay` and `clustermesh-apiserver`. Because the image tag can
contain a docker image digest (e.g. `@sha256:a1b2c3d4e5f6..`), which
does not apply to other images, we want to strip that digest from
auto-detected version.

Fixes #456
