### PR TITLE
sysdump: Collect hubble flows

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -100,7 +100,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          cilium sysdump --output-filename cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out --hubble-flows-count 10000
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload Artifacts

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -73,6 +73,12 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().StringVar(&sysdumpOptions.HubbleNamespace,
 		"hubble-namespace", sysdump.DefaultHubbleNamespace,
 		"The namespace Hubble is running in")
+	cmd.Flags().Int64Var(&sysdumpOptions.HubbleFlowsCount,
+		"hubble-flows-count", sysdump.DefaultHubbleFlowsCount,
+		"Number of Hubble flows to collect. Setting to zero disables collecting Hubble flows.")
+	cmd.Flags().DurationVar(&sysdumpOptions.HubbleFlowsTimeout,
+		"hubble-flows-timeout", sysdump.DefaultHubbleFlowsTimeout,
+		"Timeout for collecting Hubble flows")
 	cmd.Flags().StringVar(&sysdumpOptions.HubbleRelayLabelSelector,
 		"hubble-relay-labels", sysdump.DefaultHubbleRelayLabelSelector,
 		"The labels used to target Hubble Relay pods")

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -53,6 +53,7 @@ const (
 	eniconfigsFileName                       = "aws-eniconfigs-<ts>.yaml"
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
 	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"
+	hubbleFlowsFileName                      = "hubble-flows-%s-<ts>.json"
 	hubbleRelayDeploymentFileName            = "hubble-relay-deployment-<ts>.yaml"
 	hubbleUIDeploymentFileName               = "hubble-ui-deployment-<ts>.yaml"
 	kubernetesEventsFileName                 = "k8s-events-<ts>.yaml"

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -32,6 +32,8 @@ const (
 	DefaultDebug                       = false
 	DefaultHubbleLabelSelector         = labelPrefix + "hubble"
 	DefaultHubbleNamespace             = DefaultCiliumNamespace
+	DefaultHubbleFlowsCount            = 0
+	DefaultHubbleFlowsTimeout          = 5 * time.Second
 	DefaultHubbleRelayLabelSelector    = labelPrefix + "hubble-relay"
 	DefaultHubbleRelayNamespace        = DefaultCiliumNamespace
 	DefaultHubbleUILabelSelector       = labelPrefix + "hubble-ui"


### PR DESCRIPTION
Optionally collect hubble flows as a part of sysdump. This PR adds two
new flags to the sysdump subcommand:

--hubble-flows-timeout

  Timeout for the flow collection task. Default to 5 seconds.

--hubble-flows-count

  Specifies the --last flag to pass to hubble observe command. Default
  to zero, which disables the flow collection altogether. Note that the
  actual number of flows that get collected might be different from the
  value specified by this flag.

The output file can then be passed to hubble observe command, for example:

    cat hubble-flows-cilium-nq247-20210729-220228.json | hubble observe

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>