### PR TITLE
workflows: display logs in job execution step

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -173,7 +173,11 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli-install
+          exit ${EXIT_CODE}
 
       - name: Delete the first node pool
         run: |
@@ -209,15 +213,15 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli
+          exit ${EXIT_CODE}
 
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Retrieve in-cluster jobs logs ==="
-          kubectl logs --timestamps -n kube-system job/cilium-cli-install
-          kubectl logs --timestamps -n kube-system job/cilium-cli
-
           echo "=== Install latest stable CLI ==="
           curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -130,14 +130,15 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli
+          exit ${EXIT_CODE}
 
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Retrieve in-cluster jobs logs ==="
-          kubectl logs --timestamps -n kube-system job/cilium-cli
-
           echo "=== Install latest stable CLI ==="
           curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -130,14 +130,15 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli
+          exit ${EXIT_CODE}
 
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Retrieve in-cluster jobs logs ==="
-          kubectl logs --timestamps -n kube-system job/cilium-cli
-
           echo "=== Install latest stable CLI ==="
           curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -142,7 +142,11 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli-install
+          exit ${EXIT_CODE}
 
       - name: Copy VM install script from cilium-cli-install pod
         run: |
@@ -194,15 +198,15 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli
+          exit ${EXIT_CODE}
 
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Retrieve in-cluster jobs logs ==="
-          kubectl logs --timestamps -n kube-system job/cilium-cli-install
-          kubectl logs --timestamps -n kube-system job/cilium-cli
-
           echo "=== Retrieve VM state ==="
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -118,14 +118,15 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli
+          exit ${EXIT_CODE}
 
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Retrieve in-cluster jobs logs ==="
-          kubectl logs --timestamps -n kube-system job/cilium-cli
-
           echo "=== Install latest stable CLI ==="
           curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -154,14 +154,15 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
+
+          # Retrieve job logs
+          kubectl logs --timestamps -n kube-system job/cilium-cli
+          exit ${EXIT_CODE}
 
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Retrieve in-cluster jobs logs ==="
-          kubectl logs --timestamps -n kube-system job/cilium-cli
-
           echo "=== Install latest stable CLI ==="
           curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum


### PR DESCRIPTION
Doing this has two advantages:

- Behavior is similar to what we currently have on `cilium/cilium` and what we had on `cilium/cilium-cli` before #212, with the logs to the various `cilium` commands displayed immediately on execution.
- When a job fails, the failing step is automatically expanded in GitHub Actions workflow run view. This will avoid the need to manually open the post-test gathering step to know why a job failed.