### PR TITLE
external workload: Increase the VM creation retry count

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -74,7 +74,7 @@ jobs:
         with:
           retry_on: error
           timeout_minutes: 1
-          max_attempts: 3
+          max_attempts: 10
           command: |
             gcloud compute instances create ${{ env.vmName }} \
               --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \


### PR DESCRIPTION
Increase the retry count from 3 to 10. I have seen 3 consecutive
failures a couple of times 😐

Ref: https://github.com/cilium/cilium-cli/actions/runs/1113449756

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>