### PR TITLE
workflows: fix logs not being displayed on failure

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -178,6 +178,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Delete the first node pool
         run: |
@@ -218,6 +219,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -135,6 +135,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -175,10 +176,12 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
 
-          echo "=== Retrieve in-cluster jobs logs ==="
+          # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli-uninstall
+          exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS
         if: ${{ always() }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -135,6 +135,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -175,10 +176,12 @@ jobs:
 
           # Active wait for whichever background process ends first
           wait -n $complete_pid $failed_pid
-          exit $?
+          EXIT_CODE=$?
 
-          echo "=== Retrieve in-cluster jobs logs ==="
+          # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli-uninstall
+          exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS
         if: ${{ always() }}

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -147,6 +147,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli-install
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Copy VM install script from cilium-cli-install pod
         run: |
@@ -203,6 +204,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -123,6 +123,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -159,6 +159,7 @@ jobs:
           # Retrieve job logs
           kubectl logs --timestamps -n kube-system job/cilium-cli
           exit ${EXIT_CODE}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Post-test information gathering
         if: ${{ !success() }}


### PR DESCRIPTION
In #471, we refactored in-cluster jobs log retrieval to be displayed immediately in the same step as the one waiting for job execution to end.

Unfortunately, this only works when the job succeeds, as if the job does not then a non-0 exit code is received and the step immediately stops due to fail-fast being enabled by default in workflows.

Since we are manually handling exit codes, we disable fail-fast behaviour.

Also, we fix exit codes not being properly handled for EKS uninstall steps.

Fixes: e20c76976fde976e52603608810c1c034bf2c016