### PR TITLE
sysdump: Remove the Hidden flag

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -34,7 +34,6 @@ var (
 
 func newCmdSysdump() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
 		Use:    "sysdump",
 		Short:  "Collects information required to troubleshoot issues with Cilium and Hubble",
 		Long:   ``,


### PR DESCRIPTION
We've been using the sysdump command for a while in both cilium and
cilium-cli CI workflows and it's been stable.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>