### PR TITLE
internal/cli/cmd: fix formatting linter issue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,22 +26,10 @@ jobs:
     - name: Run static checks
       uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
       with:
-        # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.41.1
-
-        # Optional: golangci-lint command line arguments.
         args: --config=.golangci.yml --verbose
-
-        # Optional: show only new issues if it's a pull request. The default value is `false`.
-        only-new-issues: true
-
-        # Optional: if set to true then the action will use pre-installed Go.
         skip-go-installation: true
-
-        # Optional: if set to true then the action don't cache or restore ~/go/pkg.
         skip-pkg-cache: true
-
-        # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
         skip-build-cache: true
 
     - name: Check module vendoring

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -34,9 +34,9 @@ var (
 
 func newCmdSysdump() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "sysdump",
-		Short:  "Collects information required to troubleshoot issues with Cilium and Hubble",
-		Long:   ``,
+		Use:   "sysdump",
+		Short: "Collects information required to troubleshoot issues with Cilium and Hubble",
+		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)


### PR DESCRIPTION
The change in PR #481 wasn't properly formatted, leading to a
golangci-lint failure on master:
https://github.com/cilium/cilium-cli/runs/3310670546

Fix it by running `goimports -w internal/cli/cmd/sysdump.go`.

Also fix the `golangci-lint` GH action configuration to disable the `only-new-issues` which seems to lead to static checker failures correctly failing tests on PRs. See #484 for an example run.