### PR TITLE
Add a flag to disable the ipcache check

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -34,6 +34,7 @@ type Parameters struct {
 	Verbose               bool
 	Debug                 bool
 	PauseOnFail           bool
+	SkipIPCacheCheck      bool
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -477,13 +477,17 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
-	// Set the timeout for all IP cache lookup retries
-	ipCacheCtx, cancel := context.WithTimeout(ctx, ct.params.ipCacheTimeout())
-	defer cancel()
-	for _, cp := range ct.ciliumPods {
-		err := ct.waitForIPCache(ipCacheCtx, cp)
-		if err != nil {
-			return err
+	if ct.params.SkipIPCacheCheck {
+		ct.Infof("Skipping IPCache check")
+	} else {
+		// Set the timeout for all IP cache lookup retries
+		ipCacheCtx, cancel := context.WithTimeout(ctx, ct.params.ipCacheTimeout())
+		defer cancel()
+		for _, cp := range ct.ciliumPods {
+			err := ct.waitForIPCache(ipCacheCtx, cp)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -119,6 +119,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages and don't buffer any lines")
 	cmd.Flags().BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
+	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 
 	return cmd
 }


### PR DESCRIPTION
Add `--skip-ip-cache-check` flag with the default set to true. This is
meant to be a temporary flag while we investigate what's causing the flake.

Ref: #361

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>