### PR TITLE
install: set base version to current default version

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -1154,17 +1154,15 @@ func (k *K8sInstaller) Exec(command string, args ...string) ([]byte, error) {
 }
 
 func (k *K8sInstaller) getCiliumVersion() semver.Version {
-	var ersion string
-	if k.params.BaseVersion != "" {
-		ersion = strings.TrimPrefix(k.params.BaseVersion, "v")
-	} else {
-		ersion = strings.TrimPrefix(k.params.Version, "v")
-	}
+	ersion := strings.TrimPrefix(k.params.Version, "v")
 	v, err := versioncheck.Version(ersion)
 	if err != nil {
-		// TODO: Don't hard code version here, get it from stable.txt.
-		k.Log("Unable to parse the provided version %q, assuming it's =1.10.0", k.params.Version)
-		v = versioncheck.MustVersion("1.10.0")
+		ersion = strings.TrimPrefix(k.params.BaseVersion, "v")
+		v, err = versioncheck.Version(ersion)
+		if err != nil {
+			v = versioncheck.MustVersion(defaults.Version)
+			k.Log("Unable to parse the provided version %q, assuming %v for ConfigMap compatibility", k.params.Version)
+		}
 	}
 	return v
 }

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -6,12 +6,21 @@ package install
 import (
 	"io"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/blang/semver/v4"
 )
 
 func TestK8sInstaller_getCiliumVersion(t *testing.T) {
+	defaultCiliumVersion, err := versioncheck.Version(strings.TrimPrefix(defaults.Version, "v"))
+	if err != nil {
+		t.Fatalf("failed to parse default Cilium version %q as semver", defaults.Version)
+	}
+
 	type fields struct{ params Parameters }
 	tests := []struct {
 		name   string
@@ -21,12 +30,12 @@ func TestK8sInstaller_getCiliumVersion(t *testing.T) {
 		{
 			name:   "default",
 			fields: fields{Parameters{Writer: io.Discard}},
-			want:   semver.Version{Major: 1, Minor: 10, Patch: 0},
+			want:   defaultCiliumVersion,
 		},
 		{
 			name:   "version",
-			fields: fields{Parameters{Writer: io.Discard, Version: "v1.10.3"}},
-			want:   semver.Version{Major: 1, Minor: 10, Patch: 3},
+			fields: fields{Parameters{Writer: io.Discard, Version: "v9.9.99"}},
+			want:   semver.Version{Major: 9, Minor: 9, Patch: 99},
 		},
 		{
 			name:   "base-version",
@@ -36,7 +45,7 @@ func TestK8sInstaller_getCiliumVersion(t *testing.T) {
 		{
 			name:   "random-version-without-base-version",
 			fields: fields{Parameters{Writer: io.Discard, Version: "random-version-string"}},
-			want:   semver.Version{Major: 1, Minor: 10, Patch: 0},
+			want:   defaultCiliumVersion,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -50,7 +50,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.ClusterName, "cluster-name", "", "Name of the cluster")
 	cmd.Flags().StringSliceVar(&params.DisableChecks, "disable-check", []string{}, "Disable a particular validation check")
 	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
-	cmd.Flags().StringVar(&params.BaseVersion, "base-version", "",
+	cmd.Flags().StringVar(&params.BaseVersion, "base-version", defaults.Version,
 		"Specify the base Cilium version for configuration purpose in case the --version flag doesn't indicate the actual Cilium version")
 	cmd.Flags().MarkHidden("base-version")
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use")


### PR DESCRIPTION
Always set the base version to the current default version and rework
the parsing in `(*K8sInstaller).getCiliumVersion` to fall back to the base
version in case of a non-parseable version. This avoids the confusing log
message, e.g. when using `cilium install --version latest`:

    Unable to parse the provided version latest, assuming it's =1.10.0

Also reword the log message to hopefully be a bit less confusing.

Fixes #491