### PR TITLE
conn-tests: move away from jenkins url

### DIFF
--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -34,7 +34,7 @@ func (s *podToWorld) Name() string {
 func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	chttp := check.HTTPEndpoint("cilium-io-http", "http://cilium.io")
 	chttps := check.HTTPEndpoint("cilium-io-https", "https://cilium.io")
-	jhttp := check.HTTPEndpoint("jenkins-cilium-io-http", "http://jenkins.cilium.io")
+	dhttp := check.HTTPEndpoint("docs-cilium-io-http", "http://docs.cilium.io")
 
 	fp := check.FlowParameters{
 		DNSRequired: true,
@@ -57,8 +57,8 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		})
 
 		// With http to jenkins.cilium.io.
-		t.NewAction(s, fmt.Sprintf("http-to-jenkins-cilium-%d", i), &client, jhttp).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(jhttp))
+		t.NewAction(s, fmt.Sprintf("http-to-docs-cilium-%d", i), &client, dhttp).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, curl(dhttp))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 


### PR DESCRIPTION
as reported here:
https://github.com/cilium/cilium/issues/16938#issuecomment-903841950 the
usage of the jenkins url causes our tests to flake.

in this patch we move away from jenkins to the "http://docs.cilium.io"
URL which should have more reliable uptime.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>