### PR TITLE
ci: increase hubble events buffer

### DIFF
--- a/.github/in-cluster-test-scripts/aks-install.sh
+++ b/.github/in-cluster-test-scripts/aks-install.sh
@@ -12,4 +12,5 @@ cilium install \
   --azure-client-id "${AZURE_CLIENT_ID}" \
   --azure-client-secret "${AZURE_CLIENT_SECRET}" \
   --wait=false \
+  --config hubble-event-buffer-capacity=65535 \
   --config monitor-aggregation=none

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -8,6 +8,7 @@ cilium install \
   --cluster-name "${CLUSTER_NAME}" \
   --wait=false \
   --config monitor-aggregation=none \
+  --config hubble-event-buffer-capacity=65535 \
   --datapath-mode=tunnel \
   --ipam cluster-pool
 

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -7,6 +7,7 @@ set -e
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
   --wait=false \
+  --config hubble-event-buffer-capacity=65535 \
   --config monitor-aggregation=none
 
 # Enable Relay

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -6,6 +6,7 @@ set -e
 # Install Cilium
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
+  --config hubble-event-buffer-capacity=65535 \
   --config monitor-aggregation=none \
   --native-routing-cidr="${CLUSTER_CIDR}"
 

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -12,6 +12,7 @@ cilium install \
   --context "${CONTEXT1}" \
   --cluster-name "${CLUSTER_NAME_1}" \
   --cluster-id 1 \
+  --config hubble-event-buffer-capacity=65535 \
   --config monitor-aggregation=none \
   --native-routing-cidr=10.0.0.0/9
 
@@ -20,6 +21,7 @@ cilium install \
   --context "${CONTEXT2}" \
   --cluster-name "${CLUSTER_NAME_2}" \
   --cluster-id 2 \
+  --config hubble-event-buffer-capacity=65535 \
   --config monitor-aggregation=none \
   --native-routing-cidr=10.0.0.0/9 \
   --inherit-ca "${CONTEXT1}"


### PR DESCRIPTION
currently the hubble event buffer is too small and events from the
begining of the test are overwritten before a read of the buffer takes
place.

this patch increases the hubble event buffer to its largest possible
value to ensure all events are captured.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>