### PR TITLE
internal/cli/cmd: mark `--skip-ip-cache-check` as hidden

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -477,6 +477,8 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
+	// TODO: unconditionally re-enable the IPCache check once
+	// https://github.com/cilium/cilium-cli/issues/361 is resolved.
 	if ct.params.SkipIPCacheCheck {
 		ct.Infof("Skipping IPCache check")
 	} else {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -120,6 +120,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
+	cmd.Flags().MarkHidden("skip-ip-cache-check")
 
 	return cmd
 }


### PR DESCRIPTION
Follow-up for #503 to address
https://github.com/cilium/cilium-cli/pull/503#discussion_r699117235

Also add a comment so we don't forget to re-enable the check again once
issue #361 is resolved.