### PR TITLE
Switch pod to world testing from `cilium.io` to `one.one.one.one`

### DIFF
--- a/connectivity/manifests/client-egress-l7-http.yaml
+++ b/connectivity/manifests/client-egress-l7-http.yaml
@@ -1,5 +1,5 @@
 ---
-# client2 is allowed to contact cilium.io/ on port 80 and the echo Pod
+# client2 is allowed to contact one.one.one.one/ on port 80 and the echo Pod
 # on port 8080. HTTP introspection is enabled for client2.
 # The toFQDNs section relies on DNS introspection being performed by
 # the client-egress-only-dns policy.
@@ -9,7 +9,7 @@ metadata:
   namespace: cilium-test
   name: client-egress-l7-http
 spec:
-  description: "Allow GET cilium.io:80/ and GET <echo>:8080/ from client2"
+  description: "Allow GET one.one.one.one:80/ and GET <echo>:8080/ from client2"
   endpointSelector:
     matchLabels:
       other: client
@@ -26,9 +26,9 @@ spec:
         http:
         - method: "GET"
           path: "/"
-  # Allow GET / requests, only towards cilium.io.
+  # Allow GET / requests, only towards one.one.one.one.
   - toFQDNs:
-    - matchName: "cilium.io"
+    - matchName: "one.one.one.one"
     toPorts:
     - ports:
       - port: "80"

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   namespace: cilium-test
-  name: client-egress-to-fqdns-cilium-io
+  name: client-egress-to-fqdns-one-one-one-one
 spec:
   endpointSelector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
         - method: "GET"
           path: "/"
     toFQDNs:
-    - matchName: "cilium.io"
+    - matchName: "one.one.one.one"
   - toPorts:
     - ports:
       - port: "53"

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 )
 
-// PodToWorld sends multiple HTTP(S) requests to cilium.io
+// PodToWorld sends multiple HTTP(S) requests to one.one.one.one
 // from random client Pods.
 func PodToWorld(name string) check.Scenario {
 	return &podToWorld{
@@ -32,10 +32,9 @@ func (s *podToWorld) Name() string {
 }
 
 func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
-	chttp := check.HTTPEndpoint("cilium-io-http", "http://cilium.io")
-	chttps := check.HTTPEndpoint("cilium-io-https", "https://cilium.io")
-	chttpindex := check.HTTPEndpoint("cilium-io-http-index", "http://cilium.io/index.html")
-	jhttp := check.HTTPEndpoint("jenkins-cilium-io-http", "http://jenkins.cilium.io")
+	http := check.HTTPEndpoint("one-one-one-one-http", "http://one.one.one.one")
+	https := check.HTTPEndpoint("one-one-one-one-https", "https://one.one.one.one")
+	httpsindex := check.HTTPEndpoint("one-one-one-one-https-index", "https://one.one.one.one/index.html")
 
 	fp := check.FlowParameters{
 		DNSRequired: true,
@@ -45,27 +44,21 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, client := range t.Context().ClientPods() {
-		// With https, over port 443.
-		t.NewAction(s, fmt.Sprintf("https-to-cilium-io-%d", i), &client, chttps).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(chttps))
-			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
-		})
-
 		// With http, over port 80.
-		t.NewAction(s, fmt.Sprintf("http-to-cilium-io-%d", i), &client, chttp).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(chttp))
+		t.NewAction(s, fmt.Sprintf("http-to-one-one-one-one-%d", i), &client, http).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, curl(http))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
-		// With http, over port 80, index.html
-		t.NewAction(s, fmt.Sprintf("http-to-cilium-io-index-%d", i), &client, chttpindex).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(chttpindex))
+		// With https, over port 443.
+		t.NewAction(s, fmt.Sprintf("https-to-one-one-one-one-%d", i), &client, https).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, curl(https))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
-		// With http to jenkins.cilium.io.
-		t.NewAction(s, fmt.Sprintf("http-to-jenkins-cilium-%d", i), &client, jhttp).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(jhttp))
+		// With https, over port 443, index.html.
+		t.NewAction(s, fmt.Sprintf("https-to-one-one-one-one-index-%d", i), &client, httpsindex).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, curl(httpsindex))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 


### PR DESCRIPTION
Tentative fix for #367.

We have two main hypothesis around why connections to external domains are flaky:

- The external domain itself is unreliable.
- The external domain works fine, but CoreDNS is unreliable.

`cilium.io` is hosted on single non-HA EC2 instance, which is definitely the most robus thing out there. We propose switching to
`one.one.one.one` as a quick fix to check if that helps with the reliability.

If yes, we will evaluate moving to a HA system that we control ourselves (e.g. a DNS zone hosted at a major provider).

If not, we will investigate the CoreDNS hypothesis.