### PR TITLE
sysdump: remove support for standalone hubble

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -55,9 +55,6 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().BoolVar(&sysdumpOptions.Debug,
 		"debug", sysdump.DefaultDebug,
 		"Whether to enable debug logging")
-	cmd.Flags().StringVar(&sysdumpOptions.HubbleLabelSelector,
-		"hubble-label-selector", sysdump.DefaultHubbleLabelSelector,
-		"The labels used to target Hubble pods")
 	cmd.Flags().Int64Var(&sysdumpOptions.HubbleFlowsCount,
 		"hubble-flows-count", sysdump.DefaultHubbleFlowsCount,
 		"Number of Hubble flows to collect. Setting to zero disables collecting Hubble flows.")

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -21,8 +21,6 @@ const (
 	ciliumEtcdSecretsSecretName        = "cilium-etcd-secrets"
 	ciliumOperatorDeploymentName       = defaults.OperatorDeploymentName
 	clustermeshApiserverDeploymentName = defaults.ClusterMeshDeploymentName
-	hubbleContainerName                = "hubble"
-	hubbleDaemonSetName                = "hubble"
 	hubbleRelayContainerName           = defaults.RelayContainerName
 	hubbleRelayDeploymentName          = defaults.RelayDeploymentName
 	hubbleUIDeploymentName             = defaults.HubbleUIDeploymentName
@@ -46,7 +44,6 @@ const (
 	clustermeshApiserverDeploymentFileName   = "clustermesh-apiserver-deployment-<ts>.yaml"
 	eniconfigsFileName                       = "aws-eniconfigs-<ts>.yaml"
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
-	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"
 	hubbleFlowsFileName                      = "hubble-flows-%s-<ts>.json"
 	hubbleRelayDeploymentFileName            = "hubble-relay-deployment-<ts>.yaml"
 	hubbleUIDeploymentFileName               = "hubble-ui-deployment-<ts>.yaml"

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -19,7 +19,6 @@ const (
 	DefaultCiliumOperatorLabelSelector       = "io.cilium/app=operator"
 	DefaultClustermeshApiserverLabelSelector = labelPrefix + "clustermesh-apiserver"
 	DefaultDebug                             = false
-	DefaultHubbleLabelSelector               = labelPrefix + "hubble"
 	DefaultHubbleFlowsCount                  = 10000
 	DefaultHubbleFlowsTimeout                = 5 * time.Second
 	DefaultHubbleRelayLabelSelector          = labelPrefix + "hubble-relay"


### PR DESCRIPTION
Standalone Hubble is pre-1.8, and hence not supported anymore. This commit removes support for dumping the daemonset + logs + etc..