### PR TITLE
[ DO NOT MERGE ] experiment,ci: bump dynamic map sizes

### DIFF
--- a/.github/in-cluster-test-scripts/aks-install.sh
+++ b/.github/in-cluster-test-scripts/aks-install.sh
@@ -12,4 +12,5 @@ cilium install \
   --azure-client-id "${AZURE_CLIENT_ID}" \
   --azure-client-secret "${AZURE_CLIENT_SECRET}" \
   --wait=false \
+  --config bpf-map-dynamic-size-ratio="0.9" \
   --config monitor-aggregation=none

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -9,6 +9,7 @@ cilium install \
   --wait=false \
   --config monitor-aggregation=none \
   --datapath-mode=tunnel \
+  --config bpf-map-dynamic-size-ratio="0.9" \
   --ipam cluster-pool
 
 # Enable Relay

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -7,6 +7,7 @@ set -e
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
   --wait=false \
+  --config bpf-map-dynamic-size-ratio="0.9" \
   --config monitor-aggregation=none
 
 # Enable Relay

--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -9,6 +9,7 @@ cilium install \
   --config monitor-aggregation=none \
   --config tunnel=vxlan \
   --kube-proxy-replacement=strict \
+  --config bpf-map-dynamic-size-ratio="0.9" \
   --native-routing-cidr="${CLUSTER_CIDR}"
 
 # Enable Relay

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -7,6 +7,7 @@ set -e
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
   --config monitor-aggregation=none \
+  --config bpf-map-dynamic-size-ratio="0.9" \
   --native-routing-cidr="${CLUSTER_CIDR}"
 
 # Enable Relay

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -13,6 +13,7 @@ cilium install \
   --cluster-name "${CLUSTER_NAME_1}" \
   --cluster-id 1 \
   --config monitor-aggregation=none \
+  --config bpf-map-dynamic-size-ratio="0.9" \
   --native-routing-cidr=10.0.0.0/9
 
 # Install Cilium in cluster2
@@ -22,6 +23,7 @@ cilium install \
   --cluster-id 2 \
   --config monitor-aggregation=none \
   --native-routing-cidr=10.0.0.0/9 \
+  --config bpf-map-dynamic-size-ratio="0.9" \
   --inherit-ca "${CONTEXT1}"
 
 # Enable Relay

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours


### PR DESCRIPTION
in response to ticket: https://github.com/cilium/cilium-cli/issues/367
this pull request bumps all dynamically sized maps to .9 the available
memory.

map sizes still have bpf specific max sizes so over shooting these
numbers is generally safe.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>