### PR TITLE
Fix `make release` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ release:
 		--rm \
 		--workdir /cilium \
 		--volume `pwd`:/cilium docker.io/library/golang:1.17.0-alpine3.14 \
-		sh -c "apk add --no-cache make && make local-release"
+		sh -c "apk add --no-cache make git && make local-release"
 
 local-release: clean
 	for OS in darwin linux; do \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ local-release: clean
 				;; \
 			windows) \
 				ARCHS='386 amd64'; \
-				EXT=".exe"
+				EXT=".exe"; \
 				;; \
 		esac; \
 		for ARCH in $$ARCHS; do \


### PR DESCRIPTION
See individual commits for details.

Noticed while trying to create a new `v0.9.0` release, see the failed build at https://github.com/cilium/cilium-cli/runs/3526736152?check_suite_focus=true