### PR TITLE
More release process fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ release:
 		sh -c "apk add --no-cache make git && make local-release"
 
 local-release: clean
-	for OS in darwin linux; do \
+	for OS in darwin linux windows; do \
 		EXT=; \
 		ARCHS=; \
 		case $$OS in \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ example, they will look as follows:
 
 ## Tag a release
 
-    git tag -a $RELEASE -m '$RELEASE release' $COMMIT_SHA && git push origin $RELEASE
+    git tag -a $RELEASE -m "$RELEASE release" $COMMIT_SHA && git push origin $RELEASE
 
 ## Prepare the release notes
 


### PR DESCRIPTION
* Fix the `git tag` invocation in `RELEASE.md` to expand the release version in the tag message
* Actually build windows release binaries