### PR TITLE
connectivity test: Use ubuntu-curl by default

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -35,6 +35,7 @@ type Parameters struct {
 	Debug                 bool
 	PauseOnFail           bool
 	SkipIPCacheCheck      bool
+	CurlImage             string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -241,8 +241,8 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			Name:    ClientDeploymentName,
 			Kind:    kindClientName,
 			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
+			Image:   ct.params.CurlImage,
+			Command: []string{"/bin/sh", "-c", "sleep 10000000"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
@@ -258,8 +258,8 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			Name:    Client2DeploymentName,
 			Kind:    kindClientName,
 			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
+			Image:   ct.params.CurlImage,
+			Command: []string{"/bin/sh", "-c", "sleep 10000000"},
 			Labels:  map[string]string{"other": "client"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -63,8 +63,8 @@ const (
 
 	ConnectivityCheckNamespace = "cilium-test"
 
-	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956"
-	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b"
+	ConnectivityCheckCurlImage     = "quay.io/cilium/ubuntu-curl:20.04@sha256:680b7828318f9d6dff8eddda44af3288ca37490996915ec7ba0adf93d446539a"
+	ConnectivityCheckJSONMockImage = "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b"
 
 	ConfigMapName = "cilium-config"
 	Version       = "v1.10.4"

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -121,6 +121,8 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
+	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckCurlImage, "Docker image to use for connectivity test client pods")
+	cmd.Flags().MarkHidden("curl-image")
 
 	return cmd
 }


### PR DESCRIPTION
- Modify the connectivity test client deployments to use an Ubuntu-based
  image by default, and add a hidden `--curl-image` flag so that you can
  still use alpine-curl. Empirical evidence suggests that alpine-curl is
  more prone to DNS-related flakes.
- Use sh instead of ash so that the command works with both alpine-curl
  and ubuntu-curl.

Ref: https://github.com/cilium/ubuntu-curl

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>