### PR TITLE
Add issue templates and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report a bug encountered while operating Cilium CLI
+title: ''
+labels: 'kind/bug'
+assignees: ''
+
+---
+
+<!--
+
+If you have usage questions, please try the [slack
+channel](http://cilium.io/slack) and see the [FAQ](https://goo.gl/qG2YmU)
+first.
+
+Choose either "Proposal" or "Bug report"
+
+-->
+
+## Bug report
+
+<!--
+
+Important: For security related issues: We strongly encourage you to report
+security vulnerabilities to our private security mailing list:
+security@cilium.io - first, before disclosing them in any public forums.
+
+-->
+
+**General Information**
+
+- Cilium CLI version (run `cilium version`)
+- Orchestration system version in use (e.g. `kubectl version`, ...)
+- Platform / infrastructure information (e.g. AWS / Azure / GCP, image / kernel versions)
+- Link to relevant artifacts (policies, deployments scripts, ...)
+- Generate and upload a system zip: `cilium sysdump`
+
+**How to reproduce the issue**
+
+1. instruction 1
+2. instruction 2

--- a/.github/ISSUE_TEMPLATE/failing_test_template.md
+++ b/.github/ISSUE_TEMPLATE/failing_test_template.md
@@ -1,0 +1,16 @@
+---
+name: Failing Test
+about: Report test failures in Cilium CLI CI jobs
+title: 'CI: '
+labels: area/CI, ci/flake
+assignees: ''
+
+---
+
+## CI failure
+
+- Set title to be in the format `CI: <test-name>`.
+- Copy-paste the output the test failure.
+- Upload the zip file generated from that test failure.
+- Copy-paste the link of the CI build where that test failure has happen.
+- Include any output from logs that you think may be relevant (to ease GitHub searches).

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Suggest a feature to Cilium CLI
+title: ''
+labels: kind/feature
+assignees: ''
+
+---
+
+<!--
+
+If you have usage questions, please try the [slack
+channel](http://cilium.io/slack) and see the [FAQ](https://goo.gl/qG2YmU)
+first.
+
+Choose either "Proposal" or "Bug report"
+
+-->
+
+## Proposal / RFE
+
+**Is your feature request related to a problem?**
+
+**Describe the solution you'd like**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We strongly encourage you to report security vulnerabilities to
+our private security mailing list: security@cilium.io - first, before
+disclosing them in any public forums.
+
+This is a private mailing list where only members of the Cilium internal
+security team are subscribed to, and is treated as top priority.


### PR DESCRIPTION
Labels automatically added via issue templates have been adjusted from their original name to match the names from `cilium/cilium`.