### PR TITLE
test: Always deploy `client2` on same node as `client`

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -261,6 +261,20 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			Image:   defaults.ConnectivityCheckAlpineCurlImage,
 			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
 			Labels:  map[string]string{"other": "client"},
+			Affinity: &corev1.Affinity{
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{ClientDeploymentName}},
+								},
+							},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION
The node placement for `client2` is not currently fixed such that a given test (e.g., `client-egress-l7/pod-to-pod/curl-3`) may be covering different packet paths on distinct runs (e.g., `pod->local pod` or `pod->remote pod`). This nondeterminism can be a bit confusing when debugging as a failure on a specific packet path may appear under various names.

This pull request fixes the placement of `client2` to the same node as `client`, via an affinity rule.