### PR TITLE
Enable additional linters in golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,16 +7,37 @@ linters:
   disable-all: true
   enable:
     - goerr113
+    - gofmt
     - goimports
+    - gosec
+    - gosimple
     - govet
     - ineffassign
     - misspell
     - revive
     - staticcheck
+    - structcheck
+    - typecheck
     - unused
     - varcheck
 
+linters-settings:
+  gosimple:
+    go: "1.17"
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
+  staticcheck:
+    go: "1.17"
+  unused:
+    go: "1.17"
+
 issues:
+  # This also warns about credential name variables which are false positives.
+  exclude:
+    - G101 # gosec: Potential hardcoded credentials
   exclude-rules:
       # Disallows any kind of `fmt.Errorf("%s is too high", bar)`, too opinionated.
     - linters: [goerr113]

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -741,8 +741,8 @@ func (a *Action) matchAllFlowRequirements(ctx context.Context, reqs []filters.Fl
 	a.flowsMu.Lock()
 	defer a.flowsMu.Unlock()
 
-	for _, req := range reqs {
-		res := a.matchFlowRequirements(ctx, a.flows, &req)
+	for i := range reqs {
+		res := a.matchFlowRequirements(ctx, a.flows, &reqs[i])
 		//TODO(timo): The matcher should probably take in all requirements
 		// and return its verdict in a single struct.
 		out.Merge(&res)

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -234,7 +234,7 @@ func (a *Action) extractExitCode(err error) (ExitCode, error) {
 		return ExitInvalidCode, fmt.Errorf("Invalid exit code %q in error %s", m[1], err.Error())
 	}
 	if i < 0 || i > 255 {
-		return ExitInvalidCode, fmt.Errorf("Exit code %q out of range [0-255] in error %s", m[1], err.Error())
+		return ExitInvalidCode, fmt.Errorf("Exit code %q out of range [0-255]", m[1])
 	}
 	return ExitCode(i), nil
 }

--- a/connectivity/tests/cidr.go
+++ b/connectivity/tests/cidr.go
@@ -41,6 +41,8 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 	for _, ep := range eps {
 		var i int
 		for _, src := range t.Context().ClientPods() {
+			src := src // copy to avoid memory aliasing when using reference
+
 			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, curl(ep))
 
@@ -48,7 +50,6 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 					RSTAllowed: true,
 				}))
 			})
-
 			i++
 		}
 	}

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -35,12 +35,16 @@ func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, src := range t.Context().ClientPods() {
+		src := src // copy to avoid memory aliasing when using reference
+
 		for _, dst := range t.Context().ClientPods() {
 			if src.Pod.Status.PodIP == dst.Pod.Status.PodIP {
 				// Currently we only get flows once per IP,
 				// skip pings to self.
 				continue
 			}
+
+			dst := dst // copy to avoid memory aliasing when using reference
 
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &src, &dst).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ping(dst))

--- a/connectivity/tests/externalworkload.go
+++ b/connectivity/tests/externalworkload.go
@@ -32,8 +32,9 @@ func (s *podToExternalWorkload) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, pod := range t.Context().ClientPods() {
-		for _, wl := range t.Context().ExternalWorkloads() {
+		pod := pod // copy to avoid memory aliasing when using reference
 
+		for _, wl := range t.Context().ExternalWorkloads() {
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, wl).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ping(wl))
 

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -48,8 +48,9 @@ func (s *podToHost) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, pod := range t.Context().ClientPods() {
-		for _, node := range nodes {
+		pod := pod // copy to avoid memory aliasing when using reference
 
+		for _, node := range nodes {
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, node).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ping(node))
 

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -36,8 +36,9 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, client := range t.Context().ClientPods() {
-		for _, echo := range t.Context().EchoPods() {
+		client := client // copy to avoid memory aliasing when using reference
 
+		for _, echo := range t.Context().EchoPods() {
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, echo).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, curl(echo))
 

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -35,8 +35,9 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, pod := range t.Context().ClientPods() {
-		for _, svc := range t.Context().EchoServices() {
+		pod := pod // copy to avoid memory aliasing when using reference
 
+		for _, svc := range t.Context().EchoServices() {
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, curl(svc))
 
@@ -76,8 +77,12 @@ func (s *podToRemoteNodePort) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, pod := range t.Context().ClientPods() {
+		pod := pod // copy to avoid memory aliasing when using reference
+
 		for _, svc := range t.Context().EchoServices() {
 			for _, node := range t.Context().CiliumPods() {
+				node := node // copy to avoid memory aliasing when using reference
+
 				// Use Cilium Pods as a substitute for nodes accepting workloads.
 				if pod.Pod.Status.HostIP != node.Pod.Status.HostIP {
 					// If src and dst pod are running on different nodes,
@@ -117,8 +122,12 @@ func (s *podToLocalNodePort) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, pod := range t.Context().ClientPods() {
+		pod := pod // copy to avoid memory aliasing when using reference
+
 		for _, svc := range t.Context().EchoServices() {
 			for _, node := range t.Context().CiliumPods() {
+				node := node // copy to avoid memory aliasing when using reference
+
 				// Use Cilium Pods as a substitute for nodes accepting workloads.
 				if pod.Pod.Status.HostIP == node.Pod.Status.HostIP {
 					// If src and dst pod are running on the same node,

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -44,6 +44,8 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, client := range t.Context().ClientPods() {
+		client := client // copy to avoid memory aliasing when using reference
+
 		// With http, over port 80.
 		t.NewAction(s, fmt.Sprintf("http-to-one-one-one-one-%d", i), &client, http).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, curl(http))

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -237,7 +237,7 @@ func (k *K8sStatusCollector) podStatus(ctx context.Context, status *Status, name
 
 	phaseCount, imageCount := MapCount{}, MapCount{}
 
-	for _, pod := range pods.Items {
+	for i, pod := range pods.Items {
 		phaseCount[string(pod.Status.Phase)]++
 
 		switch pod.Status.Phase {
@@ -253,7 +253,7 @@ func (k *K8sStatusCollector) podStatus(ctx context.Context, status *Status, name
 		}
 
 		if callback != nil {
-			callback(ctx, status, name, &pod)
+			callback(ctx, status, name, &pods.Items[i])
 		}
 	}
 

--- a/status/status.go
+++ b/status/status.go
@@ -332,8 +332,7 @@ func (s *Status) Format() string {
 		}
 	}
 
-	header := "Cluster Pods:"
-	fmt.Fprintf(w, "%s\t%s\n", header, formatPodsCount(s.PodsCount))
+	fmt.Fprintf(w, "Cluster Pods:\t%s\n", formatPodsCount(s.PodsCount))
 
 	if len(s.ImageCount) > 0 {
 		header := "Image versions"
@@ -345,7 +344,7 @@ func (s *Status) Format() string {
 		}
 	}
 
-	header = "Errors:"
+	header := "Errors:"
 	for deployment, pods := range s.Errors {
 		for pod, a := range pods {
 			for _, err := range a.Errors {


### PR DESCRIPTION
The first three commits fix various issues found by the additional linters, the last commit enables these linters and configures them accordingly.

See individual commit messages for details.