### PR TITLE
Ensure defaultMode=0400 for projected volumes containing secrets

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -46,7 +46,7 @@ var (
 	replicas                 = int32(1)
 	deploymentMaxSurge       = intstr.FromInt(1)
 	deploymentMaxUnavailable = intstr.FromInt(1)
-	secretDefaultMode        = int32(420)
+	secretDefaultMode        = int32(0400)
 )
 
 var clusterRole = &rbacv1.ClusterRole{

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -27,6 +27,7 @@ const (
 )
 
 var (
+	secretDefaultMode        = int32(0400)
 	relayReplicas            = int32(1)
 	relayPortIntstr          = intstr.FromInt(defaults.RelayPort)
 	deploymentMaxSurge       = intstr.FromInt(1)
@@ -168,6 +169,7 @@ func (k *K8sHubble) generateRelayDeployment() *appsv1.Deployment {
 							Name: "tls",
 							VolumeSource: corev1.VolumeSource{
 								Projected: &corev1.ProjectedVolumeSource{
+									DefaultMode: &secretDefaultMode,
 									Sources: []corev1.VolumeProjection{
 										{
 											Secret: &corev1.SecretProjection{

--- a/install/install.go
+++ b/install/install.go
@@ -37,7 +37,7 @@ var (
 	agentTerminationGracePeriodSeconds = int64(1)
 	hostPathDirectoryOrCreate          = corev1.HostPathDirectoryOrCreate
 	hostPathFileOrCreate               = corev1.HostPathFileOrCreate
-	secretDefaultMode                  = int32(420)
+	secretDefaultMode                  = int32(0400)
 	operatorReplicas                   = int32(1)
 	operatorMaxSurge                   = intstr.FromInt(1)
 	operatorMaxUnavailable             = intstr.FromInt(1)
@@ -594,6 +594,7 @@ func (k *K8sInstaller) generateAgentDaemonSet() *appsv1.DaemonSet {
 							Name: "hubble-tls",
 							VolumeSource: corev1.VolumeSource{
 								Projected: &corev1.ProjectedVolumeSource{
+									DefaultMode: &secretDefaultMode,
 									Sources: []corev1.VolumeProjection{
 										{
 											Secret: &corev1.SecretProjection{


### PR DESCRIPTION
Follow https://github.com/cilium/cilium/pull/17367:

It seems that these volumes were wrongly given permission 420 instead of
0400, giving write permission to the group. In all instances, the actual
volumeMounts were set to readonly so this change should have no effect
but better be more cautious about permissions for secrets.

Reported-by: Robin Hahling <robin.hahling@gw-computing.net>
Signed-off-by: Tobias Klauser <tobias@cilium.io>