### PR TITLE
connectivity/check: use correct ServicePort name

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -119,7 +119,7 @@ func newService(name string, selector map[string]string, labels map[string]strin
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeNodePort,
 			Ports: []corev1.ServicePort{
-				{Name: name, Port: int32(port)},
+				{Name: portName, Port: int32(port)},
 			},
 			Selector: selector,
 		},


### PR DESCRIPTION
Use the provided port name, not the service name for ServicePort.

Before:

```
  ports:
  - name: echo-other-node
    nodePort: 31244
    port: 8080
    protocol: TCP
    targetPort: 8080
```

After:

```
  ports:
  - name: http
    nodePort: 31244
    port: 8080
    protocol: TCP
    targetPort: 8080
```