### PR TITLE
cmd: Add --extra-label-selectors log collector

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -55,6 +55,9 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().BoolVar(&sysdumpOptions.Debug,
 		"debug", sysdump.DefaultDebug,
 		"Whether to enable debug logging")
+	cmd.Flags().StringArrayVar(&sysdumpOptions.ExtraLabelSelectors,
+		"extra-label-selectors", nil,
+		"Optional set of labels selectors used to target additional pods for log collection.")
 	cmd.Flags().StringVar(&sysdumpOptions.HubbleLabelSelector,
 		"hubble-label-selector", sysdump.DefaultHubbleLabelSelector,
 		"The labels used to target Hubble pods")


### PR DESCRIPTION
This adds an optional flag which allows users to specify additional pod label selectors, which will be used to collect collect logs of additional pods matching that selector in the Cilium namespace.

The flag allows for multiple selectors, e.g. `--extra-label-selectors key=value --extra-label-selectors foo=bar,baz=bat` will select any pods with the `key=value` label OR any pods with both the `foo=bar` AND `baz=bat` labels.

Example usage:
```console
cilium sysdump --extra-label-selectors k8s-app=kube-dns
```