### PR TITLE
.github/workflows: install Go for `go run` in multicluster job

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -51,6 +51,11 @@ jobs:
         run: |
           gcloud info
 
+      - name: Set up Go
+        uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57
+        with:
+          go-version: 1.17.1
+
       - name: Set up job variables
         id: vars
         run: |


### PR DESCRIPTION
The multicluster workflow uses `go run` but doesn't explicitly install a
specific Go version. Thus, in some cases an older Go version might be
used which leads to failures such as:
    
```
vendor/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go:21:2: cannot find package "." in:
        /home/runner/work/cilium-cli/cilium-cli/vendor/io/fs
```

Fixes #554