### PR TITLE
Disable cfssl log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ To install Cilium while automatically detected:
     🔮 Auto-detected datapath mode: tunnel
     🔑 Found existing CA in secret cilium-ca
     🔑 Generating certificates for Hubble...
-    2021/01/06 14:40:09 [INFO] generate received request
-    2021/01/06 14:40:09 [INFO] received CSR
-    2021/01/06 14:40:09 [INFO] generating key: ecdsa-256
-    2021/01/06 14:40:09 [INFO] encoded CSR
-    2021/01/06 14:40:09 [INFO] signed certificate with serial number 100064573681617100283382379701098370105206717828
     🚀 Creating service accounts...
     🚀 Creating cluster roles...
     🚀 Creating ConfigMap...
@@ -75,16 +70,6 @@ To install Cilium while automatically detected:
 
     cilium hubble enable
     🔑 Generating certificates for Relay...
-    2021/01/06 14:40:21 [INFO] generate received request
-    2021/01/06 14:40:21 [INFO] received CSR
-    2021/01/06 14:40:21 [INFO] generating key: ecdsa-256
-    2021/01/06 14:40:21 [INFO] encoded CSR
-    2021/01/06 14:40:21 [INFO] signed certificate with serial number 257161504887184430913779255692233956510035935986
-    2021/01/06 14:40:21 [INFO] generate received request
-    2021/01/06 14:40:21 [INFO] received CSR
-    2021/01/06 14:40:21 [INFO] generating key: ecdsa-256
-    2021/01/06 14:40:21 [INFO] encoded CSR
-    2021/01/06 14:40:21 [INFO] signed certificate with serial number 282554813841417773944504735898535346056548994034
     ✨ Deploying Relay...
 
 ### Status
@@ -231,11 +216,6 @@ Install Cilium & enable ClusterMesh in Cluster 1
     🚀 Creating resource quotas...
     🔑 Found existing CA in secret cilium-ca
     🔑 Generating certificates for Hubble...
-    2021/01/08 23:07:52 [INFO] generate received request
-    2021/01/08 23:07:52 [INFO] received CSR
-    2021/01/08 23:07:52 [INFO] generating key: ecdsa-256
-    2021/01/08 23:07:52 [INFO] encoded CSR
-    2021/01/08 23:07:52 [INFO] signed certificate with serial number 412940817381691474277840557608535075673795002662
     🚀 Creating service accounts...
     🚀 Creating cluster roles...
     🚀 Creating ConfigMap...
@@ -248,21 +228,6 @@ Install Cilium & enable ClusterMesh in Cluster 1
     ✅ Valid cluster identification found: name="gke-cilium-dev-us-west2-a-tgraf-cluster1" id="1"
     🔑 Found existing CA in secret cilium-ca
     🔑 Generating certificates for ClusterMesh...
-    2021/01/08 23:11:48 [INFO] generate received request
-    2021/01/08 23:11:48 [INFO] received CSR
-    2021/01/08 23:11:48 [INFO] generating key: ecdsa-256
-    2021/01/08 23:11:48 [INFO] encoded CSR
-    2021/01/08 23:11:48 [INFO] signed certificate with serial number 670714666407590575359066679305478681356106905869
-    2021/01/08 23:11:48 [INFO] generate received request
-    2021/01/08 23:11:48 [INFO] received CSR
-    2021/01/08 23:11:48 [INFO] generating key: ecdsa-256
-    2021/01/08 23:11:49 [INFO] encoded CSR
-    2021/01/08 23:11:49 [INFO] signed certificate with serial number 591065363597916136413807294935737333774847803115
-    2021/01/08 23:11:49 [INFO] generate received request
-    2021/01/08 23:11:49 [INFO] received CSR
-    2021/01/08 23:11:49 [INFO] generating key: ecdsa-256
-    2021/01/08 23:11:49 [INFO] encoded CSR
-    2021/01/08 23:11:49 [INFO] signed certificate with serial number 212022707754116737648249489711560171325685820957
     ✨ Deploying clustermesh-apiserver...
     🔮 Auto-exposing service within GCP VPC (cloud.google.com/load-balancer-type=internal)
 
@@ -278,11 +243,6 @@ Install Cilium in Cluster 2
     🚀 Creating resource quotas...
     🔑 Found existing CA in secret cilium-ca
     🔑 Generating certificates for Hubble...
-    2021/01/08 23:08:28 [INFO] generate received request
-    2021/01/08 23:08:28 [INFO] received CSR
-    2021/01/08 23:08:28 [INFO] generating key: ecdsa-256
-    2021/01/08 23:08:28 [INFO] encoded CSR
-    2021/01/08 23:08:28 [INFO] signed certificate with serial number 166290456484087465763866003270622908833747392670
     🚀 Creating service accounts...
     🚀 Creating cluster roles...
     🚀 Creating ConfigMap...
@@ -295,21 +255,6 @@ Install Cilium in Cluster 2
     ✅ Valid cluster identification found: name="gke-cilium-dev-us-west2-a-tgraf-cluster2" id="2"
     🔑 Found existing CA in secret cilium-ca
     🔑 Generating certificates for ClusterMesh...
-    2021/01/08 23:12:44 [INFO] generate received request
-    2021/01/08 23:12:44 [INFO] received CSR
-    2021/01/08 23:12:44 [INFO] generating key: ecdsa-256
-    2021/01/08 23:12:45 [INFO] encoded CSR
-    2021/01/08 23:12:45 [INFO] signed certificate with serial number 450145143290293186546054780525926209813963421076
-    2021/01/08 23:12:45 [INFO] generate received request
-    2021/01/08 23:12:45 [INFO] received CSR
-    2021/01/08 23:12:45 [INFO] generating key: ecdsa-256
-    2021/01/08 23:12:45 [INFO] encoded CSR
-    2021/01/08 23:12:45 [INFO] signed certificate with serial number 341741502649230631228454642926521374579240641715
-    2021/01/08 23:12:45 [INFO] generate received request
-    2021/01/08 23:12:45 [INFO] received CSR
-    2021/01/08 23:12:45 [INFO] generating key: ecdsa-256
-    2021/01/08 23:12:45 [INFO] encoded CSR
-    2021/01/08 23:12:45 [INFO] signed certificate with serial number 233979838156429984835251051892420687423155442107
     ✨ Deploying clustermesh-apiserver...
     🔮 Auto-exposing service within GCP VPC (cloud.google.com/load-balancer-type=internal)
 
@@ -341,12 +286,7 @@ Install a Cilium in a cluster and enable encryption with IPsec
     🔮 Auto-detected cluster name: kind-chart-testing
     🔮 Auto-detected IPAM mode: kubernetes
     🔑 Found existing CA in secret cilium-ca
-    2021/01/25 10:13:47 [INFO] generate received request
     🔑 Generating certificates for Hubble...
-    2021/01/25 10:13:47 [INFO] received CSR
-    2021/01/25 10:13:47 [INFO] generating key: ecdsa-256
-    2021/01/25 10:13:47 [INFO] encoded CSR
-    2021/01/25 10:13:47 [INFO] signed certificate with serial number 254989930644407824918712685524397372889683962312
     🚀 Creating Service accounts...
     🚀 Creating Cluster roles...
     🔑 Generated encryption secret cilium-ipsec-keys

--- a/cmd/cilium/main.go
+++ b/cmd/cilium/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 
 	"github.com/cilium/cilium-cli/internal/cli/cmd"
+	// necessary to disable unwanted cfssl log messages
+	_ "github.com/cilium/cilium-cli/internal/logging"
 
 	gops "github.com/google/gops/agent"
 )

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+package logging
+
+import (
+	cfsslLog "github.com/cloudflare/cfssl/log"
+)
+
+func init() {
+	cfsslLog.SetLogger(&noopLogger{})
+}
+
+// noopLogger implements cfsslLog.SyslogWriter to avoid logging unwanted log messages.
+type noopLogger struct{}
+
+// Debug implements cfsslLog.SyslogWriter.
+func (s *noopLogger) Debug(msg string) {}
+
+// Info implements cfsslLog.SyslogWriter.
+func (s *noopLogger) Info(msg string) {}
+
+// Warning implements cfsslLog.SyslogWriter.
+func (s *noopLogger) Warning(msg string) {}
+
+// Error implements cfsslLog.SyslogWriter.
+func (s *noopLogger) Err(msg string) {}
+
+// Crit implements cfsslLog.SyslogWriter.
+func (s *noopLogger) Crit(msg string) {}
+
+// Emerg implements cfsslLog.SyslogWriter.
+func (s *noopLogger) Emerg(msg string) {}


### PR DESCRIPTION
The cfssl library logs to stdout by default, leading to confusing
messages during various `cilium` commands, e.g.

```
$ cilium install
🔮 Auto-detected Kubernetes kind: kind
✨ Running "kind" validation checks
✅ Detected kind version "0.11.1"
ℹ️  using Cilium version "v1.10.4"
🔮 Auto-detected cluster name: kind-chart-testing
🔮 Auto-detected IPAM mode: kubernetes
🔮 Auto-detected datapath mode: tunnel
🔮 Custom datapath mode: tunnel
🔑 Generating CA...
2021/09/23 13:05:01 [INFO] generate received request
2021/09/23 13:05:01 [INFO] received CSR
2021/09/23 13:05:01 [INFO] generating key: ecdsa-256
2021/09/23 13:05:01 [INFO] encoded CSR
2021/09/23 13:05:01 [INFO] signed certificate with serial number 287136694468458141817041413205774711456458631957
2021/09/23 13:05:01 [INFO] generate received request
🔑 Generating certificates for Hubble...
2021/09/23 13:05:01 [INFO] received CSR
2021/09/23 13:05:01 [INFO] generating key: ecdsa-256
2021/09/23 13:05:01 [INFO] encoded CSR
2021/09/23 13:05:01 [INFO] signed certificate with serial number 326863135560875035053628039061560703009800390216
🚀 Creating Service accounts...
🚀 Creating Cluster roles...
🚀 Creating ConfigMap for Cilium version 1.10.4...
ℹ️ Manual overwrite in ConfigMap: monitor-aggregation=none
🚀 Creating Agent DaemonSet...
🚀 Creating Operator Deployment...
⌛ Waiting for Cilium to become ready before restarting unmanaged pods...
✅ Cilium was successfully installed! Run 'cilium status' to view installation health
```

Disable these messages by setting the cfssl library logger to a noop
logger, leading to the following output:

```
$ cilium install
🔮 Auto-detected Kubernetes kind: kind
✨ Running "kind" validation checks
✅ Detected kind version "0.11.1"
ℹ️  using Cilium version "v1.10.4"
🔮 Auto-detected cluster name: kind-chart-testing
🔮 Auto-detected IPAM mode: kubernetes
🔮 Auto-detected datapath mode: tunnel
🔮 Custom datapath mode: tunnel
🔑 Generating CA...
🔑 Generating certificates for Hubble...
🚀 Creating Service accounts...
🚀 Creating Cluster roles...
🚀 Creating ConfigMap for Cilium version 1.10.4...
ℹ️ Manual overwrite in ConfigMap: monitor-aggregation=none
🚀 Creating Agent DaemonSet...
🚀 Creating Operator Deployment...
⌛ Waiting for Cilium to become ready before restarting unmanaged pods...
✅ Cilium was successfully installed! Run 'cilium status' to view installation health
```

If at a later point we decide to introduce a common logging package
(isee #388), this will allow us to redirect the log messages to our
logging framework, similar to github.com/cilium/certgen/internal/logging