### PR TITLE
Wait correctly for Cilium to be ready before deploying Hubble Relay

### DIFF
--- a/.github/in-cluster-test-scripts/aks.sh
+++ b/.github/in-cluster-test-scripts/aks.sh
@@ -6,9 +6,6 @@ set -e
 # Enable Relay
 cilium hubble enable
 
-# Wait for Cilium status to be ready
-cilium status --wait
-
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -14,9 +14,6 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
-# Wait for Cilium status to be ready
-cilium status --wait
-
 # Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
 [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -12,9 +12,6 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
-# Wait for Cilium status to be ready
-cilium status --wait
-
 # Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
 [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 

--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -14,9 +14,6 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
-# Wait for Cilium status to be ready
-cilium status --wait
-
 # Enable cluster mesh
 cilium clustermesh enable
 

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -12,9 +12,6 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
-# Wait for Cilium status to be ready
-cilium status --wait
-
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -28,10 +28,6 @@ cilium install \
 cilium --context "${CONTEXT1}" hubble enable
 cilium --context "${CONTEXT2}" hubble enable --relay=false
 
-# Wait for Cilium status to be ready
-cilium --context "${CONTEXT1}" status --wait
-cilium --context "${CONTEXT2}" status --wait
-
 # Enable cluster mesh
 cilium --context "${CONTEXT1}" clustermesh enable
 cilium --context "${CONTEXT2}" clustermesh enable

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -53,10 +53,6 @@ jobs:
         run: |
           cilium hubble enable --ui
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Relay Port Forward
         run: |
           cilium hubble port-forward&
@@ -78,10 +74,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable
-
-      - name: Status
-        run: |
-          cilium status --wait
 
       - name: Relay Port Forward
         run: |

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1170,7 +1170,7 @@ func (k *K8sClusterMesh) Status(ctx context.Context) (*Status, error) {
 		return nil, err
 	}
 
-	collector, err := status.NewK8sStatusCollector(ctx, k.client, status.K8sStatusParameters{
+	collector, err := status.NewK8sStatusCollector(k.client, status.K8sStatusParameters{
 		Namespace: k.params.Namespace,
 	})
 	if err != nil {
@@ -1570,7 +1570,7 @@ func formatCEW(cew ciliumv2.CiliumExternalWorkload) string {
 }
 
 func (k *K8sClusterMesh) ExternalWorkloadStatus(ctx context.Context, names []string) error {
-	collector, err := status.NewK8sStatusCollector(ctx, k.client, status.K8sStatusParameters{
+	collector, err := status.NewK8sStatusCollector(k.client, status.K8sStatusParameters{
 		Namespace: k.params.Namespace,
 	})
 	if err != nil {

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -274,7 +274,7 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 	if k.params.Relay || k.params.UI {
 		start := time.Now()
 		k.Log("⌛ Waiting for Cilium to become ready before deploying other Hubble component(s)...")
-		collector, err := status.NewK8sStatusCollector(ctx, k.client, status.K8sStatusParameters{
+		collector, err := status.NewK8sStatusCollector(k.client, status.K8sStatusParameters{
 			Namespace:       k.params.Namespace,
 			Wait:            true,
 			WaitDuration:    k.params.WaitDuration,
@@ -315,7 +315,7 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 		}
 
 		k.Log("⌛ Waiting for Hubble to be installed...")
-		collector, err := status.NewK8sStatusCollector(ctx, k.client, status.K8sStatusParameters{
+		collector, err := status.NewK8sStatusCollector(k.client, status.K8sStatusParameters{
 			Namespace:       k.params.Namespace,
 			Wait:            true,
 			WaitDuration:    k.params.WaitDuration - dur,

--- a/install/install.go
+++ b/install/install.go
@@ -1688,9 +1688,7 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 
 		s, err := collector.Status(ctx)
 		if err != nil {
-			if s != nil {
-				fmt.Println(s.Format())
-			}
+			fmt.Print(s.Format())
 			return err
 		}
 	}

--- a/install/install.go
+++ b/install/install.go
@@ -1676,7 +1676,7 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 
 	if k.params.Wait {
 		k.Log("⌛ Waiting for Cilium to be installed...")
-		collector, err := status.NewK8sStatusCollector(ctx, k.client, status.K8sStatusParameters{
+		collector, err := status.NewK8sStatusCollector(k.client, status.K8sStatusParameters{
 			Namespace:       k.params.Namespace,
 			Wait:            true,
 			WaitDuration:    k.params.WaitDuration,

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -84,9 +84,7 @@ func (k *K8sInstaller) Upgrade(ctx context.Context) error {
 
 		s, err := collector.Status(ctx)
 		if err != nil {
-			if s != nil {
-				fmt.Println(s.Format())
-			}
+			fmt.Print(s.Format())
 			return err
 		}
 	}

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -72,7 +72,7 @@ func (k *K8sInstaller) Upgrade(ctx context.Context) error {
 
 	if patched > 0 && k.params.Wait {
 		k.Log("⌛ Waiting for Cilium to be upgraded...")
-		collector, err := status.NewK8sStatusCollector(ctx, k.client, status.K8sStatusParameters{
+		collector, err := status.NewK8sStatusCollector(k.client, status.K8sStatusParameters{
 			Namespace:       k.params.Namespace,
 			Wait:            true,
 			WaitDuration:    k.params.WaitDuration,

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -56,6 +56,8 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().BoolVar(&params.UI, "ui", false, "Enable Hubble UI")
 	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", false, "Automatically create CA if needed")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
+	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait for status")
 	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
 		"Timeout for Cilium to become ready before deploying Hubble components")
 

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -58,8 +58,10 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait for status")
-	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
-		"Timeout for Cilium to become ready before deploying Hubble components")
+	// TODO(tklauser): remove for release 0.9.3
+	cmd.Flags().DurationVar(&params.WaitDuration, "cilium-ready-timeout", 15*time.Minute,
+		"Timeout for Cilium to become ready before deploying Hubble components (deprecated, alias for --wait-duration)")
+	cmd.Flags().MarkHidden("cilium-ready-timeout")
 
 	return cmd
 }

--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -21,7 +21,7 @@ func newCmdStatus() *cobra.Command {
 		Short: "Display status",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			collector, err := status.NewK8sStatusCollector(context.Background(), k8sClient, params)
+			collector, err := status.NewK8sStatusCollector(k8sClient, params)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -28,9 +28,7 @@ func newCmdStatus() *cobra.Command {
 
 			s, err := collector.Status(context.Background())
 			// Report the most recent status even if an error occurred.
-			if s != nil {
-				fmt.Println(s.Format())
-			}
+			fmt.Print(s.Format())
 			if err != nil {
 				fatalf("Unable to determine status:  %s", err)
 			}

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -50,7 +50,7 @@ type k8sImplementation interface {
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 }
 
-func NewK8sStatusCollector(ctx context.Context, client k8sImplementation, params K8sStatusParameters) (*K8sStatusCollector, error) {
+func NewK8sStatusCollector(client k8sImplementation, params K8sStatusParameters) (*K8sStatusCollector, error) {
 	return &K8sStatusCollector{
 		client: client,
 		params: params,

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -157,7 +157,7 @@ func (b *StatusSuite) TestStatus(c *check.C) {
 	client := newK8sStatusMockClient()
 	c.Assert(client, check.Not(check.IsNil))
 
-	collector, err := NewK8sStatusCollector(context.Background(), client, fakeParameters)
+	collector, err := NewK8sStatusCollector(client, fakeParameters)
 	c.Assert(err, check.IsNil)
 	c.Assert(collector, check.Not(check.IsNil))
 
@@ -206,7 +206,7 @@ func (b *StatusSuite) TestFormat(c *check.C) {
 	client := newK8sStatusMockClient()
 	c.Assert(client, check.Not(check.IsNil))
 
-	collector, err := NewK8sStatusCollector(context.Background(), client, fakeParameters)
+	collector, err := NewK8sStatusCollector(client, fakeParameters)
 	c.Assert(err, check.IsNil)
 	c.Assert(collector, check.Not(check.IsNil))
 

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -218,6 +218,9 @@ func (b *StatusSuite) TestFormat(c *check.C) {
 	status, err := collector.Status(context.Background())
 	c.Assert(err, check.IsNil)
 	buf := status.Format()
-	c.Assert(buf, check.Not(check.Equals), "")
-	fmt.Println(buf)
+	c.Assert(buf[len(buf)-1], check.Equals, byte('\n'))
+
+	var nilStatus *Status
+	buf = nilStatus.Format()
+	c.Assert(buf, check.Equals, "")
 }

--- a/status/status.go
+++ b/status/status.go
@@ -306,8 +306,11 @@ func (c PodStateCount) Format() string {
 }
 
 func (s *Status) Format() string {
-	var buf bytes.Buffer
+	if s == nil {
+		return ""
+	}
 
+	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 4, ' ', 0)
 
 	fmt.Fprintf(w, Yellow+"    /¯¯\\\n")


### PR DESCRIPTION
Like on install and upgrade, use a `K8sStatusCollector` to wait for Cilium
to be fully ready before deploying Hubble Relay. Moreover, report the
status in case Cilium didn't become ready within the given timeout.
    
The first commit refactors some common code in preparation for the second commit, which implements the actual functionality. The third commit changes `cilium hubble enable` to - by default - wait for the Hubble deployments to be ready (this behavior can be disabled using `--wait=false` as with other commands). The fourth commit drops the now superfluous `cilium status --wait` commands after `cilium hubble enable` from CI.

See individual commit messages for details.

Fixes #164
Fixes #389