### PR TITLE
Prepare flow validation for L7 LB support

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -455,7 +455,7 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 	case TCP:
 		tcpRequest := filters.TCP(0, a.dst.Port())
 		tcpResponse := filters.TCP(a.dst.Port(), 0)
-		if p.NodePort != 0 {
+		if p.NodePort != 0 && p.NodePort != a.dst.Port() {
 			tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
 			tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
 		}

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -410,10 +410,8 @@ func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, req 
 }
 
 func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSetRequirement) {
-	var egress filters.FlowSetRequirement
 	srcIP := a.src.Address()
 	dstIP := a.dst.Address()
-
 	if dstIP != "" && net.ParseIP(dstIP) == nil {
 		// dstIP is not an IP address, assume it is a domain name
 		dstIP = ""
@@ -421,6 +419,10 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 
 	ipRequest := filters.IP(srcIP, dstIP)
 	ipResponse := filters.IP(dstIP, srcIP)
+
+	var egress filters.FlowSetRequirement
+	var http filters.FlowSetRequirement
+	haveHTTP := false
 
 	switch p.Protocol {
 	case ICMP:
@@ -482,17 +484,6 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 					{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.Drop()), Msg: "L3/L4 Drop"},
 				},
 			}
-			if a.expEgress.Drop {
-				// L7 drop
-				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.L7Drop()), Msg: "L7 Drop"})
-			}
-			if a.expEgress.HTTP.Status != "" || a.expEgress.HTTP.Method != "" || a.expEgress.HTTP.URL != "" {
-				code := uint32(math.MaxUint32)
-				if s, err := strconv.Atoi(a.expEgress.HTTP.Status); err == nil {
-					code = uint32(s)
-				}
-				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.HTTP(code, a.expEgress.HTTP.Method, a.expEgress.HTTP.URL)), Msg: "HTTP"})
-			}
 			if p.RSTAllowed {
 				// For the connection termination, we will either see:
 				// a) FIN + FIN b) FIN + RST c) RST
@@ -500,6 +491,23 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 				egress.Last = filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true}
 			} else {
 				egress.Except = append(egress.Except, filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.RST()), Msg: "RST"})
+			}
+			if a.expEgress.L7Proxy || a.expEgress.HTTP.Status != "" || a.expEgress.HTTP.Method != "" || a.expEgress.HTTP.URL != "" {
+				// HTTP access logs may come from a separate Envoy proxy upstream connection which may be
+				// kept open. Add a separate flow requirement with FIN filter replaced with a L7/HTTP
+				// filter to allow for both a separate connection and a missing FIN.
+				http = egress
+				haveHTTP = true
+				if a.expEgress.Drop {
+					// L7 drop
+					http.Last = filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.L7Drop()), Msg: "L7 Drop"}
+				} else if a.expEgress.HTTP.Status != "" || a.expEgress.HTTP.Method != "" || a.expEgress.HTTP.URL != "" {
+					code := uint32(math.MaxUint32)
+					if s, err := strconv.Atoi(a.expEgress.HTTP.Status); err == nil {
+						code = uint32(s)
+					}
+					http.Last = filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.HTTP(code, a.expEgress.HTTP.Method, a.expEgress.HTTP.URL)), Msg: "HTTP"}
+				}
 			}
 		}
 	case UDP:
@@ -530,6 +538,9 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 		reqs = append(reqs, dns)
 	}
 	reqs = append(reqs, egress)
+	if haveHTTP {
+		reqs = append(reqs, http)
+	}
 
 	return reqs
 }


### PR DESCRIPTION
Make flow validation more robust when multiple TCP connections may be seen in Hubble output, as in the case of L7 LB by:

- Avoid duplicate port filters (only a cosmetic change)
- Settle wildcarded ephemeral port and destination IP on the first SYN only
  - Otherwise multiple L4 connections during the test will not be properly matched
- Move HTTP flow validation to a separate requirement
  - FIN requirement is removed from the HTTP connection, as Envoy may keep the connection open
  - The same connection may match both L3/L4 and HTTP requirement as before
