### PR TITLE
external workload: Run cilium-agent in host cgroup namespace

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1420,6 +1420,10 @@ fi
 
 DOCKER_OPTS=" -d --log-driver local --restart always"
 DOCKER_OPTS+=" --privileged --network host --cap-add NET_ADMIN --cap-add SYS_MODULE"
+# Run cilium agent in the host's cgroup namespace so that
+# socket-based load balancing works as expected.
+# See https://github.com/cilium/cilium/pull/16259 for more details.
+DOCKER_OPTS+=" --cgroupns=host"
 DOCKER_OPTS+=" --volume /var/lib/cilium/etcd:/var/lib/cilium/etcd"
 DOCKER_OPTS+=" --volume /var/run/cilium:/var/run/cilium"
 DOCKER_OPTS+=" --volume /boot:/boot"


### PR DESCRIPTION
Recent versions of Docker create a new cgroup namespace for each container.
Add Docker CLI option `--cgroupns=host` to the external workload installation
script (generated by `cilium clustermesh vm install`) so that the cilium
agent will run in host cgroup namespace and service load-balancing will work
as expected in external workloads.

Fixes: #569

Signed-off-by: Wazir Ahmed <wazir@accuknox.com>
