### PR TITLE
Explicitly pass VERSION to the release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ release:
 		--rm \
 		--workdir /cilium \
 		--volume `pwd`:/cilium docker.io/library/golang:1.17.2-alpine3.14 \
-		sh -c "apk add --no-cache make git && make local-release"
+		sh -c "apk add --no-cache make git && make local-release VERSION=${VERSION}"
 
 local-release: clean
 	for OS in darwin linux windows; do \


### PR DESCRIPTION
This allows you to override the default VERSION when necessary by
running:

    make release VERSION=custom-version

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>