### PR TITLE
sysdump: Add --cilium-bugtool-flags flag

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -96,6 +96,9 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().IntVar(&sysdumpOptions.WorkerCount,
 		"worker-count", sysdump.DefaultWorkerCount,
 		"The number of workers to use\nNOTE: There is a lower bound requirement on the number of workers for the sysdump operation to be effective. Therefore, for low values, the actual number of workers may be adjusted upwards.")
+	cmd.Flags().StringArrayVar(&sysdumpOptions.CiliumBugtoolFlags,
+		"cilium-bugtool-flags", nil,
+		"Optional set of flags to pass to cilium-bugtool command.")
 
 	return cmd
 }


### PR DESCRIPTION
- Add --cilium-bugtool-flags flag to allow users to pass flags to
  cilium-bugtool. For example:

      % ./cilium sysdump --debug \
        --cilium-bugtool-flags=--exec-timeout=60s \
        --cilium-bugtool-flags=--enable-markdown
      ...
      🩺 Executing cilium-bugtool command: [cilium-bugtool --exec-timeout=60s --enable-markdown]
      ...
- Log stderr from cilium-bugtool if it fails.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>