### PR TITLE
install: Add CENP to agent ClusterRole

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -116,6 +116,7 @@ var ciliumClusterRole = &rbacv1.ClusterRole{
 				"ciliumlocalredirectpolicies",
 				"ciliumlocalredirectpolicies/status",
 				"ciliumlocalredirectpolicies/finalizers",
+				"ciliumegressnatpolicies",
 			},
 			Verbs: []string{"*"},
 		},


### PR DESCRIPTION
This pull request allows the agents to handle `CiliumEgressNATPolicies` to use the egress gateway. The CRD was missing from the ClusterRole.