### PR TITLE
sysdump: report error if NewCollector fails

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -33,7 +33,7 @@ func newCmdSysdump() *cobra.Command {
 			// Collect the sysdump.
 			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now())
 			if err != nil {
-				return nil
+				return fmt.Errorf("failed to create sysdump collector: %v", err)
 			}
 			if err = collector.Run(); err != nil {
 				return fmt.Errorf("failed to collect sysdump: %v", err)


### PR DESCRIPTION
If sysdump.NewCollector fails for some reason (e.g. while collecting
Kubernetes nodes), report the error back to the user instead of ignoring
it and leaving the user in the dark about which step failed.

Fixes: d8d6f2df60de ("sysdump: Refactor absoluteTempPath")