### PR TITLE
client: add 'v2alpha1' types to scheme

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -54,6 +54,7 @@ type Client struct {
 func NewClient(contextName, kubeconfig string) (*Client, error) {
 	// Register the Cilium types in the default scheme.
 	_ = ciliumv2.AddToScheme(scheme.Scheme)
+	_ = ciliumv2alpha1.AddToScheme(scheme.Scheme)
 
 	restClientGetter := genericclioptions.ConfigFlags{
 		Context:    &contextName,


### PR DESCRIPTION
The fact that `v2alpha1` types are currently not added to the scheme may
cause errors during, for instance, sysdump execution. In particular,
`CiliumEgressNATPolicy` resources may be skipped altogether.
