### PR TITLE
install: Disable BPF masquerading by default

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -1264,7 +1264,7 @@ func (k *K8sInstaller) generateConfigMap() (*corev1.ConfigMap, error) {
 			// wait-bpf-mount makes init container wait until bpf filesystem is mounted
 			"wait-bpf-mount": "true",
 
-			"enable-bpf-masquerade": "true",
+			"enable-bpf-masquerade": "false",
 
 			"enable-xt-socket-fallback":           "true",
 			"install-iptables-rules":              "true",


### PR DESCRIPTION
In commit bf2c1f99, we switched `kube-proxy-replacement` to disabled by default. We didn't change the default setting for BPF masquerading, even though it requires `kube-proxy-replacement` to be enabled. As a result, default installation result in a warning when BPF masquerading is forcefully disabled.

This pull request disables BPF masquerading by default to fix it. We could enable BPF masquerading when `kube-proxy-replacement` is enabled by the user, but it seems more confusing than anything.

Fixes: https://github.com/cilium/cilium-cli/pull/136.