### PR TITLE
connectivity: drop `cilium status --wait` from Hubble enable instructions

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -314,7 +314,6 @@ func (ct *ConnectivityTest) enableHubbleClient(ctx context.Context) error {
 		ct.Warn("Unable to contact Hubble Relay, disabling Hubble telescope and flow validation:", err)
 		ct.Info(`Expose Relay locally with:
    cilium hubble enable
-   cilium status --wait
    cilium hubble port-forward&`)
 		ct.hubbleClient = nil
 		ct.params.Hubble = false


### PR DESCRIPTION
After commit b0b3bd519f2f ("hubble: wait for deployments to be ready
after enabling them") `cilium hubble enable` itself waits for the relay
deployment to become ready, so `cilium status --wait` is no longer
necessary.