### PR TITLE
install: Add init container to mount cgroup2 filesystem

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -71,6 +71,8 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
 		"Timeout for Cilium to become ready before restarting unmanaged pods")
 	cmd.Flags().BoolVar(&params.Rollback, "rollback", true, "Roll back installed resources on failure")
+	cmd.Flags().StringVar(&params.CgroupHostRoot, "cgroup-hostRoot", "/run/cilium/cgroupv2", "Host path to mount cgroup2 filesystem")
+	cmd.Flags().StringVar(&params.CniBinPath, "cni-bin-path", "/home/kubernetes/bin", "Path for CNI binary files")
 
 	cmd.Flags().StringVar(&params.Azure.ResourceGroupName, "azure-resource-group", "", "Azure resource group name the cluster is in (required)")
 	cmd.Flags().StringVar(&params.Azure.AKSNodeResourceGroup, "azure-node-resource-group", "", "Azure node resource group name the cluster is in. Bypasses `--azure-resource-group` if provided.")


### PR DESCRIPTION
We need to mount cgroup2 filesystem on the underlying host in order to enable socket-based load-balancing in environments with container runtime cgroupv2 configurations.

See issues for more details - https://github.com/cilium/cilium/pull/16259
and https://github.com/cilium/cilium/pull/16815.

Fixes: #256 