### PR TITLE
kind: Bump kindest/node image to support testing on arm64

### DIFF
--- a/.github/kind-config-1.yaml
+++ b/.github/kind-config-1.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.19.11
 networking:
   disableDefaultCNI: true
   podSubnet: "10.201.0.0/16"

--- a/.github/kind-config-2.yaml
+++ b/.github/kind-config-2.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.19.11
 networking:
   disableDefaultCNI: true
   podSubnet: "10.202.0.0/16"

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.19.11
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.19.11
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"


### PR DESCRIPTION
Bump kindest/node to v1.19.11 (latest for k8s 1.19) to support testing
on arm64, as arm64 native images are available with these and later
future versions:

v1.14.10
v1.15.12
v1.16.15
v1.17.17
v1.18.19
v1.19.11
v1.20.7
v1.21.1 - v1.21.2
v1.22.0 - v1.22.4

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>