### PR TITLE
Cilium CA: Autogenerate Cilium CA if it is missing

### DIFF
--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -183,23 +183,19 @@ func (k *K8sClusterMesh) deleteCertificates(ctx context.Context) error {
 }
 
 func (k *K8sClusterMesh) installCertificates(ctx context.Context) error {
-	err := k.certManager.LoadCAFromK8s(ctx)
+	caSecret, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, k.params.CreateCA)
 	if err != nil {
-		if !k.params.CreateCA {
-			k.Log("❌ Cilium CA not found: %s", err)
+		k.Log("❌ Unable to get or create the Cilium CA Secret: %s", err)
+		return err
+	}
+
+	if caSecret != nil {
+		err = k.certManager.LoadCAFromK8s(ctx, caSecret)
+		if err != nil {
+			k.Log("❌ Unable to load Cilium CA: %s", err)
 			return err
 		}
-
-		k.Log("🔑 Generating CA...")
-		if err := k.certManager.GenerateCA(); err != nil {
-			return fmt.Errorf("unable to generate CA: %w", err)
-		}
-
-		if err := k.certManager.StoreCAInK8s(ctx); err != nil {
-			return fmt.Errorf("unable to store CA in secret: %w", err)
-		}
-	} else {
-		k.Log("🔑 Found existing CA in secret %s", defaults.CASecretName)
+		k.Log("🔑 Found CA in secret %s", caSecret.Name)
 	}
 
 	k.Log("🔑 Generating certificates for ClusterMesh...")

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -246,23 +246,19 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 		return err
 	}
 
-	err = k.certManager.LoadCAFromK8s(ctx)
+	caSecret, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, k.params.CreateCA)
 	if err != nil {
-		if !k.params.CreateCA {
-			k.Log("❌ Cilium CA not found: %s", err)
+		k.Log("❌ Unable to get or create the Cilium CA Secret: %s", err)
+		return err
+	}
+
+	if caSecret != nil {
+		err = k.certManager.LoadCAFromK8s(ctx, caSecret)
+		if err != nil {
+			k.Log("❌ Unable to load Cilium CA: %s", err)
 			return err
 		}
-
-		k.Log("🔑 Generating CA...")
-		if err := k.certManager.GenerateCA(); err != nil {
-			return fmt.Errorf("unable to generate CA: %w", err)
-		}
-
-		if err := k.certManager.StoreCAInK8s(ctx); err != nil {
-			return fmt.Errorf("unable to store CA in secret: %w", err)
-		}
-	} else {
-		k.Log("🔑 Found existing CA in secret %s", defaults.CASecretName)
+		k.Log("🔑 Found CA in secret %s", caSecret.Name)
 	}
 
 	if err := k.enableHubble(ctx); err != nil {

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -58,7 +58,7 @@ func newCmdClusterMeshEnable() *cobra.Command {
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { ClusterIP | LoadBalancer | NodePort }")
 	cmd.Flags().StringVar(&params.ApiserverImage, "apiserver-image", "", "Container image for clustermesh-apiserver")
 	cmd.Flags().StringVar(&params.ApiserverVersion, "apiserver-version", "", "Container image version for clustermesh-apiserver")
-	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", false, "Automatically create CA if needed")
+	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", true, "Automatically create CA if needed")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "clustermesh-apiserver config entries (key=value)")
 

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -54,7 +54,7 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().StringVar(&params.RelayVersion, "relay-version", "", "Version of Relay to deploy")
 	cmd.Flags().StringVar(&params.RelayServiceType, "relay-service-type", "ClusterIP", "Type of Kubernetes service to expose Hubble Relay")
 	cmd.Flags().BoolVar(&params.UI, "ui", false, "Enable Hubble UI")
-	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", false, "Automatically create CA if needed")
+	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", true, "Automatically create CA if needed")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", defaults.StatusWaitDuration, "Maximum time to wait for status")


### PR DESCRIPTION
Per the [Setting Up Hubble Observability](https://docs.cilium.io/en/stable/gettingstarted/hubble_setup/#hubble-setup) and the [Setting Up Clustermesh](https://docs.cilium.io/en/stable/gettingstarted/clustermesh/clustermesh/#clustermesh) documentation users should expect the `cilium hubble enable` and `cilium clustermesh enable` commands to work as described without having to pass the `--create-ca` flag. 

This PR:
* Splits the `client.GetSecrets` function out of the `LoadCAFromK8s` function in `internal/certs/certs.go` into a new `GetCASecret` function.
  * This simplifies `LoadCAFromK8s` by making it only load the CA and not both get the secret data from K8s and load the CA.
  * This also simplifies checking whether the CA exists.
* Updates `StoreCAInK8s` to return the pointer for the secret that is created. Since this function already has the pointer for the new secret it is easier to return the pointer and then pass it to `LoadCAFromK8s` when a new CA is automatically generated.
* Updates clients of `LoadCAFromK8s` and `StoreCAInK8s` to include the new `GetCASecret` function and new dependencies.

Signed-off-by: Nicholas Lane <nicklaneovi@gmail.com>