### PR TITLE
.github: let dependabot ignore Cilium and Hubble dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     open-pull-requests-limit: 1
     rebase-strategy: disabled
     ignore:
+      - dependency-name: "github.com/cilium/cilium"
+      - dependency-name: "github.com/cilium/hubble"
         # k8s dependencies will be updated manually all at once
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"


### PR DESCRIPTION
To properly update Cilium and Hubble, the replace directives need to be updated as well, something the bot can't do.