### PR TITLE
upgrade: determine correct operator image on AKS/EKS

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -140,9 +140,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		if k.params.DatapathMode != "" {
 			k.Log("🔮 Auto-detected datapath mode: %s", k.params.DatapathMode)
 		}
-	}
-
-	if k.params.DatapathMode != "" {
+	} else {
 		k.Log("🔮 Custom datapath mode: %s", k.params.DatapathMode)
 	}
 

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -57,7 +57,41 @@ func (k *K8sUninstaller) autodetect(ctx context.Context) error {
 	return nil
 }
 
-func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
+func (k *K8sInstaller) detectDatapathMode(withKPR bool) {
+	if k.params.DatapathMode != "" {
+		k.Log("🔮 Custom datapath mode: %s", k.params.DatapathMode)
+		return
+	}
+
+	switch k.flavor.Kind {
+	case k8s.KindKind:
+		k.params.DatapathMode = DatapathTunnel
+
+		if withKPR && k.params.KubeProxyReplacement == "" {
+			k.Log("ℹ️  kube-proxy-replacement disabled")
+			k.params.KubeProxyReplacement = "disabled"
+		}
+	case k8s.KindMinikube:
+		k.params.DatapathMode = DatapathTunnel
+	case k8s.KindEKS:
+		k.params.DatapathMode = DatapathAwsENI
+	case k8s.KindGKE:
+		k.params.DatapathMode = DatapathGKE
+	case k8s.KindAKS:
+		k.params.DatapathMode = DatapathAzure
+
+		if withKPR && k.params.KubeProxyReplacement == "" {
+			k.Log("ℹ️  kube-proxy-replacement disabled")
+			k.params.KubeProxyReplacement = "disabled"
+		}
+	}
+
+	if k.params.DatapathMode != "" {
+		k.Log("🔮 Auto-detected datapath mode: %s", k.params.DatapathMode)
+	}
+}
+
+func (k *K8sInstaller) autodetect(ctx context.Context) error {
 	f, err := k.client.AutodetectFlavor(ctx)
 	if err != nil {
 		return err
@@ -69,9 +103,17 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		k.Log("🔮 Auto-detected Kubernetes kind: %s", f.Kind)
 	}
 
+	return nil
+}
+
+func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
+	if err := k.autodetect(ctx); err != nil {
+		return err
+	}
+
 	if len(validationChecks[k.flavor.Kind]) > 0 {
-		k.Log("✨ Running %q validation checks", f.Kind)
-		for _, check := range validationChecks[f.Kind] {
+		k.Log("✨ Running %q validation checks", k.flavor.Kind)
+		for _, check := range validationChecks[k.flavor.Kind] {
 			name := check.Name()
 			if k.params.checkDisabled(name) {
 				k.Log("⏭️  Skipping disabled validation test %q", name)
@@ -81,7 +123,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 			if err := check.Check(ctx, k); err != nil {
 				k.Log("❌ Validation test %s failed: %s", name, err)
 				k.Log("ℹ️  You can disable the test with --disable-check=%s", name)
-				return fmt.Errorf("validation check for kind %q failed: %w", f.Kind, err)
+				return fmt.Errorf("validation check for kind %q failed: %w", k.flavor.Kind, err)
 			}
 		}
 	}
@@ -89,15 +131,15 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 	k.Log("ℹ️  using Cilium version %q", k.params.Version)
 
 	if k.params.ClusterName == "" {
-		if f.ClusterName != "" {
-			name := strings.ReplaceAll(f.ClusterName, "_", "-")
+		if k.flavor.ClusterName != "" {
+			name := strings.ReplaceAll(k.flavor.ClusterName, "_", "-")
 			k.Log("🔮 Auto-detected cluster name: %s", name)
 			k.params.ClusterName = name
 		}
 	}
 
 	if k.params.IPAM == "" {
-		switch f.Kind {
+		switch k.flavor.Kind {
 		case k8s.KindKind:
 			k.params.IPAM = ipamKubernetes
 		case k8s.KindEKS:
@@ -113,36 +155,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		k.Log("🔮 Auto-detected IPAM mode: %s", k.params.IPAM)
 	}
 
-	if k.params.DatapathMode == "" {
-		switch f.Kind {
-		case k8s.KindKind:
-			k.params.DatapathMode = DatapathTunnel
-
-			if k.params.KubeProxyReplacement == "" {
-				k.Log("ℹ️  kube-proxy-replacement disabled")
-				k.params.KubeProxyReplacement = "disabled"
-			}
-		case k8s.KindMinikube:
-			k.params.DatapathMode = DatapathTunnel
-		case k8s.KindEKS:
-			k.params.DatapathMode = DatapathAwsENI
-		case k8s.KindGKE:
-			k.params.DatapathMode = DatapathGKE
-		case k8s.KindAKS:
-			k.params.DatapathMode = DatapathAzure
-
-			if k.params.KubeProxyReplacement == "" {
-				k.Log("ℹ️  kube-proxy-replacement disabled")
-				k.params.KubeProxyReplacement = "disabled"
-			}
-		}
-
-		if k.params.DatapathMode != "" {
-			k.Log("🔮 Auto-detected datapath mode: %s", k.params.DatapathMode)
-		}
-	} else {
-		k.Log("🔮 Custom datapath mode: %s", k.params.DatapathMode)
-	}
+	k.detectDatapathMode(true)
 
 	if strings.Contains(k.params.ClusterName, ".") {
 		k.Log("❌ Cluster name %q cannot contain dots", k.params.ClusterName)

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -74,7 +74,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		for _, check := range validationChecks[f.Kind] {
 			name := check.Name()
 			if k.params.checkDisabled(name) {
-				k.Log("⏭️  Skipping disabled validtion test %q", name)
+				k.Log("⏭️  Skipping disabled validation test %q", name)
 				continue
 			}
 

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -16,6 +16,14 @@ import (
 )
 
 func (k *K8sInstaller) Upgrade(ctx context.Context) error {
+	if err := k.autodetect(ctx); err != nil {
+		return err
+	}
+
+	// no need to determine KPR setting on upgrade, keep the setting configured with the old
+	// version.
+	k.detectDatapathMode(false)
+
 	daemonSet, err := k.client.GetDaemonSet(ctx, k.params.Namespace, defaults.AgentDaemonSetName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to retrieve DaemonSet of cilium-agent: %s", err)


### PR DESCRIPTION
Use the correct operator image for `cilium upgrade` on AKS or EKS. Also fix a duplicate log message and a log message typo.

See commit messages for details

Fixes #407