### PR TITLE
hubble: remove deprecated `cilium-ready-timeout` flag

### DIFF
--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -58,10 +58,6 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", defaults.StatusWaitDuration, "Maximum time to wait for status")
-	// TODO(tklauser): remove for release 0.9.3
-	cmd.Flags().DurationVar(&params.WaitDuration, "cilium-ready-timeout", defaults.StatusWaitDuration,
-		"Timeout for Cilium to become ready before deploying Hubble components (deprecated, alias for --wait-duration)")
-	cmd.Flags().MarkHidden("cilium-ready-timeout")
 
 	return cmd
 }


### PR DESCRIPTION
Commit 33d86603f56d ("hubble: deprecate and hide `cilium-ready-timeout`
flag") deprecated the `cilium-ready-timeout` flag for cilium-cli v0.9.3
which was released in the meantime. Remove it now for the upcoming
v0.9.4 release.