### PR TITLE
version: Detect special running Cilium versions

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -661,6 +661,14 @@ func (c *Client) GetRunningCiliumVersion(ctx context.Context, namespace string) 
 		if digest := strings.Index(v, "@"); digest > 0 {
 			v = v[:digest]
 		}
+		// Add any part in the pod image separated by a '-` to the version,
+		// e.g., "quay.io/cilium/cilium-ci:1234" -> "-ci:1234"
+		base := strings.Split(version[0], "/")
+		last := base[len(base)-1]
+		dash := strings.Index(last, "-")
+		if dash >= 0 {
+			v = last[dash:] + ":" + v
+		}
 		return v, nil
 	}
 	return "", errors.New("unable to obtain cilium version: no cilium pods found")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -35,6 +35,10 @@ func BuildImagePath(userImage, defaultImage, userVersion, defaultVersion string)
 	if userImage == "" {
 		switch {
 		case userVersion == "":
+			// ':' in defaultVersion?
+			if strings.Contains(defaultVersion, ":") {
+				return defaultImage + defaultVersion
+			}
 			return defaultImage + ":" + defaultVersion
 		case strings.Contains(userVersion, ":"):
 			// userVersion already contains the colon. Useful for ":latest",


### PR DESCRIPTION
When cilium is installed with 'cilium install --version="-ci:1234"'
this version string is added to the standard image names. For the
Cilium agent this becomes "quay.io/cilium/cilium-ci:1234". Detect this
when decoding version from a running Cilium pod by finding the part
after the dash in the image reference, so that the detected version
becomes "-ci:1234". This allows hubble to be enabled without passing
--hubble-version parameter explicitly in this case.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>