### PR TITLE
Cilium envoy crd pre beta

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -353,6 +353,8 @@ func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, req 
 
 		flowCtx := filters.NewFlowContext()
 
+		// First match can fix wildcarded source port & destination IP,
+		// all other requirements must have the same values.
 		index, matched, _ := match(true, req.First, &flowCtx)
 		if !matched {
 			r.NeedMoreFlows = true
@@ -360,6 +362,8 @@ func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, req 
 			break
 		}
 		r.FirstMatch = index
+		// Fix wildcards if any
+		flowCtx.FixWildcards(flows[index].Flow)
 
 		for _, f := range req.Middle {
 			if f.SkipOnAggregation && a.test.ctx.FlowAggregation() {

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -402,6 +402,9 @@ func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, req 
 
 func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSetRequirement) {
 	var egress filters.FlowSetRequirement
+	var http filters.FlowSetRequirement
+	haveHTTP := false
+
 	srcIP := a.src.Address()
 	dstIP := a.dst.Address()
 
@@ -473,17 +476,6 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 					{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.Drop()), Msg: "L3/L4 Drop"},
 				},
 			}
-			if a.expEgress.Drop {
-				// L7 drop
-				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.L7Drop()), Msg: "L7 Drop"})
-			}
-			if a.expEgress.HTTP.Status != "" || a.expEgress.HTTP.Method != "" || a.expEgress.HTTP.URL != "" {
-				code := uint32(math.MaxUint32)
-				if s, err := strconv.Atoi(a.expEgress.HTTP.Status); err == nil {
-					code = uint32(s)
-				}
-				egress.Middle = append(egress.Middle, filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.HTTP(code, a.expEgress.HTTP.Method, a.expEgress.HTTP.URL)), Msg: "HTTP"})
-			}
 			if p.RSTAllowed {
 				// For the connection termination, we will either see:
 				// a) FIN + FIN b) FIN + RST c) RST
@@ -491,6 +483,22 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 				egress.Last = filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.Or(filters.FIN(), filters.RST())), Msg: "FIN or RST", SkipOnAggregation: true}
 			} else {
 				egress.Except = append(egress.Except, filters.FlowRequirement{Filter: filters.And(filters.Or(filters.And(ipRequest, tcpRequest), filters.And(ipResponse, tcpResponse)), filters.RST()), Msg: "RST"})
+			}
+			if a.expEgress.L7Proxy || a.expEgress.HTTP.Status != "" || a.expEgress.HTTP.Method != "" || a.expEgress.HTTP.URL != "" {
+				// HTTP access logs may come from a separate Envoy proxy upstream connection which may be
+				// kept open. Add a separate flow requirement with only HTTP level requirements.
+				haveHTTP = true
+				http.First = filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.HTTPRequest(a.expEgress.HTTP.Method, a.expEgress.HTTP.URL)), Msg: "HTTP-Request"}
+				if a.expEgress.Drop {
+					// L7 drop
+					http.Last = filters.FlowRequirement{Filter: filters.And(ipRequest, tcpRequest, filters.L7Drop()), Msg: "L7 Drop"}
+				} else if a.expEgress.HTTP.Status != "" || a.expEgress.HTTP.Method != "" || a.expEgress.HTTP.URL != "" {
+					code := uint32(math.MaxUint32)
+					if s, err := strconv.Atoi(a.expEgress.HTTP.Status); err == nil {
+						code = uint32(s)
+					}
+					http.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, tcpResponse, filters.HTTPResponse(code, a.expEgress.HTTP.Method, a.expEgress.HTTP.URL)), Msg: "HTTP-Response"}
+				}
 			}
 		}
 	case UDP:
@@ -521,6 +529,9 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 		reqs = append(reqs, dns)
 	}
 	reqs = append(reqs, egress)
+	if haveHTTP {
+		reqs = append(reqs, http)
+	}
 
 	return reqs
 }

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -442,7 +442,7 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 	case TCP:
 		tcpRequest := filters.TCP(0, a.dst.Port())
 		tcpResponse := filters.TCP(a.dst.Port(), 0)
-		if p.NodePort != 0 {
+		if p.NodePort != 0 && p.NodePort != a.dst.Port() {
 			tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
 			tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
 		}

--- a/connectivity/manifests/envoy-ingress-test.yaml
+++ b/connectivity/manifests/envoy-ingress-test.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-ingress
+  namespace: cilium-test
+spec:
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: my-ingress
+  namespace: cilium-test
+subsets:
+  - addresses:
+      # Dummy IP, never used but required for now
+      - ip: 192.192.192.192
+    ports:
+      - port: 8080
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-ingress-listener
+spec:
+  services:
+  - name: my-ingress
+    namespace: cilium-test
+  backendServices:
+  - name: echo-other-node
+    namespace: cilium-test
+  - name: echo-same-node
+    namespace: cilium-test
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: envoy-ingress-listener
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: envoy-ingress-listener
+          rds:
+            route_config_name: ingress_route
+          http_filters:
+          - name: envoy.filters.http.router
+  - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: ingress_route
+    virtual_hosts:
+    - name: "ingress_route"
+      domains: ["*"]
+      routes:
+      - match:
+          prefix: "/"
+        route:
+          weighted_clusters:
+            clusters:
+            - name: "cilium-test/echo-same-node"
+              weight: 50
+            - name: "cilium-test/echo-other-node"
+              weight: 50
+          retry_policy:
+            retry_on: 5xx
+            num_retries: 3
+            per_try_timeout: 1s
+          regex_rewrite:
+            pattern:
+              google_re2: {}
+              regex: "^/foo.*$"
+            substitution: "/"
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: "cilium-test/echo-same-node"
+    connect_timeout: 5s
+    lb_policy: ROUND_ROBIN
+    type: EDS
+    outlier_detection:
+      split_external_local_origin_errors: true
+      consecutive_local_origin_failure: 2
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: "cilium-test/echo-other-node"
+    connect_timeout: 3s
+    lb_policy: ROUND_ROBIN
+    type: EDS
+    outlier_detection:
+      split_external_local_origin_errors: true
+      consecutive_local_origin_failure: 2

--- a/connectivity/manifests/envoy-prometheus-metrics-listener-multiresource.yaml
+++ b/connectivity/manifests/envoy-prometheus-metrics-listener-multiresource.yaml
@@ -1,0 +1,34 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-prometheus-metrics-listener
+spec:
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: envoy-prometheus-metrics-listener
+    address:
+      socket_address:
+        address: "::"
+        ipv4_compat: true
+        port_value: 9090
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: envoy-prometheus-metrics-listener
+          rds:
+            route_config_name: prometheus_route
+          http_filters:
+          - name: envoy.filters.http.router
+  - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: prometheus_route
+    virtual_hosts:
+    - name: "prometheus_metrics_route"
+      domains: ["*"]
+      routes:
+      - match:
+          path: "/metrics"
+        route:
+          cluster: "envoy-admin"
+          prefix_rewrite: "/stats/prometheus"

--- a/connectivity/manifests/envoy-prometheus-metrics-listener.yaml
+++ b/connectivity/manifests/envoy-prometheus-metrics-listener.yaml
@@ -1,0 +1,31 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-prometheus-metrics-listener
+spec:
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: envoy-prometheus-metrics-listener
+    address:
+      socket_address:
+        address: "::"
+        ipv4_compat: true
+        port_value: 9090
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: envoy-prometheus-metrics-listener
+          route_config:
+            virtual_hosts:
+            - name: "prometheus_metrics_route"
+              domains: ["*"]
+              routes:
+              - match:
+                  path: "/metrics"
+                route:
+                  cluster: "envoy-admin"
+                  prefix_rewrite: "/stats/prometheus"
+          http_filters:
+          - name: envoy.filters.http.router

--- a/connectivity/manifests/envoy-test.yaml
+++ b/connectivity/manifests/envoy-test.yaml
@@ -1,0 +1,63 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-lb-listener
+spec:
+  services:
+  - name: echo-other-node
+    namespace: cilium-test
+  - name: echo-same-node
+    namespace: cilium-test
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: envoy-lb-listener
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: envoy-lb-listener
+          rds:
+            route_config_name: lb_route
+          http_filters:
+          - name: envoy.filters.http.router
+  - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: lb_route
+    virtual_hosts:
+    - name: "lb_route"
+      domains: ["*"]
+      routes:
+      - match:
+          prefix: "/"
+        route:
+          weighted_clusters:
+            clusters:
+            - name: "cilium-test/echo-same-node"
+              weight: 50
+            - name: "cilium-test/echo-other-node"
+              weight: 50
+          retry_policy:
+            retry_on: 5xx
+            num_retries: 3
+            per_try_timeout: 1s
+          regex_rewrite:
+            pattern:
+              google_re2: {}
+              regex: "^/foo.*$"
+            substitution: "/"
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: "cilium-test/echo-same-node"
+    connect_timeout: 5s
+    lb_policy: ROUND_ROBIN
+    type: EDS
+    outlier_detection:
+      split_external_local_origin_errors: true
+      consecutive_local_origin_failure: 2
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: "cilium-test/echo-other-node"
+    connect_timeout: 3s
+    lb_policy: ROUND_ROBIN
+    type: EDS
+    outlier_detection:
+      split_external_local_origin_errors: true
+      consecutive_local_origin_failure: 2

--- a/connectivity/manifests/ingress.yaml
+++ b/connectivity/manifests/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: cilium-test
+spec:
+  ingressClassName: cilium
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: echo-same-node
+            port:
+              number: 8080
+        path: /publiz
+        pathType: Exact
+      - backend:
+          service:
+            name: echo-other-node
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/connectivity/manifests/ingress2.yaml
+++ b/connectivity/manifests/ingress2.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress2
+  namespace: cilium-test
+spec:
+  ingressClassName: cilium
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: echo-same-node
+            port:
+              number: 80
+        path: /private
+        pathType: Exact
+      - backend:
+          service:
+            name: echo-same-node
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -156,6 +156,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		WithPolicy(clientEgressL7HTTPPolicyYAML).  // L7 allow policy with HTTP introspection
 		WithScenarios(
 			tests.PodToPod(""),
+			tests.PodToService(""),
 			tests.PodToWorld(""),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -661,6 +661,14 @@ func (c *Client) GetRunningCiliumVersion(ctx context.Context, namespace string) 
 		if digest := strings.Index(v, "@"); digest > 0 {
 			v = v[:digest]
 		}
+		// Add any part in the pod image separated by a '-` to the version,
+		// e.g., "quay.io/cilium/cilium-ci:1234" -> "-ci:1234"
+		base := strings.Split(version[0], "/")
+		last := base[len(base)-1]
+		dash := strings.Index(last, "-")
+		if dash >= 0 {
+			v = last[dash:] + ":" + v
+		}
 		return v, nil
 	}
 	return "", errors.New("unable to obtain cilium version: no cilium pods found")

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -679,13 +679,13 @@ func (c *Client) GetPlatform(ctx context.Context) (*Platform, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Kubernetes version: %w", err)
 	}
-	fileds := strings.Split(v.Platform, "/")
-	if len(fileds) != 2 {
+	fields := strings.Split(v.Platform, "/")
+	if len(fields) != 2 {
 		return nil, fmt.Errorf("unknown platform type")
 	}
 	return &Platform{
-		OS:   fileds[0],
-		Arch: fileds[1],
+		OS:   fields[0],
+		Arch: fields[1],
 	}, err
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -35,6 +35,10 @@ func BuildImagePath(userImage, defaultImage, userVersion, defaultVersion string)
 	if userImage == "" {
 		switch {
 		case userVersion == "":
+			// ':' in defaultVersion?
+			if strings.Contains(defaultVersion, ":") {
+				return defaultImage + defaultVersion
+			}
 			return defaultImage + ":" + defaultVersion
 		case strings.Contains(userVersion, ":"):
 			// userVersion already contains the colon. Useful for ":latest",


### PR DESCRIPTION
Minor fixes and manifests for testing k8s ingress beta builds:

Draft support for Cilium Envoy Config CRD.

To test:
1. Download [cilium-cli release v0.10.2](https://github.com/cilium/cilium-cli/releases/tag/v0.10.2) OR build this branch:
```
BINDIR=~/.local/bin make install
```
(You may need to modify `BINDIR` to something in your `PATH`)

2. Start Kind cluster (from your `cilium-cli` repo):
```
kind create cluster --config .github/kind-config.yaml
```

3. Install the beta version of Cilium with feature and kube proxy replacement flags on:
```
cilium install --version -service-mesh:v1.11.0-beta.1 --config enable-envoy-config=true --kube-proxy-replacement=probe
cilium hubble enable
cilium hubble port-forward&
```

4. Apply `envoy-test.yaml`:
```
kubectl apply -f connectivity/manifests/envoy-test.yaml
```

5. Run connectivity test to deploy the test services:
```
cilium connectivity test --test egress-l7
```

6. Apply L7 policy:
```
kubectl apply -f connectivity/manifests/client-egress-l7-http.yaml
kubectl apply -f connectivity/manifests/client-egress-only-dns.yaml
```

7. Observe traffic from Hubble:
```
hubble observe --from-pod cilium-test/client2-6dd75b74c6-68h7d -f
```
Note: You need to adjust the exact name of `client2-xxxxx-xxxx`.

8. Try out traffic from client2 (allowed by the policy) couple of times:
```
kubectl exec -it -n cilium-test client2-6dd75b74c6-68h7d -- curl -v echo-other-node:8080/foo
```
Note: You need to adjust (auto-complete) the exact name of `client2-xxxxx-xxxx`.

Observe:
- Without the `envoy-test.yaml` CRD the path `/foo` is not found. This L7 LB rewrites paths starting with `/foo` to `/`, which is found in the echo services.
- ClusterIP (`echo-other-node`) is observed in Hubble output, showing that cluster IP gets out of the source pod.
- The service is 50/50 load balanced to backend(s) of both `echo-same-node` and `echo-other-node`

Example:
```
Oct 13 16:30:59.023: cilium-test/client2-6dd75b74c6-68h7d:45004 <> cilium-test/echo-other-node:8080 from-endpoint FORWARDED (TCP Flags: SYN)
Oct 13 16:30:59.032: cilium-test/client2-6dd75b74c6-68h7d:45004 <> cilium-test/echo-other-node-697d5d69b7-x6qnp:8080 from-proxy FORWARDED (TCP Flags: SYN)
Oct 13 16:31:10.717: cilium-test/client2-6dd75b74c6-68h7d:45164 <> cilium-test/echo-other-node:8080 from-endpoint FORWARDED (TCP Flags: SYN)
Oct 13 16:31:10.721: cilium-test/client2-6dd75b74c6-68h7d:45164 <> cilium-test/echo-same-node-7967996674-t24mq:8080 from-proxy FORWARDED (TCP Flags: SYN)
```

9. Try out denied traffic from client2 (denied by the policy):
```
kubectl exec -it -n cilium-test client2-6dd75b74c6-68h7d -- curl -v echo-other-node:8080/bar
```
Note: You need to adjust (auto-complete) the exact name of `client2-xxxxx-xxxx`.

Observe:
- the path `/bar` is not allowed by the L7 policy, and will get a 403 access denied response.
- ClusterIP (`echo-other-node`) is observed in Hubble output, showing that cluster IP gets out of the source pod.
- Connection to the backend is established as it is allowed on the network level by the policy
- This specific HTTP request is DROPPED by the L7 LB due to the L7 policy not allowing it at the HTTP level.

Example:
```
Feb  8 12:13:55.172: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-other-node:8080 none REDIRECTED (TCP Flags: SYN)
Feb  8 12:13:55.172: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-other-node:8080 to-proxy FORWARDED (TCP Flags: SYN)
Feb  8 12:13:55.172: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-other-node:8080 to-proxy FORWARDED (TCP Flags: ACK)
Feb  8 12:13:55.172: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-other-node:8080 to-proxy FORWARDED (TCP Flags: ACK, PSH)
Feb  8 12:13:55.173: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-same-node-7967996674-vjkpj:8080 L3-L4 REDIRECTED (TCP Flags: SYN)
Feb  8 12:13:55.173: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-same-node-7967996674-vjkpj:8080 to-endpoint FORWARDED (TCP Flags: SYN)
Feb  8 12:13:55.173: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-same-node-7967996674-vjkpj:8080 to-endpoint FORWARDED (TCP Flags: ACK)
Feb  8 12:13:55.174: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-same-node-7967996674-vjkpj:8080 http-request DROPPED (HTTP/1.1 GET http://echo-other-node:8080/bar)
Feb  8 12:13:55.174: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-same-node-7967996674-vjkpj:8080 to-endpoint FORWARDED (TCP Flags: ACK, FIN)
Feb  8 12:13:55.174: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-other-node:8080 to-proxy FORWARDED (TCP Flags: ACK, FIN)
Feb  8 12:13:55.174: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-same-node-7967996674-vjkpj:8080 to-endpoint FORWARDED (TCP Flags: ACK)
Feb  8 12:13:55.174: cilium-test/client2-6dd75b74c6-6bv64:43244 -> cilium-test/echo-other-node:8080 to-proxy FORWARDED (TCP Flags: ACK)
```