### PR TITLE
sysdump: Support fetching DaemonSet with custom name

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -51,6 +51,9 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().StringVar(&sysdumpOptions.CiliumNamespace,
 		"cilium-namespace", sysdump.DefaultCiliumNamespace,
 		"The namespace Cilium is running in")
+	cmd.Flags().StringVar(&sysdumpOptions.CiliumDaemonSetSelector,
+		"cilium-daemon-set-label-selector", sysdump.DefaultCiliumLabelSelector,
+		"The labels used to target Cilium daemon set")
 	cmd.Flags().StringVar(&sysdumpOptions.CiliumOperatorLabelSelector,
 		"cilium-operator-label-selector", sysdump.DefaultCiliumOperatorLabelSelector,
 		"The labels used to target Cilium operator pods")

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -384,6 +384,10 @@ func (c *Client) GetDaemonSet(ctx context.Context, namespace, name string, opts 
 	return c.Clientset.AppsV1().DaemonSets(namespace).Get(ctx, name, opts)
 }
 
+func (c *Client) ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error) {
+	return c.Clientset.AppsV1().DaemonSets(namespace).List(ctx, o)
+}
+
 func (c *Client) DeleteDaemonSet(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.Clientset.AppsV1().DaemonSets(namespace).Delete(ctx, name, opts)
 }

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cilium/cilium-cli/internal/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,6 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/cilium/cilium-cli/internal/k8s"
 )
 
 type KubernetesClient interface {
@@ -37,6 +38,7 @@ type KubernetesClient interface {
 	ListCiliumLocalRedirectPolicies(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumLocalRedirectPolicyList, error)
 	ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error)
 	ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeList, error)
+	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
 	ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error)
 	ListNamespaces(ctx context.Context, o metav1.ListOptions) (*corev1.NamespaceList, error)
 	ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -17,7 +17,6 @@ const (
 	awsNodeDaemonSetNamespace          = metav1.NamespaceSystem
 	ciliumAgentContainerName           = defaults.AgentContainerName
 	ciliumConfigMapName                = defaults.ConfigMapName
-	ciliumDaemonSetName                = defaults.AgentDaemonSetName
 	ciliumEtcdSecretsSecretName        = "cilium-etcd-secrets"
 	ciliumOperatorDeploymentName       = defaults.OperatorDeploymentName
 	clustermeshApiserverDeploymentName = defaults.ClusterMeshDeploymentName

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium-cli/internal/utils"
 
 	"github.com/cilium/workerpool"
-	archiver "github.com/mholt/archiver/v3"
+	"github.com/mholt/archiver/v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +32,8 @@ type Options struct {
 	CiliumLabelSelector string
 	// The namespace Cilium is running in.
 	CiliumNamespace string
+	// The labels used to target Cilium daemon set. Usually, this label is same as CiliumLabelSelector.
+	CiliumDaemonSetSelector string
 	// The labels used to target Cilium operator pods.
 	CiliumOperatorLabelSelector string
 	// The labels used to target 'clustermesh-apiserver' pods.
@@ -437,11 +439,16 @@ func (c *Collector) Run() error {
 			Description: "Collecting the Cilium daemonset",
 			Quick:       true,
 			Task: func(ctx context.Context) error {
-				v, err := c.Client.GetDaemonSet(ctx, c.Options.CiliumNamespace, ciliumDaemonSetName, metav1.GetOptions{})
+				v, err := c.Client.ListDaemonSet(ctx, c.Options.CiliumNamespace, metav1.ListOptions{
+					LabelSelector: c.Options.CiliumDaemonSetSelector,
+				})
 				if err != nil {
 					return fmt.Errorf("failed to collect the Cilium daemonset: %w", err)
 				}
-				if err := c.WriteYAML(ciliumDaemonSetFileName, v); err != nil {
+				if len(v.Items) == 0 {
+					return fmt.Errorf("failed to find Cilium daemonset with label %q in namespace %q", c.Options.CiliumDaemonSetSelector, c.Options.CiliumNamespace)
+				}
+				if err = c.WriteYAML(ciliumDaemonSetFileName, &v.Items[0]); err != nil {
 					return fmt.Errorf("failed to collect the Cilium daemonset: %w", err)
 				}
 				return nil

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -170,6 +170,10 @@ func (c *fakeClient) ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeL
 	panic("implement me")
 }
 
+func (c *fakeClient) ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
### Description 

This commit is to support fetching DaemonSet based on labels, which
is requireds in case of any installation having custom name for
Cilium DaemonSet. Default value for this label selector will be
same as Cilium pod label selector.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

### Testing

Testing was done locally with kind cluster + cilium install, please find below details. 

<details>
<summary>Default run to make sure nothing breaks</summary>

```
$ ./cilium sysdump
🔍 Collecting Kubernetes nodes
🔍 Collect Kubernetes nodes
🔍 Collect Kubernetes version
🔍 Collecting Kubernetes pods
🔍 Collecting Kubernetes services
🔍 Collecting Cilium network policies
🔍 Collecting Kubernetes namespaces
🔍 Collecting Kubernetes pods summary
🔍 Collecting Kubernetes events
🔍 Collecting Kubernetes network policies
🔍 Collecting Cilium egress NAT policies
🔍 Collecting Cilium cluster-wide network policies
🔍 Collecting Cilium endpoints
🔍 Collecting Cilium local redirect policies
🔍 Collecting Cilium identities
🔍 Collecting Cilium nodes
🔍 Collecting Cilium etcd secret
🔍 Collecting the Cilium configuration
🔍 Collecting the Cilium daemonset
...
🗳 Compiling sysdump
✅ The sysdump has been saved to /Users/tammach/go/src/github.com/cilium/cilium-cli/cilium-sysdump-20211222-181533.zip

$ cat cilium-sysdump-20211222-181533/cilium-daemonset-20211222-181533.yaml | head -10
apiVersion: apps/v1
items:
- metadata:
    annotations:
      deprecated.daemonset.template.generation: "1"
    creationTimestamp: "2021-12-22T07:12:24Z"
    generation: 1
    labels:
      k8s-app: cilium
    managedFields:

```

</details>


<details>
<summary>Run with non-default label</summary>

```
$ ./cilium sysdump --cilium-daemon-set-label-selector dummy=label
🔍 Collecting Kubernetes nodes
🔍 Collect Kubernetes nodes
🔍 Collecting Kubernetes events
🔍 Collecting Kubernetes pods
🔍 Collecting Kubernetes services
🔍 Collecting Cilium network policies
🔍 Collect Kubernetes version
🔍 Collecting Kubernetes namespaces
🔍 Collecting Kubernetes network policies
🔍 Collecting Kubernetes pods summary
🔍 Collecting Cilium egress NAT policies
🔍 Collecting Cilium cluster-wide network policies
🔍 Collecting Cilium endpoints
🔍 Collecting Cilium local redirect policies
🔍 Collecting Cilium identities
🔍 Collecting Cilium nodes
🔍 Collecting Cilium etcd secret
🔍 Collecting the Cilium configuration
🔍 Collecting the Cilium daemonset
...
🗳 Compiling sysdump
✅ The sysdump has been saved to /Users/tammach/go/src/github.com/cilium/cilium-cli/cilium-sysdump-20211222-183626.zip

$ cat cilium-sysdump-20211222-183626/cilium-daemonset-20211222-183626.yaml
apiVersion: apps/v1
items: []
kind: DaemonSetList
metadata:
  resourceVersion: "2352"
  selfLink: /apis/apps/v1/namespaces/kube-system/daemonsets
```
</details>

