### PR TITLE
Incorporate review comments

### DIFF
--- a/internal/k8s/copy.go
+++ b/internal/k8s/copy.go
@@ -22,10 +22,11 @@ func (c *Client) CopyFromPod(ctx context.Context, namespace, pod, container stri
 		ReadFunc: readFromPod(ctx, c, namespace, pod, container, srcFile),
 	})
 
-	outFile, err := os.Create(destFile)
+	outFile, err := os.OpenFile(destFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
+	defer outFile.Close()
 
 	if _, err = io.Copy(outFile, pipe); err != nil {
 		return err

--- a/internal/k8s/copy.go
+++ b/internal/k8s/copy.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright 2022 Authors of Cilium
 
 package k8s
 

--- a/internal/k8s/pipe.go
+++ b/internal/k8s/pipe.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright 2022 Authors of Cilium
 
 package k8s
 

--- a/internal/k8s/pipe_test.go
+++ b/internal/k8s/pipe_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of Cilium
+
 package k8s
 
 import (


### PR DESCRIPTION
### Description

To incorporate review comments in #671 

### Testing

Sanity check was done locally with kind cluster to make sure there is no silly mistake :)

<details>
<summary>Sanity check</summary>

```
$ ./cilium sysdump         
🔍 Collecting Kubernetes nodes
🔍 Collect Kubernetes nodes
🔍 Collect Kubernetes version
🔍 Collecting Kubernetes pods
...
🔍 Collecting 'cilium-bugtool' output from Cilium pods
🔍 Collecting logs from Hubble pods
🔍 Collecting logs from Hubble Relay pods
🔍 Collecting platform-specific data
🔍 Collecting Hubble flows from Cilium pods
⚠️ The following tasks failed, the sysdump may be incomplete:
⚠️ [10] Collecting Cilium egress NAT policies: failed to collect Cilium egress NAT policies: the server could not find the requested resource (get ciliumegressnatpolicies.cilium.io)
⚠️ [11] Collecting Cilium local redirect policies: failed to collect Cilium local redirect policies: the server could not find the requested resource (get ciliumlocalredirectpolicies.cilium.io)
⚠️ [19] Collecting the Hubble Relay configuration: failed to collect the Hubble Relay configuration: configmaps "hubble-relay-config" not found
⚠️ hubble-flows-cilium-gnvqz: failed to collect hubble flows for "cilium-gnvqz" in namespace "kube-system": command terminated with exit code 1: failed to connect to 'unix:///var/run/cilium/hubble.sock': connection error: desc = "transport: error while dialing: dial unix /var/run/cilium/hubble.sock: connect: no such file or directory"

⚠️ Please note that depending on your Cilium version and installation options, this may be expected
🗳 Compiling sysdump
✅ The sysdump has been saved to /home/tammach/go/src/github.com/cilium/cilium-cli/cilium-sysdump-20220105-001818.zip

$ ls -lrht cilium-sysdump-20220105-001818.zip 
-rw-rw-r-- 1 tammach tammach 5.0M Jan  5 00:18 cilium-sysdump-20220105-001818.zip

```

</details>