### PR TITLE
install: remove deprecated --native-routing-cidr option

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -9,7 +9,7 @@ cilium install \
   --config monitor-aggregation=none \
   --config tunnel=vxlan \
   --kube-proxy-replacement=strict \
-  --native-routing-cidr="${CLUSTER_CIDR}"
+  --ipv4-native-routing-cidr="${CLUSTER_CIDR}"
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -7,7 +7,7 @@ set -e
 cilium install \
   --cluster-name "${CLUSTER_NAME}" \
   --config monitor-aggregation=none \
-  --native-routing-cidr="${CLUSTER_CIDR}"
+  --ipv4-native-routing-cidr="${CLUSTER_CIDR}"
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -13,7 +13,7 @@ cilium install \
   --cluster-name "${CLUSTER_NAME_1}" \
   --cluster-id 1 \
   --config monitor-aggregation=none \
-  --native-routing-cidr=10.0.0.0/9
+  --ipv4-native-routing-cidr=10.0.0.0/9
 
 # Install Cilium in cluster2
 cilium install \
@@ -21,7 +21,7 @@ cilium install \
   --cluster-name "${CLUSTER_NAME_2}" \
   --cluster-id 2 \
   --config monitor-aggregation=none \
-  --native-routing-cidr=10.0.0.0/9 \
+  --ipv4-native-routing-cidr=10.0.0.0/9 \
   --inherit-ca "${CONTEXT1}"
 
 # Enable Relay

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2022 Authors of Cilium
 
 package cmd
 
@@ -18,9 +18,6 @@ import (
 
 func newCmdInstall() *cobra.Command {
 	var params = install.Parameters{Writer: os.Stdout}
-	var deprecated struct {
-		NativeRoutingCIDR string
-	}
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -36,13 +33,6 @@ cilium install
 cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			switch {
-			case deprecated.NativeRoutingCIDR != "" && params.IPv4NativeRoutingCIDR != "":
-				return fmt.Errorf("cannot set both --native-routing-cidr and --ipv4-native-routing-cidr")
-			case deprecated.NativeRoutingCIDR != "" && params.IPv4NativeRoutingCIDR == "":
-				params.IPv4NativeRoutingCIDR = deprecated.NativeRoutingCIDR
-			}
-
 			installer, err := install.NewK8sInstaller(k8sClient, params)
 			if err != nil {
 				return err
@@ -67,8 +57,6 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use")
 	cmd.Flags().StringVar(&params.IPAM, "ipam", "", "IP Address Management (IPAM) mode")
 	cmd.Flags().StringVar(&params.IPv4NativeRoutingCIDR, "ipv4-native-routing-cidr", "", "IPv4 CIDR within which native routing is possible")
-	cmd.Flags().StringVar(&deprecated.NativeRoutingCIDR, "native-routing-cidr", "", "IPv4 CIDR within which native routing is possible. Deprecated in favor of --ipv4-native-routing-cidr")
-	cmd.Flags().MarkDeprecated("native-routing-cidr", "use --ipv4-native-routing-cidr instead")
 	cmd.Flags().IntVar(&params.ClusterID, "cluster-id", 0, "Unique cluster identifier for multi-cluster")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().StringVar(&params.InheritCA, "inherit-ca", "", "Inherit/import CA from another cluster")


### PR DESCRIPTION
The --native-routing-cidr CLI option was deprecated for release v0.10.0
in commit f38b29f30d6d ("install: replace --native-routing-cidr by
--ipv4-native-routing-cidr"). Remove it now for the upcoming release.

Note that the Cilium ConfigMap option of the same name is still used
with the value passed in the --ipv4-native-routing-cidr option when
installing Cilium 1.10.