### PR TITLE
cilium-ca: fix the cilium-ca creation log line

### DIFF
--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -183,7 +183,7 @@ func (k *K8sClusterMesh) deleteCertificates(ctx context.Context) error {
 }
 
 func (k *K8sClusterMesh) installCertificates(ctx context.Context) error {
-	caSecret, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, k.params.CreateCA)
+	caSecret, created, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, k.params.CreateCA)
 	if err != nil {
 		k.Log("❌ Unable to get or create the Cilium CA Secret: %s", err)
 		return err
@@ -195,7 +195,11 @@ func (k *K8sClusterMesh) installCertificates(ctx context.Context) error {
 			k.Log("❌ Unable to load Cilium CA: %s", err)
 			return err
 		}
-		k.Log("🔑 Found CA in secret %s", caSecret.Name)
+		if created {
+			k.Log("🔑 Created CA in secret %s", caSecret.Name)
+		} else {
+			k.Log("🔑 Found CA in secret %s", caSecret.Name)
+		}
 	}
 
 	k.Log("🔑 Generating certificates for ClusterMesh...")

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -254,7 +254,7 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 		return err
 	}
 
-	caSecret, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, k.params.CreateCA)
+	caSecret, created, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, k.params.CreateCA)
 	if err != nil {
 		k.Log("❌ Unable to get or create the Cilium CA Secret: %s", err)
 		return err
@@ -266,7 +266,11 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 			k.Log("❌ Unable to load Cilium CA: %s", err)
 			return err
 		}
-		k.Log("🔑 Found CA in secret %s", caSecret.Name)
+		if created {
+			k.Log("🔑 Created CA in secret %s", caSecret.Name)
+		} else {
+			k.Log("🔑 Found CA in secret %s", caSecret.Name)
+		}
 	}
 
 	if err := k.enableHubble(ctx); err != nil {

--- a/install/certs.go
+++ b/install/certs.go
@@ -94,7 +94,7 @@ func (k *K8sInstaller) installCerts(ctx context.Context) error {
 		})
 	}
 
-	caSecret, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, true)
+	caSecret, created, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, true)
 	if err != nil {
 		k.Log("❌ Unable to get or create the Cilium CA Secret: %s", err)
 		return err
@@ -110,7 +110,11 @@ func (k *K8sInstaller) installCerts(ctx context.Context) error {
 			})
 			return err
 		}
-		k.Log("🔑 Found CA in secret %s", caSecret.Name)
+		if created {
+			k.Log("🔑 Created CA in secret %s", caSecret.Name)
+		} else {
+			k.Log("🔑 Found CA in secret %s", caSecret.Name)
+		}
 	}
 
 	k.Log("🔑 Generating certificates for Hubble...")


### PR DESCRIPTION
Before this patch, "_Found CA in secret cilium-ca_" would be logged when:

1. The cilium-cli loaded an already exiting secret and,
2. The `cilium-ca` secret was not found and the cilium-cli created it.

This patch log a creation message in the latter case, aiming to avoid the confusing situation where the cilium-cli would hint that an already existing secret was re-used when it was actually created instead.

### Before
On a fresh kind cluster, notice the "🔑 Found CA in secret cilium-ca" message:

```console
% kind create cluster --config ~/kind/three-nodes.yaml --name alex
Creating cluster "alex" ...
 ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
 ✓ Preparing nodes 📦 📦 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing StorageClass 💾
 ✓ Joining worker nodes 🚜
Set kubectl context to "kind-alex"
You can now use your cluster with:

kubectl cluster-info --context kind-alex

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
% cilium install
🔮 Auto-detected Kubernetes kind: kind
✨ Running "kind" validation checks
✅ Detected kind version "0.11.1"
ℹ️  using Cilium version "v1.11.1"
🔮 Auto-detected cluster name: kind-alex
🔮 Auto-detected IPAM mode: kubernetes
🔮 Auto-detected datapath mode: tunnel
🔑 Found CA in secret cilium-ca
🔑 Generating certificates for Hubble...
🚀 Creating Service accounts...
🚀 Creating Cluster roles...
🚀 Creating ConfigMap for Cilium version 1.11.1...
🚀 Creating Agent DaemonSet...
🚀 Creating Operator Deployment...
⌛ Waiting for Cilium to be installed and ready...
✅ Cilium was successfully installed! Run 'cilium status' to view installation health
```

### After

```console
% kind create cluster --config ~/kind/three-nodes.yaml --name alex
Creating cluster "alex" ...
 ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
 ✓ Preparing nodes 📦 📦 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing StorageClass 💾
 ✓ Joining worker nodes 🚜
Set kubectl context to "kind-alex"
You can now use your cluster with:

kubectl cluster-info --context kind-alex

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
% cilium install
🔮 Auto-detected Kubernetes kind: kind
✨ Running "kind" validation checks
✅ Detected kind version "0.11.1"
ℹ️  using Cilium version "v1.11.1"
🔮 Auto-detected cluster name: kind-alex
🔮 Auto-detected IPAM mode: kubernetes
🔮 Auto-detected datapath mode: tunnel
🔑 Created CA in secret cilium-ca
🔑 Generating certificates for Hubble...
🚀 Creating Service accounts...
🚀 Creating Cluster roles...
🚀 Creating ConfigMap for Cilium version 1.11.1...
🚀 Creating Agent DaemonSet...
🚀 Creating Operator Deployment...
⌛ Waiting for Cilium to be installed and ready...
✅ Cilium was successfully installed! Run 'cilium status' to view installation health
```