### PR TITLE
connectivity: include k8s-app=coredns matchLabels

### DIFF
--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -19,3 +19,6 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: coredns

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -24,3 +24,6 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: coredns

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -18,6 +18,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: coredns
     toPorts:
     - ports:
       - port: "53"


### PR DESCRIPTION
A few policy tests explicitly allow egress to CoreDNS, using an ancient
label selector that can't necessarily be relied on. Interestingly, some
of the tests (such as client-egress-to-fqdns-one-one-one-one), already had
network policies that included a label selector for k8s-app=coredns
in addition to k8s-app=kube-dns, but not all.

resolves #697