### PR TITLE
connectivity test: allow node-local DNS cache

### DIFF
--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -19,3 +19,22 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEntities:
+    - host

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -24,3 +24,16 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -22,3 +22,16 @@ spec:
     - ports:
       - port: "53"
         protocol: ANY
+  - toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+  - toEntities:
+    - host
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -32,3 +32,22 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: coredns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEntities:
+    - host


### PR DESCRIPTION
Similarly to https://github.com/cilium/cilium/pull/18672, this PR allows running connectivity-check on clusters with [Nodelocal DNS Cache](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns) running in `hostNetwork=true` pods bound to a link-local IP (standard node-local DNS cache deployment, not using [Cilium LRP](https://docs.cilium.io/en/latest/gettingstarted/local-redirect-policy/#node-local-dns-cache)). For cases when cluster DNS communication should be allowed, it allows DNS requests to the link-local subnets recommended by the [node-local-dns configuration documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/#configuration).

Due to https://github.com/cilium/cilium/issues/18644, it also allows DNS requests to the `host` entity.

Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>