### PR TITLE
autodetect: Allow more characters in cluster name

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -30,7 +30,7 @@ var (
 		},
 	}
 
-	clusterNameValidation = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])$`)
+	clusterNameValidation = regexp.MustCompile(`^[a-z0-9]([-/:a-z0-9]*[a-z0-9])$`)
 )
 
 func (p Parameters) checkDisabled(name string) bool {


### PR DESCRIPTION
### Description

The normal workflow for eks user is to run below command to update
kubeconfig. However, the cluster name in kubeconfig file is following
full ARN format, hence if user uses cilium cli for installation, it
will fail cluster name validation as per below.

This commit is to extend cluster name regex to allow few more characters
e.g. '/', ':' and '-'.

```
aws eks update-kubeconfig --name tammach-17899
```

```
$ cilium install
🔮 Auto-detected Kubernetes kind: EKS
ℹ️  using Cilium version "v1.11.1"
🔮 Auto-detected cluster name: arn:aws:eks:ap-southeast-2:926702434684:cluster/tammach-17899
🔮 Auto-detected IPAM mode: eni
🔮 Auto-detected datapath mode: aws-eni
❌ Cluster name "arn:aws:eks:ap-southeast-2:926702434684:cluster/tammach-17899" is not valid, must match regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])$
↩️ Rolling back installation...
```

Signed-off-by: Tam Mach <tam.mach@isovalent.com>