### PR TITLE
ci: update `az` to 2.30.0

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Display Azure CLI info
         uses: azure/CLI@7378ce2ca3c38b4b063feb7a4cbe384fef978055
         with:
-          azcliversion: 2.0.72
+          azcliversion: 2.34.1
           inlineScript: |
             az account show
 


### PR DESCRIPTION
We believe this might fix the issues we've seen where the operator reports it is missing permissions:

```
level=warning msg="Unable to synchronize Azure virtualnetworks list" error="network.VirtualNetworksClient#ListAll: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code=\"AuthorizationFailed\" Message=\"The client 'd09fb531-793a-40fc-b934-7af73ca60e32' with object id 'd09fb531-793a-40fc-b934-7af73ca60e32' does not have authorization to perform action 'Microsoft.Network/virtualNetworks/read' over scope '/subscriptions/22716d91-fb67-4a07-ac5f-d36ea49d6167' or the scope is invalid. If access was recently granted, please refresh your credentials.\"" subsys=azure
level=fatal msg="Unable to start azure allocator" error="Initial synchronization with instances API failed" subsys=cilium-operator-azure
```