### PR TITLE
Connectivity test network performance

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -63,6 +63,9 @@ type Action struct {
 
 	// failed is true when Fail was called on the Action
 	failed bool
+
+	// Output from action if there is any
+	cmdOutput string
 }
 
 func newAction(t *Test, name string, s Scenario, src *Pod, dst TestPeer) *Action {
@@ -105,6 +108,10 @@ func (a *Action) Source() TestPeer {
 
 func (a *Action) Destination() TestPeer {
 	return a.dst
+}
+
+func (a *Action) CmdOutput() string {
+	return a.cmdOutput
 }
 
 // Run executes function f.
@@ -187,7 +194,7 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 
 	cmdName := cmd[0]
 	cmdStr := strings.Join(cmd, " ")
-
+	a.cmdOutput = output.String()
 	showOutput := false
 	expectedExitCode := a.expectedExitCode()
 	if err != nil {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -39,7 +39,8 @@ type ConnectivityTest struct {
 	ciliumPods        map[string]Pod
 	echoPods          map[string]Pod
 	clientPods        map[string]Pod
-	perfPods          map[string]Pod
+	perfClientPods    map[string]Pod
+	perfServerPod     map[string]Pod
 	echoServices      map[string]Service
 	externalWorkloads map[string]ExternalWorkload
 
@@ -136,7 +137,8 @@ func NewConnectivityTest(client *k8s.Client, p Parameters) (*ConnectivityTest, e
 		ciliumPods:         make(map[string]Pod),
 		echoPods:           make(map[string]Pod),
 		clientPods:         make(map[string]Pod),
-		perfPods:           make(map[string]Pod),
+		perfClientPods:     make(map[string]Pod),
+		perfServerPod:      make(map[string]Pod),
 		echoServices:       make(map[string]Service),
 		externalWorkloads:  make(map[string]ExternalWorkload),
 		tests:              []*Test{},
@@ -442,8 +444,12 @@ func (ct *ConnectivityTest) ClientPods() map[string]Pod {
 	return ct.clientPods
 }
 
-func (ct *ConnectivityTest) PerfPods() map[string]Pod {
-	return ct.perfPods
+func (ct *ConnectivityTest) PerfServerPod() map[string]Pod {
+	return ct.perfServerPod
+}
+
+func (ct *ConnectivityTest) PerfClientPods() map[string]Pod {
+	return ct.perfClientPods
 }
 
 func (ct *ConnectivityTest) EchoPods() map[string]Pod {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -39,6 +39,7 @@ type ConnectivityTest struct {
 	ciliumPods        map[string]Pod
 	echoPods          map[string]Pod
 	clientPods        map[string]Pod
+	perfPods          map[string]Pod
 	echoServices      map[string]Service
 	externalWorkloads map[string]ExternalWorkload
 
@@ -135,6 +136,7 @@ func NewConnectivityTest(client *k8s.Client, p Parameters) (*ConnectivityTest, e
 		ciliumPods:         make(map[string]Pod),
 		echoPods:           make(map[string]Pod),
 		clientPods:         make(map[string]Pod),
+		perfPods:           make(map[string]Pod),
 		echoServices:       make(map[string]Service),
 		externalWorkloads:  make(map[string]ExternalWorkload),
 		tests:              []*Test{},
@@ -438,6 +440,10 @@ func (ct *ConnectivityTest) CiliumPods() map[string]Pod {
 
 func (ct *ConnectivityTest) ClientPods() map[string]Pod {
 	return ct.clientPods
+}
+
+func (ct *ConnectivityTest) PerfPods() map[string]Pod {
+	return ct.perfPods
 }
 
 func (ct *ConnectivityTest) EchoPods() map[string]Pod {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -301,6 +301,7 @@ func (ct *ConnectivityTest) report() error {
 			ct.Logf("🔥 Performance Test : %s", t)
 			ct.Logf("📋 Test Type: %s", r["test"])
 			ct.Logf("📋 Test Protocol: %s", r["protocol"])
+			ct.Logf("📋 Test Duration: %s", r["duration"])
 			ct.Logf("📋 Test Iteration: %s", r["iteration"])
 			ct.Logf("📋 Test Result (in Mbps): %s", r["bps"])
 		}

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -41,6 +41,7 @@ type ConnectivityTest struct {
 	clientPods        map[string]Pod
 	perfClientPods    map[string]Pod
 	perfServerPod     map[string]Pod
+	PerfResults       map[string]map[string]string
 	echoServices      map[string]Service
 	externalWorkloads map[string]ExternalWorkload
 
@@ -140,6 +141,7 @@ func NewConnectivityTest(client *k8s.Client, p Parameters) (*ConnectivityTest, e
 		perfClientPods:     make(map[string]Pod),
 		perfServerPod:      make(map[string]Pod),
 		echoServices:       make(map[string]Service),
+		PerfResults:        make(map[string]map[string]string),
 		externalWorkloads:  make(map[string]ExternalWorkload),
 		tests:              []*Test{},
 		testNames:          make(map[string]struct{}),
@@ -292,6 +294,16 @@ func (ct *ConnectivityTest) report() error {
 		}
 
 		return fmt.Errorf("%d tests failed", nf)
+	}
+	// Report Performance results
+	if len(ct.PerfResults) > 0 {
+		for t, r := range ct.PerfResults {
+			ct.Logf("🔥 Performance Test : %s", t)
+			ct.Logf("📋 Test Type: %s", r["test"])
+			ct.Logf("📋 Test Protocol: %s", r["protocol"])
+			ct.Logf("📋 Test Iteration: %s", r["iteration"])
+			ct.Logf("📋 Test Result (in Mbps): %s", r["bps"])
+		}
 	}
 
 	ct.Headerf("✅ All %d tests (%d actions) successful, %d tests skipped, %d scenarios skipped.", nt-nst, na, nst, nss)

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -248,7 +248,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, PerfClientDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying Perf Client deployment...", ct.clients.src.ClusterName())
-		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, PerfServerName, metav1.GetOptions{})
 		perfClientDeployment := newDeployment(deploymentParameters{
 			Name:  PerfClientDeploymentName,
 			Kind:  kindPerfName,

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -45,8 +45,8 @@ var (
 
 func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	ct.NewTest("perf").WithScenarios(
-		tests.TCPPodtoPod(""),
-		tests.UDPPodtoPod(""),
+		tests.TCPPodtoPod("", ct),
+		tests.UDPPodtoPod("", ct),
 	)
 	// Run all tests without any policies in place.
 	ct.NewTest("no-policies").WithScenarios(

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -45,7 +45,8 @@ var (
 
 func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	ct.NewTest("perf").WithScenarios(
-		tests.PerfPodtoPod(""),
+		tests.TCPPodtoPod(""),
+		tests.UDPPodtoPod(""),
 	)
 	// Run all tests without any policies in place.
 	ct.NewTest("no-policies").WithScenarios(

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -49,7 +49,6 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	)
 	// Run all tests without any policies in place.
 	ct.NewTest("no-policies").WithScenarios(
-		tests.PerfPodtoPod(""),
 		tests.PodToPod(""),
 		tests.ClientToClient(""),
 		tests.PodToService(""),

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -44,8 +44,12 @@ var (
 )
 
 func Run(ctx context.Context, ct *check.ConnectivityTest) error {
+	ct.NewTest("perf").WithScenarios(
+		tests.PerfPodtoPod(""),
+	)
 	// Run all tests without any policies in place.
 	ct.NewTest("no-policies").WithScenarios(
+		tests.PerfPodtoPod(""),
 		tests.PodToPod(""),
 		tests.ClientToClient(""),
 		tests.PodToService(""),

--- a/connectivity/tests/perfpod.go
+++ b/connectivity/tests/perfpod.go
@@ -44,7 +44,7 @@ func iperf(sip string, ctx context.Context, podname string, a *check.Action, sam
 	}
 	for i := 0; i < samples; i++ {
 		var r Result
-		exec := []string{"/usr/bin/iperf3", "-c", sip, "-t", "5", "-Z", "--no-delay", "-J"}
+		exec := []string{"/usr/bin/iperf3", "-c", sip, "-t", "60", "-Z", "--no-delay", "-J"}
 		if udp {
 			exec = []string{"/usr/bin/iperf3", "-u", "-c", sip, "-t", "5", "-Z", "--no-delay", "-J"}
 		}
@@ -55,11 +55,15 @@ func iperf(sip string, ctx context.Context, podname string, a *check.Action, sam
 			a.Fatal("unable to parse output from iperf3")
 		}
 		r.iteration = i
-		r.bps = payload["end"].(map[string]interface{})["sum_sent"].(map[string]interface{})["bits_per_second"]
 		if !udp {
+			r.bps = payload["end"].(map[string]interface{})["sum_sent"].(map[string]interface{})["bits_per_second"]
 			r.rt = payload["end"].(map[string]interface{})["sum_sent"].(map[string]interface{})["retransmits"]
+			results[fmt.Sprintf("%s-tcp-stream-%d", podname, i)] = r
+		} else {
+			r.bps = payload["end"].(map[string]interface{})["sum"].(map[string]interface{})["bits_per_second"]
+			results[fmt.Sprintf("%s-udp-stream-%d", podname, i)] = r
 		}
-		results[fmt.Sprintf("%s-tcp-stream-%d", podname, i)] = r
+
 	}
 	return results
 }
@@ -70,10 +74,10 @@ func (s *tcpPodToPod) Run(ctx context.Context, t *check.Test) {
 			t.NewAction(s, "iperf-tcp", &c, server).Run(func(a *check.Action) {
 				results := iperf(server.Pod.Status.PodIP, ctx, c.Pod.Name, a, 1, false)
 				for test, result := range results {
-					a.Logf("📄 Results for : %s", test)
-					a.Logf("✅ TCP Retransmissions (lower is better) : %d", int(result.rt.(float64)))
-					a.Logf("✅ TCP Stream Performance - Iteration %d : %f (", result.iteration, (result.bps).(float64)/1000000000.0)
-					a.Log()
+
+					fmt.Printf("\n📄 Results for : %s\n", test)
+					fmt.Printf("✅ TCP Retransmissions (lower is better) : %d\n", int(result.rt.(float64)))
+					fmt.Printf("✅ TCP Stream Performance - Iteration %d : %f(Mbps)\n", result.iteration, (result.bps).(float64)/1000000.0)
 				}
 			})
 		}
@@ -106,11 +110,11 @@ func (s *udpPodtoPod) Run(ctx context.Context, t *check.Test) {
 			t.NewAction(s, "iperf-udp", &c, server).Run(func(a *check.Action) {
 				results := iperf(server.Pod.Status.PodIP, ctx, c.Pod.Name, a, 1, true)
 				for test, result := range results {
-					a.Logf("📄 Results for : %s", test)
-					a.Logf("✅ UDP Stream Performance - Iteration %d : %f (", result.iteration, (result.bps).(float64)/1000000000.0)
-					a.Log()
+					fmt.Printf("\n📄 Results for : %s\n", test)
+					fmt.Printf("✅ UDP Stream Performance - Iteration %d : %f(Mbps)\n", result.iteration, (result.bps).(float64)/1000000.0)
 				}
 			})
 		}
 	}
+	t.Info("Message")
 }

--- a/connectivity/tests/perfpod.go
+++ b/connectivity/tests/perfpod.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 )
 
-// TCP Network perforamnce between pods
+// TCP Network Performance
 func TCPPodtoPod(n string, ct *check.ConnectivityTest) check.Scenario {
 	return &tcpPodToPod{
 		name:             n,
@@ -33,16 +33,16 @@ func (s *tcpPodToPod) Name() string {
 
 func (s *tcpPodToPod) Run(ctx context.Context, t *check.Test) {
 	for _, c := range t.Context().PerfClientPods() {
+		c := c
 		for _, server := range t.Context().PerfServerPod() {
 			t.NewAction(s, "iperf-tcp", &c, server).Run(func(a *check.Action) {
-				iperfStream(server.Pod.Status.PodIP, ctx, c.Pod.Name, a, s.connectivityTest, 1, false)
+				iperfStream(ctx, server.Pod.Status.PodIP, c.Pod.Name, a, s.connectivityTest, 1, false)
 			})
 		}
 	}
 }
 
-// UDP Network performance between
-// TCP Network perforamnce between pods
+// UDP Network pPerformance
 func UDPPodtoPod(n string, ct *check.ConnectivityTest) check.Scenario {
 	return &udpPodtoPod{
 		name:             n,
@@ -65,15 +65,16 @@ func (s *udpPodtoPod) Name() string {
 
 func (s *udpPodtoPod) Run(ctx context.Context, t *check.Test) {
 	for _, c := range t.Context().PerfClientPods() {
+		c := c
 		for _, server := range t.Context().PerfServerPod() {
 			t.NewAction(s, "iperf-udp", &c, server).Run(func(a *check.Action) {
-				iperfStream(server.Pod.Status.PodIP, ctx, c.Pod.Name, a, s.connectivityTest, 1, true)
+				iperfStream(ctx, server.Pod.Status.PodIP, c.Pod.Name, a, s.connectivityTest, 1, true)
 			})
 		}
 	}
 }
 
-func iperfStream(sip string, ctx context.Context, podname string, a *check.Action, ct *check.ConnectivityTest, samples int, udp bool) {
+func iperfStream(ctx context.Context, sip string, podname string, a *check.Action, ct *check.ConnectivityTest, samples int, udp bool) {
 	// Allow the user to override the number of samples to capture
 	env, _ := strconv.Atoi(os.Getenv("samples"))
 	if samples < env {

--- a/connectivity/tests/perfpod.go
+++ b/connectivity/tests/perfpod.go
@@ -1,0 +1,116 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+)
+
+// TCP Network perforamnce between pods
+func TCPPodtoPod(n string) check.Scenario {
+	return &tcpPodToPod{
+		name: n,
+	}
+}
+
+type tcpPodToPod struct {
+	name string
+}
+
+func (s *tcpPodToPod) Name() string {
+	tn := "perf[tcp]-pod-to-pod"
+	if s.name == "" {
+		return tn
+	}
+	return fmt.Sprintf("%s:%s", tn, s.name)
+}
+
+type Result struct {
+	iteration int
+	bps       interface{}
+	rt        interface{}
+}
+
+func iperf(sip string, ctx context.Context, podname string, a *check.Action, samples int, udp bool) map[string]Result {
+	results := make(map[string]Result)
+	// Allow the user to override the number of samples to capture
+	env, _ := strconv.Atoi(os.Getenv("samples"))
+	if samples < env {
+		samples = env
+	}
+	for i := 0; i < samples; i++ {
+		var r Result
+		exec := []string{"/usr/bin/iperf3", "-c", sip, "-t", "5", "-Z", "--no-delay", "-J"}
+		if udp {
+			exec = []string{"/usr/bin/iperf3", "-u", "-c", sip, "-t", "5", "-Z", "--no-delay", "-J"}
+		}
+		a.ExecInPod(ctx, exec)
+		var payload map[string]interface{}
+		err := json.Unmarshal([]byte(a.CmdOutput()), &payload)
+		if err != nil {
+			a.Fatal("unable to parse output from iperf3")
+		}
+		r.iteration = i
+		r.bps = payload["end"].(map[string]interface{})["sum_sent"].(map[string]interface{})["bits_per_second"]
+		if !udp {
+			r.rt = payload["end"].(map[string]interface{})["sum_sent"].(map[string]interface{})["retransmits"]
+		}
+		results[fmt.Sprintf("%s-tcp-stream-%d", podname, i)] = r
+	}
+	return results
+}
+
+func (s *tcpPodToPod) Run(ctx context.Context, t *check.Test) {
+	for _, c := range t.Context().PerfClientPods() {
+		for _, server := range t.Context().PerfServerPod() {
+			t.NewAction(s, "iperf-tcp", &c, server).Run(func(a *check.Action) {
+				results := iperf(server.Pod.Status.PodIP, ctx, c.Pod.Name, a, 1, false)
+				for test, result := range results {
+					a.Logf("📄 Results for : %s", test)
+					a.Logf("✅ TCP Retransmissions (lower is better) : %d", int(result.rt.(float64)))
+					a.Logf("✅ TCP Stream Performance - Iteration %d : %f (", result.iteration, (result.bps).(float64)/1000000000.0)
+					a.Log()
+				}
+			})
+		}
+	}
+}
+
+// UDP Network performance between
+// TCP Network perforamnce between pods
+func UDPPodtoPod(n string) check.Scenario {
+	return &udpPodtoPod{
+		name: n,
+	}
+}
+
+type udpPodtoPod struct {
+	name string
+}
+
+func (s *udpPodtoPod) Name() string {
+	tn := "perf-pod-to-pod"
+	if s.name == "" {
+		return tn
+	}
+	return fmt.Sprintf("%s:%s", tn, s.name)
+}
+
+func (s *udpPodtoPod) Run(ctx context.Context, t *check.Test) {
+	for _, c := range t.Context().PerfClientPods() {
+		for _, server := range t.Context().PerfServerPod() {
+			t.NewAction(s, "iperf-udp", &c, server).Run(func(a *check.Action) {
+				results := iperf(server.Pod.Status.PodIP, ctx, c.Pod.Name, a, 1, true)
+				for test, result := range results {
+					a.Logf("📄 Results for : %s", test)
+					a.Logf("✅ UDP Stream Performance - Iteration %d : %f (", result.iteration, (result.bps).(float64)/1000000000.0)
+					a.Log()
+				}
+			})
+		}
+	}
+}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -66,7 +66,7 @@ const (
 	ConnectivityCheckNamespace = "cilium-test"
 
 	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956"
-	ConnectivityPerformanceImage     = "quay.io/cloud-bulldozer/iperf3:latest"
+	ConnectivityPerformanceImage     = "quay.io/jtaleric/iperf3:latest"
 	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b"
 
 	ConfigMapName   = "cilium-config"

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -73,6 +73,8 @@ const (
 	Version         = "v1.11.1"
 	HubbleUIVersion = "v0.8.5"
 
+	PerfTestDuration = 30
+
 	TunnelType = "vxlan"
 
 	StatusWaitDuration = 5 * time.Minute

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -66,6 +66,7 @@ const (
 	ConnectivityCheckNamespace = "cilium-test"
 
 	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956"
+	ConnectivityPerformanceImage     = "quay.io/cloud-bulldozer/iperf3:latest"
 	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b"
 
 	ConfigMapName   = "cilium-config"


### PR DESCRIPTION
Adding TCP/UDP stream data-plane performance test. 

`> cilium connectivity test --test perf` 

User can increase the number of samples to capture by `export samples=<N>`. 
