### PR TITLE
improve status performance

### DIFF
--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -40,6 +40,9 @@ func newCmdStatus() *cobra.Command {
 	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait for status to report success (no errors and warnings)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", defaults.StatusWaitDuration, "Maximum time to wait for status")
 	cmd.Flags().BoolVar(&params.IgnoreWarnings, "ignore-warnings", false, "Ignore warnings when waiting for status to report success")
+	cmd.Flags().IntVar(&params.WorkerCount,
+		"worker-count", status.DefaultWorkerCount,
+		"The number of workers to use")
 
 	return cmd
 }

--- a/status/status.go
+++ b/status/status.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -99,6 +100,8 @@ type Status struct {
 	// CollectionErrors is the errors that accumulated while collecting the
 	// status
 	CollectionErrors []error
+
+	mutex *sync.Mutex
 }
 
 func newStatus() *Status {
@@ -109,6 +112,7 @@ func newStatus() *Status {
 		PodsCount:    PodsCount{},
 		CiliumStatus: CiliumStatusMap{},
 		Errors:       ErrorCountMapMap{},
+		mutex:        &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
## Current situation

`cilium status` takes on our cluster over a minute to execute. This can even be longer in some circumstances.
The status fetching is fully synchronous, if one pod is not ready anymore at the time of the exec this also adds unnecessary time.
Generally speaking the bigger the cluster the longer it takes.

## Proposal
Make the  processing of the agents async.
Tested on a cluster with around 150 nodes.