### PR TITLE
cmd: Add debug-mode flags for install,hubble,clustermesh commands

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -250,6 +250,7 @@ func (k *K8sClusterMesh) generateDeployment(clustermeshApiserverArgs []string) *
 							Name:    "apiserver",
 							Command: []string{"/usr/bin/clustermesh-apiserver"},
 							Args: append(clustermeshApiserverArgs,
+								"--debug="+strconv.FormatBool(k.params.DebugMode),
 								"--cluster-name="+k.clusterName,
 								"--cluster-id="+k.clusterID,
 								"--kvstore-opt",
@@ -458,6 +459,7 @@ type Parameters struct {
 	All                  bool
 	ConfigOverwrites     []string
 	Retries              int
+	DebugMode            bool
 }
 
 func (p Parameters) validateParams() error {

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -84,6 +84,7 @@ type Parameters struct {
 	Context          string // Only for 'kubectl' pass-through commands
 	Wait             bool
 	WaitDuration     time.Duration
+	DebugMode        bool
 }
 
 func (p *Parameters) Log(format string, a ...interface{}) {

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -6,6 +6,7 @@ package hubble
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/cloudflare/cfssl/config"
@@ -100,6 +101,7 @@ func (k *K8sHubble) generateRelayDeployment() *appsv1.Deployment {
 							Command: []string{"hubble-relay"},
 							Args: []string{
 								"serve",
+								"--debug=" + strconv.FormatBool(k.params.DebugMode),
 							},
 							Image:           k.relayImage(utils.ImagePathIncludeDigest),
 							ImagePullPolicy: corev1.PullIfNotPresent,

--- a/install/install.go
+++ b/install/install.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -412,7 +413,7 @@ func (k *K8sInstaller) generateAgentDaemonSet() *appsv1.DaemonSet {
 							Lifecycle: &corev1.Lifecycle{
 								PostStart: &corev1.LifecycleHandler{
 									Exec: &corev1.ExecAction{
-										Command: []string{"/cni-install.sh", "--enable-debug=false"},
+										Command: []string{"/cni-install.sh", fmt.Sprintf("--enable-debug=%t", k.params.DebugMode)},
 									},
 								},
 								PreStop: &corev1.LifecycleHandler{
@@ -1081,6 +1082,7 @@ type Parameters struct {
 	ConfigOverwrites      []string
 	configOverwrites      map[string]string
 	Rollback              bool
+	DebugMode             bool
 
 	// CiliumReadyTimeout defines the wait timeout for Cilium to become ready
 	// after installing.
@@ -1226,8 +1228,7 @@ func (k *K8sInstaller) generateConfigMap() (*corev1.ConfigMap, error) {
 			"identity-allocation-mode":    "crd",
 			"cilium-endpoint-gc-interval": "5m0s",
 
-			// If you want to run cilium in debug mode change this value to true
-			"debug": "false",
+			"debug": strconv.FormatBool(k.params.DebugMode),
 			// The agent can be put into the following three policy enforcement modes
 			// default, always and never.
 			// https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -60,6 +60,7 @@ func newCmdClusterMeshEnable() *cobra.Command {
 	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", true, "Automatically create CA if needed")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "clustermesh-apiserver config entries (key=value)")
+	cmd.Flags().BoolVar(&params.DebugMode, "debug-mode", false, "Enabled debug mode for clustermesh-apiserver")
 
 	return cmd
 }

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -61,7 +61,7 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", defaults.StatusWaitDuration, "Maximum time to wait for status")
-
+	cmd.Flags().BoolVar(&params.DebugMode, "debug-mode", false, "Enabled debug mode for hubble")
 	return cmd
 }
 

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -72,6 +72,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
 		"Timeout for Cilium to become ready before restarting unmanaged pods")
 	cmd.Flags().BoolVar(&params.Rollback, "rollback", true, "Roll back installed resources on failure")
+	cmd.Flags().BoolVar(&params.DebugMode, "debug-mode", false, "Enable debug mode for cilium related component(s)")
 
 	cmd.Flags().StringVar(&params.Azure.ResourceGroupName, "azure-resource-group", "", "Azure resource group name the cluster is in (required)")
 	cmd.Flags().StringVar(&params.Azure.AKSNodeResourceGroup, "azure-node-resource-group", "", "Azure node resource group name the cluster is in. Bypasses `--azure-resource-group` if provided.")


### PR DESCRIPTION
### Description

Having component running with debug mode is handy as part of daily
development activities. While one can easily get around this by
manual modification in code, confimmap, or manifest, it's easier
just to have debug flag from cilium cli. The flag is named as
debug-mode to avoid any conflict with --debug flag, which to enable
debug message in Cilium CLI itself.

Signed-off-by: Tam Mach <tam.mach@isovalent.com>

### Testing

Testing was done locally with below code snippet

<details>

```
cilium install --cluster-name "${CLUSTER_2_NAME}" --cluster-id "2" \
  --inherit-ca "${CLUSTER_1_CONTEXT}" \
  --agent-image "localhost:5000/cilium/cilium:${GIT_HASH}" \
  --operator-image "localhost:5000/cilium/operator-generic:${GIT_HASH}" \
  --ipam kubernetes \
  --debug-mode

cilium clustermesh enable --context "${CLUSTER_2_CONTEXT}" --service-type NodePort \
  --apiserver-image "localhost:5000/cilium/clustermesh-apiserver:${GIT_HASH}" \
  --debug-mode  

```

</details>