### PR TITLE
hubble: don't log to stdout/stderr when opening browser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.2
 	github.com/google/gops v0.3.22
 	github.com/mholt/archiver/v3 v3.5.1
-	github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.3.0
 	google.golang.org/grpc v1.44.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c

--- a/go.sum
+++ b/go.sum
@@ -1332,8 +1332,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.2 h1:qvY3YFXRQE/XB8MlLzJH7mSzBs74eA2gg52YTk6jUPM=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2 h1:acNfDZXmm28D2Yg/c3ALnZStzNaZMSagpbr96vY6Zjc=
-github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -6,6 +6,7 @@ package hubble
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/pkg/browser"
@@ -328,6 +329,9 @@ func (p *Parameters) UIPortForwardCommand(ctx context.Context) error {
 		time.Sleep(5 * time.Second)
 		url := fmt.Sprintf("http://localhost:%d", p.UIPortForward)
 
+		// avoid cluttering stdout/stderr when opening the browser
+		browser.Stdout = io.Discard
+		browser.Stderr = io.Discard
 		p.Log("ℹ️  Opening %q in your browser...", url)
 		browser.OpenURL(url)
 	}()

--- a/vendor/github.com/pkg/browser/browser_netbsd.go
+++ b/vendor/github.com/pkg/browser/browser_netbsd.go
@@ -1,0 +1,14 @@
+package browser
+
+import (
+	"errors"
+	"os/exec"
+)
+
+func openBrowser(url string) error {
+	err := runCmd("xdg-open", url)
+	if e, ok := err.(*exec.Error); ok && e.Err == exec.ErrNotFound {
+		return errors.New("xdg-open: command not found - install xdg-utils from pkgsrc(7)")
+	}
+	return err
+}

--- a/vendor/github.com/pkg/browser/browser_unsupported.go
+++ b/vendor/github.com/pkg/browser/browser_unsupported.go
@@ -1,10 +1,9 @@
-// +build !linux,!windows,!darwin,!openbsd,!freebsd
+// +build !linux,!windows,!darwin,!openbsd,!freebsd,!netbsd
 
 package browser
 
 import (
 	"fmt"
-	"os/exec"
 	"runtime"
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -543,7 +543,7 @@ github.com/pierrec/lz4/v4/internal/lz4block
 github.com/pierrec/lz4/v4/internal/lz4errors
 github.com/pierrec/lz4/v4/internal/lz4stream
 github.com/pierrec/lz4/v4/internal/xxh32
-# github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2
+# github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 ## explicit; go 1.14
 github.com/pkg/browser
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
On some platforms (e.g. Linux), opening the browser using
`cilium hubble ui` might clutter stdout/stderr with messages
from the browser process due to `pkg/browser.OpenURL` logging them to
`os.Stdout`/`os.Stderr` by default. Avoid this by discarding the browser
process' stdout/stderr.