### PR TITLE
sysdump: include own log messages in sysdump

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,7 +19,7 @@ var (
 	sysdumpOptions = sysdump.Options{
 		LargeSysdumpAbortTimeout: sysdump.DefaultLargeSysdumpAbortTimeout,
 		LargeSysdumpThreshold:    sysdump.DefaultLargeSysdumpThreshold,
-		Writer:                   sysdump.DefaultWriter,
+		Writer:                   os.Stdout,
 	}
 )
 

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -4,7 +4,6 @@
 package sysdump
 
 import (
-	"os"
 	"runtime"
 	"time"
 )
@@ -36,7 +35,4 @@ const (
 var (
 	// DefaultWorkerCount is initialized to the machine's available CPUs.
 	DefaultWorkerCount = runtime.NumCPU()
-
-	// DefaultWriter points to os.Stdout by default.
-	DefaultWriter = os.Stdout
 )

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -51,6 +52,8 @@ func (b *SysdumpSuite) TestSysdumpCollector(c *check.C) {
 	c.Assert(path.Base(collector.sysdumpDir), check.Equals, "my-sysdump-"+timestamp)
 	tempFile := collector.AbsoluteTempPath("my-file-<ts>")
 	c.Assert(tempFile, check.Equals, path.Join(collector.sysdumpDir, "my-file-"+timestamp))
+	_, err = os.Stat(path.Join(collector.sysdumpDir, sysdumpLogFile))
+	c.Assert(err, check.IsNil)
 }
 
 func (b *SysdumpSuite) TestNodeList(c *check.C) {


### PR DESCRIPTION
Store the messages logged by `cilium sysdump` in the
`cilium-sysdump.log` file in the sysdump itself. This allows to analyze
potential issues with `cilium sysdump` itself without having to ask
users to retrieve a new sysdump.

Fixes #351