### PR TITLE
connectivity: Don't ignore errors during setup & validation

### DIFF
--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -50,7 +50,9 @@ var (
 )
 
 func Run(ctx context.Context, ct *check.ConnectivityTest) error {
-	ct.SetupAndValidate(ctx)
+	if err := ct.SetupAndValidate(ctx); err != nil {
+		return err
+	}
 
 	version := ct.FetchCiliumPodImageTag()
 	ct.Debugf("Cilium image version: %v", version)


### PR DESCRIPTION
This was causing a timeout during the resolution of services to go unnoticed as it was never logged.

cc @christarazi @tklauser 

Fixes: https://github.com/cilium/cilium-cli/pull/720.