### PR TITLE
workflows: fix AKS workflow not using the right CLI pod

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -203,7 +203,10 @@ jobs:
       - name: Create cilium-cli job
         run: |
           helm install .github/cilium-cli-test-job-chart \
-            --generate-name
+            --generate-name \
+            --set job_name=cilium-cli \
+            --set test_script_cm=cilium-cli-test-script \
+            --set tag=${{ steps.vars.outputs.sha }}
 
       - name: Wait for test job
         env:


### PR DESCRIPTION
The AKS workflow, like the external workload workflow, loads a shell script to execute via a Helm chart twice: first for installing Cilium, then for the connectivity test itself.

The Helm chart takes in additional parameters to specify which version of the CLI should be loaded, and these were missing on the test part of the AKS workflow, resulting in the CLI being loaded off `latest` and not from the PR itself.

Fixes: f6cc7c6c00b7dbd25119f094c2db62f2b1b68b5f