### PR TITLE
Make CRR standalone workload

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -37,6 +37,7 @@ type Parameters struct {
 	SkipIPCacheCheck      bool
 	Perf                  bool
 	PerfDuration          time.Duration
+	PerfCRR               bool
 	PerfSamples           int
 	CiliumBaseVersion     string
 }

--- a/connectivity/tests/perfpod.go
+++ b/connectivity/tests/perfpod.go
@@ -42,17 +42,21 @@ func (s *netPerfPodtoPod) Name() string {
 func (s *netPerfPodtoPod) Run(ctx context.Context, t *check.Test) {
 	samples := t.Context().Params().PerfSamples
 	duration := t.Context().Params().PerfDuration
+	crr := t.Context().Params().PerfCRR
 	for _, c := range t.Context().PerfClientPods() {
 		c := c
 		for _, server := range t.Context().PerfServerPod() {
-			action := t.NewAction(s, "iperf-tcp", &c, server)
+			action := t.NewAction(s, "netperf", &c, server)
 			action.CollectFlows = false
 			action.Run(func(a *check.Action) {
-				netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "TCP_RR", a, t.Context().PerfResults, samples, duration)
-				netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "TCP_CRR", a, t.Context().PerfResults, samples, duration)
-				netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "TCP_STREAM", a, t.Context().PerfResults, samples, duration)
-				netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "UDP_RR", a, t.Context().PerfResults, samples, duration)
-				netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "UDP_STREAM", a, t.Context().PerfResults, samples, duration)
+				if crr {
+					netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "TCP_CRR", a, t.Context().PerfResults, 1, 30)
+				} else {
+					netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "TCP_RR", a, t.Context().PerfResults, samples, duration)
+					netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "TCP_STREAM", a, t.Context().PerfResults, samples, duration)
+					netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "UDP_RR", a, t.Context().PerfResults, samples, duration)
+					netperf(ctx, server.Pod.Status.PodIP, c.Pod.Name, "UDP_STREAM", a, t.Context().PerfResults, samples, duration)
+				}
 			})
 		}
 	}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -66,12 +66,7 @@ func newCmdConnectivityTest() *cobra.Command {
 
 			// Instantiate the test harness.
 			cc, err := check.NewConnectivityTest(k8sClient, params)
-			if params.PerfSamples > 3 {
-				cc.Warn("Having Performance Samples > 3 can cause issues")
-			}
-			if params.PerfDuration > 30*time.Second {
-				cc.Warn("Having Performance Duration > 30s can cause issues")
-			}
+
 			if err != nil {
 				return err
 			}
@@ -130,6 +125,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVar(&params.Perf, "perf", false, "Run network Performance tests")
 	cmd.Flags().DurationVar(&params.PerfDuration, "perf-duration", 10*time.Second, "Duration for the Performance test to run")
 	cmd.Flags().IntVar(&params.PerfSamples, "perf-samples", 1, "Number of Performance samples to capture (how many times to run each test)")
+	cmd.Flags().BoolVar(&params.PerfCRR, "perf-crr", false, "Run Netperf CRR Test. --perf-samples and --perf-duration ignored")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().StringVar(&params.CiliumBaseVersion, "base-version", defaults.Version,
 		"Specify the base Cilium version for configuration purpose in case image tag doesn't indicate the actual Cilium version")


### PR DESCRIPTION
CRR can quickly burn through `nf_conntrack_max` if the user passes too
many `--perf-samples` or an extended `--perf-duration`.

Adding `--perf-crr` to allow the user to run the CRR test, but it will
be a single sample of 30s.

closes #749 

Signed-off-by: Joe Talerico <rook@isovalent.com>