### PR TITLE
Moving pkill to cleanup

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Uninstall cilium
         run: |
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --wait
 
       - name: Install Cilium with IPsec Encryption
@@ -77,8 +78,6 @@ jobs:
 
       - name: Relay Port Forward
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          sleep 1s
           cilium hubble port-forward&
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]


### PR DESCRIPTION
Making the workflow look more closely to what we do in cilium/cilium,
where we kill the port-forward before uninstalling.

Signed-off-by: Joe Talerico <rook@isovalent.com>