### PR TITLE
Deprecate old CLI flags

### DIFF
--- a/.github/in-cluster-test-scripts/aks-install.sh
+++ b/.github/in-cluster-test-scripts/aks-install.sh
@@ -6,10 +6,10 @@ set -e
 # Install Cilium
 cilium install \
   --disable-check=az-binary \
-  --azure-subscription-id "${AZURE_SUBSCRIPTION_ID}" \
-  --azure-node-resource-group "${AZURE_NODE_RESOURCE_GROUP}" \
-  --azure-tenant-id "${AZURE_TENANT_ID}" \
-  --azure-client-id "${AZURE_CLIENT_ID}" \
-  --azure-client-secret "${AZURE_CLIENT_SECRET}" \
+  --helm-set=azure.subscriptionID="${AZURE_SUBSCRIPTION_ID}" \
+  --helm-set=azure.resourceGroup="${AZURE_NODE_RESOURCE_GROUP}" \
+  --helm-set=azure.tenantID="${AZURE_TENANT_ID}" \
+  --helm-set=azure.clientID="${AZURE_CLIENT_ID}" \
+  --helm-set=azure.clientSecret="${AZURE_CLIENT_SECRET}" \
   --wait=false \
-  --config monitor-aggregation=none
+  --helm-set=bpf.monitorAggregation=none

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -5,11 +5,11 @@ set -e
 
 # Install Cilium
 cilium install \
-  --cluster-name "${CLUSTER_NAME}" \
+  --helm-set=cluster.name="${CLUSTER_NAME}" \
   --wait=false \
-  --config monitor-aggregation=none \
+  --helm-set=bpf.monitorAggregation=none \
   --datapath-mode=tunnel \
-  --ipam cluster-pool
+  --helm-set=ipam.mode=cluster-pool
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -5,9 +5,9 @@ set -e
 
 # Install Cilium
 cilium install \
-  --cluster-name "${CLUSTER_NAME}" \
+  --helm-set=cluster.name="${CLUSTER_NAME}" \
   --wait=false \
-  --config monitor-aggregation=none
+  --helm-set=bpf.monitorAggregation=none
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -5,11 +5,11 @@ set -e
 
 # Install Cilium in cluster
 cilium install \
-  --cluster-name "${CLUSTER_NAME}" \
-  --config monitor-aggregation=none \
-  --config tunnel=vxlan \
-  --kube-proxy-replacement=strict \
-  --ipv4-native-routing-cidr="${CLUSTER_CIDR}"
+  --helm-set=cluster.name="${CLUSTER_NAME}" \
+  --helm-set=bpf.monitorAggregation=none \
+  --helm-set=tunnel=vxlan \
+  --helm-set=kubeProxyReplacement=strict \
+  --helm-set=ipv4NativeRoutingCIDR="${CLUSTER_CIDR}"
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -5,9 +5,9 @@ set -e
 
 # Install Cilium
 cilium install \
-  --cluster-name "${CLUSTER_NAME}" \
-  --config monitor-aggregation=none \
-  --ipv4-native-routing-cidr="${CLUSTER_CIDR}"
+  --helm-set=cluster.name="${CLUSTER_NAME}" \
+  --helm-set=bpf.monitorAggregation=none \
+  --helm-set=ipv4NativeRoutingCIDR="${CLUSTER_CIDR}"
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -10,18 +10,18 @@ CONTEXT2=$(kubectl config view | grep "${CLUSTER_NAME_2}" | head -1 | awk '{prin
 # Install Cilium in cluster1
 cilium install \
   --context "${CONTEXT1}" \
-  --cluster-name "${CLUSTER_NAME_1}" \
-  --cluster-id 1 \
-  --config monitor-aggregation=none \
-  --ipv4-native-routing-cidr=10.0.0.0/9
+  --helm-set=cluster.name="${CLUSTER_NAME_1}" \
+  --helm-set=cluster.id=1 \
+  --helm-set=bpf.monitorAggregation=none \
+  --helm-set=ipv4NativeRoutingCIDR=10.0.0.0/9
 
 # Install Cilium in cluster2
 cilium install \
   --context "${CONTEXT2}" \
-  --cluster-name "${CLUSTER_NAME_2}" \
-  --cluster-id 2 \
-  --config monitor-aggregation=none \
-  --ipv4-native-routing-cidr=10.0.0.0/9 \
+  --helm-set=cluster.name="${CLUSTER_NAME_2}" \
+  --helm-set=cluster.id=2 \
+  --helm-set=bpf.monitorAggregation=none \
+  --helm-set=ipv4NativeRoutingCIDR=10.0.0.0/9 \
   --inherit-ca "${CONTEXT1}"
 
 # Enable Relay

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           cilium install \
             --wait=false \
-            --config monitor-aggregation=none
+            --helm-set=bpf.monitorAggregation=none
 
       - name: Enable Relay
         run: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install Cilium with IPsec Encryption
         run: |
-          cilium install --encryption=ipsec --kube-proxy-replacement=probe
+          cilium install --encryption=ipsec --helm-set=kubeProxyReplacement=probe
 
       - name: Enable Relay
         run: |

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To install Cilium while automatically detected:
 
 Install Cilium & enable ClusterMesh in Cluster 1
 
-    cilium install --cluster-id 1
+    cilium install --helm-set=cluster.id=1
     🔮 Auto-detected Kubernetes kind: GKE
     ℹ️  Cilium version not set, using default version "v1.9.1"
     🔮 Auto-detected cluster name: gke-cilium-dev-us-west2-a-tgraf-cluster1
@@ -263,7 +263,7 @@ Install Cilium & enable ClusterMesh in Cluster 1
 
 Install Cilium in Cluster 2
 
-    cilium install --context gke_cilium-dev_us-west2-a_tgraf-cluster2 --cluster-id 2
+    cilium install --context gke_cilium-dev_us-west2-a_tgraf-cluster2 --helm-set=cluster.id=2
     🔮 Auto-detected Kubernetes kind: GKE
     ℹ️  Cilium version not set, using default version "v1.9.1"
     🔮 Auto-detected cluster name: gke-cilium-dev-us-west2-a-tgraf-cluster2

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.4.0
+	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1
 	google.golang.org/grpc v1.45.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	helm.sh/helm/v3 v3.8.1
@@ -182,7 +183,6 @@ require (
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1 // indirect
 	github.com/spf13/viper v1.10.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect

--- a/install/install.go
+++ b/install/install.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/versioncheck"
+	"github.com/spf13/pflag"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -166,6 +167,28 @@ type AzureParameters struct {
 	ClientID             string
 	ClientSecret         string
 }
+
+var (
+	// FlagsToHelmOpts maps the deprecated install flags to the helm
+	// options
+	FlagsToHelmOpts = map[string]string{
+		"agent-image":              "image.override",
+		"azure-client-id":          "azure.clientID",
+		"azure-client-secret":      "azure.clientSecret",
+		"azure-resource-group":     "azure.resourceGroup",
+		"azure-subscription-id":    "azure.subscriptionID",
+		"azure-tenant-id":          "azure.tenantID",
+		"cluster-id":               "cluster.id",
+		"cluster-name":             "cluster.name",
+		"ipam":                     "ipam.mode",
+		"ipv4-native-routing-cidr": "ipv4NativeRoutingCIDR",
+		"kube-proxy-replacement":   "kubeProxyReplacement",
+		"node-encryption":          "encryption.nodeEncryption",
+		"operator-image":           "operator.image.override",
+	}
+	// FlagValues maps all FlagsToHelmOpts keys to their values
+	FlagValues = map[string]pflag.Value{}
+)
 
 type Parameters struct {
 	Namespace             string

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -48,6 +48,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	}
 
 	cmd.Flags().StringVarP(&params.Namespace, "namespace", "n", "kube-system", "Namespace to install Cilium into")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.ClusterName, "cluster-name", "", "Name of the cluster")
 	cmd.Flags().StringSliceVar(&params.DisableChecks, "disable-check", []string{}, "Disable a particular validation check")
 	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
@@ -55,32 +56,45 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 		"Specify the base Cilium version for configuration purpose in case the --version flag doesn't indicate the actual Cilium version")
 	cmd.Flags().MarkHidden("base-version")
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.IPAM, "ipam", "", "IP Address Management (IPAM) mode")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.IPv4NativeRoutingCIDR, "ipv4-native-routing-cidr", "", "IPv4 CIDR within which native routing is possible")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().IntVar(&params.ClusterID, "cluster-id", 0, "Unique cluster identifier for multi-cluster")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().StringVar(&params.InheritCA, "inherit-ca", "", "Inherit/import CA from another cluster")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.KubeProxyReplacement, "kube-proxy-replacement", "disabled", "Enable/disable kube-proxy replacement { disabled | probe | strict }")
 	cmd.Flags().BoolVar(&params.Wait, "wait", true, "Wait for status to report success (no errors)")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", defaults.StatusWaitDuration, "Maximum time to wait for status")
 	cmd.Flags().BoolVar(&params.RestartUnmanagedPods, "restart-unmanaged-pods", true, "Restart pods which are not being managed by Cilium")
 	cmd.Flags().StringVar(&params.Encryption, "encryption", "disabled", "Enable encryption of all workloads traffic { disabled | ipsec | wireguard }")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().BoolVar(&params.NodeEncryption, "node-encryption", false, "Enable encryption of all node to node traffic")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Set ConfigMap entries { key=value[,key=value,..] }")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.AgentImage, "agent-image", "", "Image path to use for Cilium agent")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.OperatorImage, "operator-image", "", "Image path to use for Cilium operator")
 	cmd.Flags().DurationVar(&params.CiliumReadyTimeout, "cilium-ready-timeout", 5*time.Minute,
 		"Timeout for Cilium to become ready before restarting unmanaged pods")
 	cmd.Flags().BoolVar(&params.Rollback, "rollback", true, "Roll back installed resources on failure")
 
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.Azure.ResourceGroupName, "azure-resource-group", "", "Azure resource group name the cluster is in (required)")
 	cmd.Flags().StringVar(&params.Azure.AKSNodeResourceGroup, "azure-node-resource-group", "", "Azure node resource group name the cluster is in. Bypasses `--azure-resource-group` if provided.")
 	cmd.Flags().MarkHidden("azure-node-resource-group") // intended for for development purposes, notably CI usage, cf. azure.go
 	cmd.Flags().StringVar(&params.Azure.SubscriptionName, "azure-subscription", "", "Azure subscription name the cluster is in (default `az account show`)")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.Azure.SubscriptionID, "azure-subscription-id", "", "Azure subscription ID. Bypasses auto-detection and `--azure-subscription` if provided.")
 	cmd.Flags().MarkHidden("azure-subscription-id") // intended for for development purposes, notably CI usage, cf. azure.go
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.Azure.TenantID, "azure-tenant-id", "", "Tenant ID of Azure Service Principal to use for installing Cilium (will create one if none provided)")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.Azure.ClientID, "azure-client-id", "", "Client (application) ID of Azure Service Principal to use for installing Cilium (will create one if none provided)")
+	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.Azure.ClientSecret, "azure-client-secret", "", "Client secret of Azure Service Principal to use for installing Cilium (will create one if none provided)")
 	cmd.Flags().StringVar(&params.K8sVersion, "k8s-version", "", "Kubernetes server version in case auto-detection fails")
 
@@ -92,6 +106,17 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.HelmGenValuesFile, "helm-auto-gen-values", "", "Write an auto-generated helm values into this file")
 	cmd.Flags().StringVar(&params.ImageSuffix, "image-suffix", "", "Set all generated images with this suffix")
 	cmd.Flags().StringVar(&params.ImageTag, "image-tag", "", "Set all images with this tag")
+
+	for flagName := range install.FlagsToHelmOpts {
+		// TODO(aanm) Do not mark the flags has deprecated for now.
+		// msg := fmt.Sprintf("use --helm-set=%s<=value> instead", helmOpt)
+		// err := cmd.Flags().MarkDeprecated(flagName, msg)
+		// if err != nil {
+		// 	panic(err)
+		// }
+		install.FlagValues[flagName] = cmd.Flags().Lookup(flagName).Value
+	}
+	install.FlagValues["config"] = cmd.Flags().Lookup("config").Value
 
 	return cmd
 }


### PR DESCRIPTION
Follow up of https://github.com/cilium/cilium-cli/pull/717

The PR is deprecating flags with `MarkDeprecate` method and giving priority to helm flags in case both CLI and helm flags are used. If all what people care is about `MarkDeprecate` then we can discuss that afterwards leave the flag prioritization on this PR.