### PR TITLE
Autodetect K3s cluster flavor

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -415,7 +415,7 @@ type k8sClusterMeshImplementation interface {
 	GetDaemonSet(ctx context.Context, namespace, name string, options metav1.GetOptions) (*appsv1.DaemonSet, error)
 	ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error)
 	ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error)
-	AutodetectFlavor(ctx context.Context) (k8s.Flavor, error)
+	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error)
 	ClusterName() string
 	ListCiliumExternalWorkloads(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error)
@@ -490,11 +490,7 @@ func (k *K8sClusterMesh) Log(format string, a ...interface{}) {
 }
 
 func (k *K8sClusterMesh) GetClusterConfig(ctx context.Context) error {
-	f, err := k.client.AutodetectFlavor(ctx)
-	if err != nil {
-		return err
-	}
-	k.flavor = f
+	k.flavor = k.client.AutodetectFlavor(ctx)
 
 	cm, err := k.client.GetConfigMap(ctx, k.params.Namespace, defaults.ConfigMapName, metav1.GetOptions{})
 	if err != nil {

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -42,19 +42,12 @@ func (p Parameters) checkDisabled(name string) bool {
 	return false
 }
 
-func (k *K8sUninstaller) autodetect(ctx context.Context) error {
-	f, err := k.client.AutodetectFlavor(ctx)
-	if err != nil {
-		return err
+func (k *K8sUninstaller) autodetect(ctx context.Context) {
+	k.flavor = k.client.AutodetectFlavor(ctx)
+
+	if k.flavor.Kind != k8s.KindUnknown {
+		k.Log("🔮 Auto-detected Kubernetes kind: %s", k.flavor.Kind)
 	}
-
-	k.flavor = f
-
-	if f.Kind != k8s.KindUnknown {
-		k.Log("🔮 Auto-detected Kubernetes kind: %s", f.Kind)
-	}
-
-	return nil
 }
 
 func (k *K8sInstaller) detectDatapathMode(withKPR bool) {
@@ -91,25 +84,16 @@ func (k *K8sInstaller) detectDatapathMode(withKPR bool) {
 	}
 }
 
-func (k *K8sInstaller) autodetect(ctx context.Context) error {
-	f, err := k.client.AutodetectFlavor(ctx)
-	if err != nil {
-		return err
+func (k *K8sInstaller) autodetect(ctx context.Context) {
+	k.flavor = k.client.AutodetectFlavor(ctx)
+
+	if k.flavor.Kind != k8s.KindUnknown {
+		k.Log("🔮 Auto-detected Kubernetes kind: %s", k.flavor.Kind)
 	}
-
-	k.flavor = f
-
-	if f.Kind != k8s.KindUnknown {
-		k.Log("🔮 Auto-detected Kubernetes kind: %s", f.Kind)
-	}
-
-	return nil
 }
 
 func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
-	if err := k.autodetect(ctx); err != nil {
-		return err
-	}
+	k.autodetect(ctx)
 
 	if len(validationChecks[k.flavor.Kind]) > 0 {
 		k.Log("✨ Running %q validation checks", k.flavor.Kind)

--- a/install/install.go
+++ b/install/install.go
@@ -128,7 +128,7 @@ type k8sInstallerImplementation interface {
 	PatchSecret(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Secret, error)
 	CreateResourceQuota(ctx context.Context, namespace string, r *corev1.ResourceQuota, opts metav1.CreateOptions) (*corev1.ResourceQuota, error)
 	DeleteResourceQuota(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
-	AutodetectFlavor(ctx context.Context) (k8s.Flavor, error)
+	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	ContextName() (name string)
 	CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -43,9 +43,7 @@ func (k *K8sUninstaller) Log(format string, a ...interface{}) {
 }
 
 func (k *K8sUninstaller) Uninstall(ctx context.Context) error {
-	if err := k.autodetect(ctx); err != nil {
-		return err
-	}
+	k.autodetect(ctx)
 
 	k.Log("🔥 Deleting %s namespace...", k.params.TestNamespace)
 	k.client.DeleteNamespace(ctx, k.params.TestNamespace, metav1.DeleteOptions{})

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -17,9 +17,7 @@ import (
 )
 
 func (k *K8sInstaller) Upgrade(ctx context.Context) error {
-	if err := k.autodetect(ctx); err != nil {
-		return err
-	}
+	k.autodetect(ctx)
 
 	// no need to determine KPR setting on upgrade, keep the setting configured with the old
 	// version.

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -21,7 +21,7 @@ import (
 )
 
 type KubernetesClient interface {
-	AutodetectFlavor(ctx context.Context) (f k8s.Flavor, err error)
+	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	CopyFromPod(ctx context.Context, namespace, pod, container string, fromFile, destFile string) error
 	ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error)
 	ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error)

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -760,11 +760,7 @@ func (c *Collector) Run() error {
 			Description:     "Collecting platform-specific data",
 			Quick:           true,
 			Task: func(ctx context.Context) error {
-				f, err := c.Client.AutodetectFlavor(ctx)
-				if err != nil {
-					c.logWarn("Failed to autodetect Kubernetes flavor: %v", err)
-					return nil
-				}
+				f := c.Client.AutodetectFlavor(ctx)
 				c.logDebug("Detected flavor %q", f.Kind)
 				if err := c.submitFlavorSpecificTasks(ctx, f); err != nil {
 					return fmt.Errorf("failed to collect platform-specific data: %w", err)

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -109,7 +109,7 @@ func (c *fakeClient) CopyFromPod(ctx context.Context, namespace, pod, container 
 	panic("implement me")
 }
 
-func (c *fakeClient) AutodetectFlavor(ctx context.Context) (f k8s.Flavor, err error) {
+func (c *fakeClient) AutodetectFlavor(ctx context.Context) k8s.Flavor {
 	panic("implement me")
 }
 


### PR DESCRIPTION
The first commit removes an unnecessary always-nil error return when auto-detecting the cluster flavor. The second commit add support for auto-detecting K3s clusters. Example `cilium install` output:

```
$ cilium install
🔮 Auto-detected Kubernetes kind: K3s
ℹ️  using Cilium version "v1.11.2"
🔮 Auto-detected cluster name: default
🔮 Auto-detected IPAM mode: cluster-pool
ℹ️  helm template --namespace kube-system cilium cilium/cilium --version 1.11.2 --set cluster.name=default,ipam.mode=cluster-pool,kubeProxyReplacement=disabled,operator.replicas=1,serviceAccounts.cilium.name=cilium,serviceAccounts.operator.name=cilium-operator
🔑 Created CA in secret cilium-ca
🔑 Generating certificates for Hubble...
🚀 Creating Service accounts...
🚀 Creating Cluster roles...
🚀 Creating ConfigMap for Cilium version 1.11.2...
🚀 Creating Agent DaemonSet...
level=warning msg="spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[1].matchExpressions[0].key: beta.kubernetes.io/os is deprecated since v1.14; use \"kubernetes.io/os\" instead" subsys=klog
level=warning msg="spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the \"priorityClassName\" field instead" subsys=klog
🚀 Creating Operator Deployment...
⌛ Waiting for Cilium to be installed and ready...
♻️  Restarting unmanaged pods...
♻️  Restarted unmanaged pod kube-system/helm-install-traefik-crd--1-gxtmd
♻️  Restarted unmanaged pod kube-system/helm-install-traefik--1-j9pr6
♻️  Restarted unmanaged pod kube-system/local-path-provisioner-84bb864455-v4z6f
♻️  Restarted unmanaged pod kube-system/metrics-server-ff9dbcb6c-6stf6
♻️  Restarted unmanaged pod kube-system/coredns-96cc4f57d-f7kcl
✅ Cilium was successfully installed! Run 'cilium status' to view installation health
```
