### PR TITLE
.github: partially revert flag changes

### DIFF
--- a/.github/in-cluster-test-scripts/aks-install.sh
+++ b/.github/in-cluster-test-scripts/aks-install.sh
@@ -6,10 +6,10 @@ set -e
 # Install Cilium
 cilium install \
   --disable-check=az-binary \
-  --helm-set=azure.subscriptionID="${AZURE_SUBSCRIPTION_ID}" \
-  --helm-set=azure.resourceGroup="${AZURE_NODE_RESOURCE_GROUP}" \
-  --helm-set=azure.tenantID="${AZURE_TENANT_ID}" \
-  --helm-set=azure.clientID="${AZURE_CLIENT_ID}" \
-  --helm-set=azure.clientSecret="${AZURE_CLIENT_SECRET}" \
+  --azure-subscription-id "${AZURE_SUBSCRIPTION_ID}" \
+  --azure-node-resource-group "${AZURE_NODE_RESOURCE_GROUP}" \
+  --azure-tenant-id "${AZURE_TENANT_ID}" \
+  --azure-client-id "${AZURE_CLIENT_ID}" \
+  --azure-client-secret "${AZURE_CLIENT_SECRET}" \
   --wait=false \
-  --helm-set=bpf.monitorAggregation=none
+  --config monitor-aggregation=none

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -5,11 +5,11 @@ set -e
 
 # Install Cilium
 cilium install \
-  --helm-set=cluster.name="${CLUSTER_NAME}" \
+  --cluster-name "${CLUSTER_NAME}" \
   --wait=false \
-  --helm-set=bpf.monitorAggregation=none \
+  --config monitor-aggregation=none \
   --datapath-mode=tunnel \
-  --helm-set=ipam.mode=cluster-pool
+  --ipam cluster-pool
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -5,9 +5,9 @@ set -e
 
 # Install Cilium
 cilium install \
-  --helm-set=cluster.name="${CLUSTER_NAME}" \
+  --cluster-name "${CLUSTER_NAME}" \
   --wait=false \
-  --helm-set=bpf.monitorAggregation=none
+  --config monitor-aggregation=none
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -5,11 +5,11 @@ set -e
 
 # Install Cilium in cluster
 cilium install \
-  --helm-set=cluster.name="${CLUSTER_NAME}" \
-  --helm-set=bpf.monitorAggregation=none \
-  --helm-set=tunnel=vxlan \
-  --helm-set=kubeProxyReplacement=strict \
-  --helm-set=ipv4NativeRoutingCIDR="${CLUSTER_CIDR}"
+  --cluster-name "${CLUSTER_NAME}" \
+  --config monitor-aggregation=none \
+  --config tunnel=vxlan \
+  --kube-proxy-replacement=strict \
+  --ipv4-native-routing-cidr="${CLUSTER_CIDR}"
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -5,9 +5,9 @@ set -e
 
 # Install Cilium
 cilium install \
-  --helm-set=cluster.name="${CLUSTER_NAME}" \
-  --helm-set=bpf.monitorAggregation=none \
-  --helm-set=ipv4NativeRoutingCIDR="${CLUSTER_CIDR}"
+  --cluster-name "${CLUSTER_NAME}" \
+  --config monitor-aggregation=none \
+  --ipv4-native-routing-cidr="${CLUSTER_CIDR}"
 
 # Enable Relay
 cilium hubble enable

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -10,18 +10,18 @@ CONTEXT2=$(kubectl config view | grep "${CLUSTER_NAME_2}" | head -1 | awk '{prin
 # Install Cilium in cluster1
 cilium install \
   --context "${CONTEXT1}" \
-  --helm-set=cluster.name="${CLUSTER_NAME_1}" \
-  --helm-set=cluster.id=1 \
-  --helm-set=bpf.monitorAggregation=none \
-  --helm-set=ipv4NativeRoutingCIDR=10.0.0.0/9
+  --cluster-name "${CLUSTER_NAME_1}" \
+  --cluster-id 1 \
+  --config monitor-aggregation=none \
+  --ipv4-native-routing-cidr=10.0.0.0/9
 
 # Install Cilium in cluster2
 cilium install \
   --context "${CONTEXT2}" \
-  --helm-set=cluster.name="${CLUSTER_NAME_2}" \
-  --helm-set=cluster.id=2 \
-  --helm-set=bpf.monitorAggregation=none \
-  --helm-set=ipv4NativeRoutingCIDR=10.0.0.0/9 \
+  --cluster-name "${CLUSTER_NAME_2}" \
+  --cluster-id 2 \
+  --config monitor-aggregation=none \
+  --ipv4-native-routing-cidr=10.0.0.0/9 \
   --inherit-ca "${CONTEXT1}"
 
 # Enable Relay

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           cilium install \
             --wait=false \
-            --helm-set=bpf.monitorAggregation=none
+            --config monitor-aggregation=none
 
       - name: Enable Relay
         run: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install Cilium with IPsec Encryption
         run: |
-          cilium install --encryption=ipsec --helm-set=kubeProxyReplacement=probe
+          cilium install --encryption=ipsec --kube-proxy-replacement=probe
 
       - name: Enable Relay
         run: |


### PR DESCRIPTION
There are certain locations in cilium-cli code that depend on the value
of certain flags that can be overwritten by helm-flags. This commit
reverts the flags that were changed on GH workflows. Users will still be
able to overwrite the cilium-cli flags with helm-values and since the
flags are not being deprecated we can still keep them in cilium-cli.

Signed-off-by: André Martins <andre@cilium.io>