### PR TITLE
sysdump - Add --cilium-operator-namespace option

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -52,6 +52,9 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().StringVar(&sysdumpOptions.CiliumNamespace,
 		"cilium-namespace", sysdump.DefaultCiliumNamespace,
 		"The namespace Cilium is running in")
+	cmd.Flags().StringVar(&sysdumpOptions.CiliumOperatorNamespace,
+		"cilium-operator-namespace", sysdump.DefaultCiliumNamespace,
+		"The namespace Cilium operator is running in")
 	cmd.Flags().StringVar(&sysdumpOptions.CiliumDaemonSetSelector,
 		"cilium-daemon-set-label-selector", sysdump.DefaultCiliumLabelSelector,
 		"The labels used to target Cilium daemon set")

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -34,6 +34,8 @@ type Options struct {
 	CiliumLabelSelector string
 	// The namespace Cilium is running in.
 	CiliumNamespace string
+	// The namespace Cilium operator is running in.
+	CiliumOperatorNamespace string
 	// The labels used to target Cilium daemon set. Usually, this label is same as CiliumLabelSelector.
 	CiliumDaemonSetSelector string
 	// The labels used to target Cilium operator pods.
@@ -557,7 +559,7 @@ func (c *Collector) Run() error {
 			Description: "Collecting the Cilium operator deployment",
 			Quick:       true,
 			Task: func(ctx context.Context) error {
-				v, err := c.Client.GetDeployment(ctx, c.Options.CiliumNamespace, ciliumOperatorDeploymentName, metav1.GetOptions{})
+				v, err := c.Client.GetDeployment(ctx, c.Options.CiliumOperatorNamespace, ciliumOperatorDeploymentName, metav1.GetOptions{})
 				if err != nil {
 					return fmt.Errorf("failed to collect the Cilium operator deployment: %w", err)
 				}


### PR DESCRIPTION
Small pull request to allow passing in `--cilium-operator-namespace` to support use cases where the `cilium-operator` runs in a different namespace than the `cilium-agent`. 