### PR TITLE
hubble: fix deployment of hubble with unreleased Cilium versions

### DIFF
--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -206,12 +206,10 @@ func (k *K8sHubble) disableHubble(ctx context.Context) error {
 }
 
 func (k *K8sHubble) Disable(ctx context.Context) error {
-	var err error
-	k.ciliumVersion, err = k.client.GetRunningCiliumVersion(ctx, k.params.Namespace)
-	if err != nil {
-		return err
-	}
 
+	// Ignore the GetRunningCiliumVersion error since it doesn't work for
+	// unreleased versions, and we will fall back to the --base-version
+	k.ciliumVersion, _ = k.client.GetRunningCiliumVersion(ctx, k.params.Namespace)
 	k.semVerCiliumVersion = k.getCiliumVersion()
 
 	cm, err := k.client.GetConfigMap(ctx, k.params.Namespace, defaults.ConfigMapName, metav1.GetOptions{})
@@ -435,12 +433,9 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 		return err
 	}
 
-	var err error
-	k.ciliumVersion, err = k.client.GetRunningCiliumVersion(ctx, k.params.Namespace)
-	if err != nil {
-		return err
-	}
-
+	// Ignore the GetRunningCiliumVersion error since it doesn't work for
+	// unreleased versions, and we will fall back to the --base-version
+	k.ciliumVersion, _ = k.client.GetRunningCiliumVersion(ctx, k.params.Namespace)
 	k.semVerCiliumVersion = k.getCiliumVersion()
 
 	caSecret, created, err := k.certManager.GetOrCreateCASecret(ctx, defaults.CASecretName, k.params.CreateCA)

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -239,12 +239,9 @@ func (k *K8sHubble) generateRelayCertificate(name string) (corev1.Secret, error)
 }
 
 func (k *K8sHubble) PortForwardCommand(ctx context.Context) error {
-	var err error
-	k.ciliumVersion, err = k.client.GetRunningCiliumVersion(ctx, k.params.Namespace)
-	if err != nil {
-		return err
-	}
-
+	// Ignore the GetRunningCiliumVersion error since it doesn't work for
+	// unreleased versions, and we will fall back to the --base-version
+	k.ciliumVersion, _ = k.client.GetRunningCiliumVersion(ctx, k.params.Namespace)
 	k.semVerCiliumVersion = k.getCiliumVersion()
 
 	cm, err := k.client.GetConfigMap(ctx, k.params.Namespace, defaults.ConfigMapName, metav1.GetOptions{})


### PR DESCRIPTION
If Cilium image is set to a tag that can't be represented as a semver we
will fallback to the base version set by --base-version available as a
flag to the hubble enable command.

Signed-off-by: André Martins <andre@cilium.io>