### PR TITLE
connectivity: Make fatal errors more visible

### DIFF
--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -14,7 +14,7 @@ const (
 	info  = "ℹ️ "
 	warn  = "⚠️ "
 	fail  = "❌"
-	fatal = "🔥"
+	fatal = "🟥"
 
 	testPrefix = "  "
 )


### PR DESCRIPTION
The fire emoji does not stand out in logs. Replace it with one that
does.

Signed-off-by: Tom Payne <tom@isovalent.com>