### PR TITLE
feat: collect Kubernetes Endpoints in sysdump

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -652,6 +652,10 @@ func (c *Client) ListUnstructured(ctx context.Context, gvr schema.GroupVersionRe
 	return c.DynamicClientset.Resource(gvr).Namespace(*namespace).List(ctx, o)
 }
 
+func (c *Client) ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error) {
+	return c.Clientset.CoreV1().Endpoints(corev1.NamespaceAll).List(ctx, o)
+}
+
 func (c *Client) ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error) {
 	return c.Clientset.NetworkingV1().NetworkPolicies(corev1.NamespaceAll).List(ctx, o)
 }

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -41,6 +41,7 @@ type KubernetesClient interface {
 	ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeList, error)
 	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
 	ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error)
+	ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error)
 	ListNamespaces(ctx context.Context, o metav1.ListOptions) (*corev1.NamespaceList, error)
 	ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error)
 	ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -53,6 +53,7 @@ const (
 	hubbleRelayConfigMapFileName             = "hubble-relay-configmap-<ts>.yaml"
 	hubbleRelayDeploymentFileName            = "hubble-relay-deployment-<ts>.yaml"
 	hubbleUIDeploymentFileName               = "hubble-ui-deployment-<ts>.yaml"
+	kubernetesEndpointsFileName              = "k8s-endpoints-<ts>.yaml"
 	kubernetesEventsFileName                 = "k8s-events-<ts>.yaml"
 	kubernetesNamespacesFileName             = "k8s-namespaces-<ts>.yaml"
 	kubernetesNetworkPoliciesFileName        = "k8s-networkpolicies-<ts>.yaml"

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -335,6 +335,20 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting Kubernetes endpoints",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.ListEndpoints(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect Kubernetes endpoints: %w", err)
+				}
+				if err := c.WriteYAML(kubernetesEndpointsFileName, v); err != nil {
+					return fmt.Errorf("failed to collect Kubernetes endpoints: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting Cilium network policies",
 			Quick:       true,
 			Task: func(ctx context.Context) error {

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -189,6 +189,10 @@ func (c *fakeClient) ListNamespaces(ctx context.Context, o metav1.ListOptions) (
 	panic("implement me")
 }
 
+func (c *fakeClient) ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
Adds the collection of Kubernetes Endpoints to the `sysdump` command as requested in https://github.com/cilium/cilium-cli/issues/520

Signed-off-by: Thorsten Pfister <thorsten.pfister@form3.tech>

Tested with a local dummy cluster which lead to the additional creation of a `k8s-endpoints-20220414-124930.yaml` file in the sysdump archive with the following truncated content:

```yaml
apiVersion: v1
items:
- metadata:
    creationTimestamp: "2022-04-14T10:45:01Z"
    labels:
      endpointslice.kubernetes.io/skip-mirror: "true"
...
<snip>
...
kind: EndpointsList
metadata:
  resourceVersion: "838"
```

Fixes #520