### PR TITLE
clustermesh: Add local systemd-resolve --status wait on External Workload install

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -711,7 +711,11 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 		// DaemonSet is up and running to guarantee the CNI configuration and binary
 		// are deployed on the node.  See https://github.com/cilium/cilium/issues/14128
 		// for details.
-		k.Log("⌛ Waiting for Cilium to be installed and ready...")
+		reason := ""
+		if !k.params.Wait {
+			reason = " before restarting unmanaged pods"
+		}
+		k.Log("⌛ Waiting for Cilium to be installed and ready%s...", reason)
 		collector, err := status.NewK8sStatusCollector(k.client, status.K8sStatusParameters{
 			Namespace:       k.params.Namespace,
 			Wait:            true,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium-cli/defaults"
 )
 
-var versionRegexp = regexp.MustCompile(`^(v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*|[a-zA-Z0-9-_.@:]*:[a-zA-Z0-9-_.@:]+)$`).MatchString
+var versionRegexp = regexp.MustCompile(`^((v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*|[a-zA-Z0-9-_.@:]*:[a-zA-Z0-9-_.@:]+)|([0-9a-fA-F]+)|(latest))$`).MatchString
 
 func CheckVersion(version string) bool {
 	return versionRegexp(version)


### PR DESCRIPTION
Check the status of systemd-resolved after modifying it to use
kube-dns. Wait until kube-dns becomes the current DNS server. This should
mitigate errors like this in the CI:

```
Verify cluster DNS on VM

Run gcloud compute ssh cilium-cilium-2158039822-vm --zone us-west2-a \
 gcloud compute ssh cilium-cilium-2158039822-vm --zone us-west2-a \
    --command "nslookup -norecurse clustermesh-apiserver.kube-system.svc.cluster.local"
...
Server:		169.254.169.254
Address:	169.254.169.254#53

** server can't find clustermesh-apiserver.kube-system.svc.cluster.local: NXDOMAIN

Error: Process completed with exit code 1.
```

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>