### PR TITLE
Perform DNS check earlier in the tests

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -572,6 +572,16 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
+	// Set the timeout for all DNS lookup retries
+	dnsCtx, cancel := context.WithTimeout(ctx, ct.params.ipCacheTimeout())
+	defer cancel()
+	for _, cp := range ct.clientPods {
+		err := ct.waitForDNS(dnsCtx, cp)
+		if err != nil {
+			return err
+		}
+	}
+
 	perfPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindPerfName})
 	if err != nil {
 		return fmt.Errorf("unable to list perf pods: %w", err)
@@ -689,16 +699,6 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-		}
-	}
-
-	// Set the timeout for all DNS lookup retries
-	dnsCtx, cancel := context.WithTimeout(ctx, ct.params.ipCacheTimeout())
-	defer cancel()
-	for _, cp := range ct.clientPods {
-		err := ct.waitForDNS(dnsCtx, cp)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -813,7 +813,7 @@ func (ct *ConnectivityTest) waitForService(ctx context.Context, service Service)
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timeout reached waiting for %s", service)
+			return fmt.Errorf("timeout reached waiting for service %s", service.Name())
 		default:
 		}
 


### PR DESCRIPTION
This PR does the following:

- Check that DNS works before trying to wait for the service, because the service wait function relies on nslookup.
- If service wait fails, make logs print only namespace and name of the service, not dump of the entire object.

Fixes: https://github.com/cilium/cilium-cli/issues/716