### PR TITLE
Version tag handling fixes

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium-cli/defaults"
 )
 
-var versionRegexp = regexp.MustCompile(`^(v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*|[a-zA-Z0-9-_.@:]*:[a-zA-Z0-9-_.@:]+)$`).MatchString
+var versionRegexp = regexp.MustCompile(`^((v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9]+)*|[a-zA-Z0-9-_.@:]*:[a-zA-Z0-9-_.@:]+)|([0-9a-fA-F]{40})|(latest))$`).MatchString
 
 func CheckVersion(version string) bool {
 	return versionRegexp(version)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -36,6 +36,7 @@ func TestCheckVersion(t *testing.T) {
 		{"v.1.9", false},
 		{"v..1.9", false},
 		{":latest", true},
+		{"92ff7ffa762f6f8bc397a28e6f3147906e20e8fa", true},
 		{":92ff7ffa762f6f8bc397a28e6f3147906e20e8fa", true},
 		{":92ff7ffa762f6f8bc397a28e6f3147906e20e8fa@sha256:4fde4abc19a1cbedb5084f683f5d91c0ea04b964a029e6d0ba43961e1ff5b5d8", true},
 		{"-ci:92ff7ffa762f6f8bc397a28e6f3147906e20e8fa", true},


### PR DESCRIPTION
Set image tag when overriding images, as otherwise "latest" will be used
by k8s.

Use operator.useDigest instead of operator.digest, which does not exist.

Only set image.tag if not overriding images.

Pass SHAs and "latest" through --version validation, so that a SHA can be
used as --version as intended.

Detect running Cilium version as "latest" if image has no tag, rather
than erroring out. This may happen if image tag is not specified for a
pod.