### PR TITLE
Add liveness checks to clustermesh deployment

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -234,6 +234,14 @@ func (k *K8sClusterMesh) generateDeployment(clustermeshApiserverArgs []string) *
 							Image:           k.etcdImage(),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env:             k.etcdEnvs(),
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/health",
+										Port: intstr.FromInt(2379),
+									},
+								},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "etcd-server-secrets",
@@ -289,6 +297,14 @@ func (k *K8sClusterMesh) generateDeployment(clustermeshApiserverArgs []string) *
 											},
 											Key: "identity-allocation-mode",
 										},
+									},
+								},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromInt(80),
 									},
 								},
 							},


### PR DESCRIPTION
Use the existing HTTP health check endpoints to ensure liveness of etcd and apiserver containers.

- etcd - https://etcd.io/docs/v3.4/op-guide/monitoring/#health-check
- clustermesh-apiserver - https://github.com/cilium/cilium/blob/080857bdedca67d58ec39f8f96c5f38b22f6dc0b/clustermesh-apiserver/main.go#L257

Tested locally on a kind cluster:

1. Create kind cluster via [cilium instructions](https://docs.cilium.io/en/stable/gettingstarted/kind/)
2. Enable cilium with `./cilium --cluster-name=kind --cluster-id=0`.
3. Enable clustermesh with `./cilium clustermesh enable --service-type ClusterIP`
4. Verify clustermesh is available via `./cilium status` output.

```
nathanperkins@nathanperkins1:~/git/cilium-cli (liveness)$ ./cilium status
...
Deployment        clustermesh-apiserver    Desired: 1, Ready: 1/1, Available: 1/1
...
```

