### PR TITLE
Add host networking scenario for performance tests

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -38,6 +38,7 @@ type Parameters struct {
 	Perf                  bool
 	PerfDuration          time.Duration
 	PerfCRR               bool
+	PerfHost              bool
 	PerfSamples           int
 	CiliumBaseVersion     string
 }

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -38,7 +38,7 @@ type Parameters struct {
 	Perf                  bool
 	PerfDuration          time.Duration
 	PerfCRR               bool
-	PerfHost              bool
+	PerfHostNet           bool
 	PerfSamples           int
 	CiliumBaseVersion     string
 }

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -58,6 +58,7 @@ type PerfTests struct {
 
 type PerfResult struct {
 	Metric   string
+	Scenario string
 	Duration time.Duration
 	Samples  int
 	Values   []float64
@@ -317,15 +318,15 @@ func (ct *ConnectivityTest) report() error {
 
 	if ct.params.Perf {
 		// Report Performance results
-		ct.Header("🔥 Performance Test Summary")
-		ct.Logf("%s", strings.Repeat("-", 125))
-		ct.Logf("📋 %-50s | %-15s | %-15s | %-15s | %-15s", "Scenario", "Test", "Num Samples", "Duration", "Avg value")
-		ct.Logf("%s", strings.Repeat("-", 125))
+		ct.Headerf("🔥 Performance Test Summary: ")
+		ct.Logf("%s", strings.Repeat("-", 145))
+		ct.Logf("📋 %-15s | %-50s | %-15s | %-15s | %-15s | %-15s", "Scenario", "Pod", "Test", "Num Samples", "Duration", "Avg value")
+		ct.Logf("%s", strings.Repeat("-", 145))
 		for p, d := range ct.PerfResults {
-			ct.Logf("📋 %-50s | %-15s | %-15d | %-15s | %.2f (%s)", p.Pod, p.Test, d.Samples, d.Duration, d.Avg, d.Metric)
+			ct.Logf("📋 %-15s | %-50s | %-15s | %-15d | %-15s | %.2f (%s)", d.Scenario, p.Pod, p.Test, d.Samples, d.Duration, d.Avg, d.Metric)
 			ct.Debugf("Individual Values from run : %s", d.Values)
 		}
-		ct.Logf("%s", strings.Repeat("-", 125))
+		ct.Logf("%s", strings.Repeat("-", 145))
 	}
 
 	ct.Headerf("✅ All %d tests (%d actions) successful, %d tests skipped, %d scenarios skipped.", nt-nst, na, nst, nss)

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -42,6 +42,10 @@ const (
 	kindPerfName                = "perf"
 )
 
+// perfDeploymentNameManager provides methods for building deployment names
+// based on the given parameters.
+// Names returned by the methods will be unique depending on how the deployments
+// are expected to be modified for the configured test.
 type perfDeploymentNameManager struct {
 	clientDeploymentName       string
 	clientAcrossDeploymentName string

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -270,7 +270,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			zone = lz
 		}
 
-		if ct.params.PerfHost {
+		if ct.params.PerfHostNet {
 			ct.Info("Deploying Perf deployments using host networking")
 		}
 
@@ -301,7 +301,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 						},
 					},
 				},
-				HostNetwork: ct.params.PerfHost,
+				HostNetwork: ct.params.PerfHostNet,
 			})
 			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, perfClientDeployment, metav1.CreateOptions{})
 			if err != nil {
@@ -347,7 +347,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 						},
 					},
 				},
-				HostNetwork: ct.params.PerfHost,
+				HostNetwork: ct.params.PerfHostNet,
 			})
 			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, perfServerDeployment, metav1.CreateOptions{})
 			if err != nil {
@@ -389,7 +389,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 										{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{PerfClientDeploymentName}}}},
 									TopologyKey: "kubernetes.io/hostname"}}}},
 					},
-					HostNetwork: ct.params.PerfHost,
+					HostNetwork: ct.params.PerfHostNet,
 				})
 				_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, perfClientDeployment, metav1.CreateOptions{})
 				if err != nil {
@@ -587,7 +587,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 	for _, perfPod := range perfPods.Items {
 		// Individual endpoints will not be created for pods using node's network stack
-		if !ct.params.PerfHost {
+		if !ct.params.PerfHostNet {
 			ctx, cancel := context.WithTimeout(ctx, ct.params.ciliumEndpointTimeout())
 			defer cancel()
 			if err := ct.waitForCiliumEndpoint(ctx, ct.clients.src, ct.params.TestNamespace, perfPod.Name); err != nil {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -125,6 +125,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().DurationVar(&params.PerfDuration, "perf-duration", 10*time.Second, "Duration for the Performance test to run")
 	cmd.Flags().IntVar(&params.PerfSamples, "perf-samples", 1, "Number of Performance samples to capture (how many times to run each test)")
 	cmd.Flags().BoolVar(&params.PerfCRR, "perf-crr", false, "Run Netperf CRR Test. --perf-samples and --perf-duration ignored")
+	cmd.Flags().BoolVar(&params.PerfHost, "perf-host", false, "Use host networking during network performance tests")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().StringVar(&params.CiliumBaseVersion, "base-version", defaults.Version,
 		"Specify the base Cilium version for configuration purpose in case image tag doesn't indicate the actual Cilium version")

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -125,7 +125,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().DurationVar(&params.PerfDuration, "perf-duration", 10*time.Second, "Duration for the Performance test to run")
 	cmd.Flags().IntVar(&params.PerfSamples, "perf-samples", 1, "Number of Performance samples to capture (how many times to run each test)")
 	cmd.Flags().BoolVar(&params.PerfCRR, "perf-crr", false, "Run Netperf CRR Test. --perf-samples and --perf-duration ignored")
-	cmd.Flags().BoolVar(&params.PerfHost, "perf-host", false, "Use host networking during network performance tests")
+	cmd.Flags().BoolVar(&params.PerfHostNet, "host-net", false, "Use host networking during network performance tests")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().StringVar(&params.CiliumBaseVersion, "base-version", defaults.Version,
 		"Specify the base Cilium version for configuration purpose in case image tag doesn't indicate the actual Cilium version")


### PR DESCRIPTION
Adds a new CLI argument `--host-net` to the `--perf` test suite, which acts a toggle for choosing whether or not pods are deployed into the node's network namespace. This involves leveraging the `HostNetwork` option in the pod spec.

The goal of this change is to allow us to run a host networking scenario performance test.