### PR TITLE
Add option to automatically detect the pid of the gops agent

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -103,6 +103,9 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().StringArrayVar(&sysdumpOptions.CiliumBugtoolFlags,
 		"cilium-bugtool-flags", nil,
 		"Optional set of flags to pass to cilium-bugtool command.")
+	cmd.Flags().BoolVar(&sysdumpOptions.DetectGopsPID,
+		"detect-gops-pid", false,
+		"Whether to automatically detect the gops agent PID.")
 
 	return cmd
 }

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -88,6 +88,7 @@ var (
 		Version:  "v1beta1",
 	}
 	ciliumBugtoolFileNameRegex = regexp.MustCompile("ARCHIVE at (.*)\n")
+	gopsRegexp                 = regexp.MustCompile(`^(?P<pid>\d+).*\*`)
 	gopsStats                  = []string{
 		"memstats",
 		"stack",

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -30,6 +30,7 @@ const (
 	DefaultNodeList                          = ""
 	DefaultQuick                             = false
 	DefaultOutputFileName                    = "cilium-sysdump-<ts>" // "<ts>" will be replaced with the timestamp
+	DefaultDetectGopsPID                     = false
 )
 
 var (


### PR DESCRIPTION
If we run `gops` standalone inside the container the output marks which process runs the agent by appending a `*` next to the binary name:
```
25863 0     gops          unknown Go version /usr/bin/gops
25852 25847 cilium        unknown Go version /usr/bin/cilium
10    1     cilium-agent* unknown Go version /usr/bin/cilium-agent
1     0     custom-binary        go1.16.3           /usr/local/bin/custom-binary
```

Opted to parse this output. An alternative is to implement what @nathanjsweet committed in https://github.com/cilium/cilium-sysdump/commit/688a81430a71e155e4bbc516e9bd17f8479f6129. I think the downside with that approach is that not all container images will have `cat` inside them (e.g., `cilium-operator` which is based on `FROM scratch` + `gops` + `ca-certificates` + the operator binary -- [Dockerfile](https://github.com/cilium/cilium/blob/master/images/operator/Dockerfile)).

Happy to discuss pro/cons on which one is better. I think both approaches need an extra k8s call. Added this as a configurable behavior so that users who do not wrap the process will not incur the extra k8s call.

Fixes https://github.com/cilium/cilium-cli/issues/519.