### PR TITLE
install: add encryption.enabled when encryption wireguard is used

### DIFF
--- a/install/helm.go
+++ b/install/helm.go
@@ -121,6 +121,7 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 				helmMapOpts["encryption.nodeEncryption"] = "true"
 			}
 		case encryptionWireguard:
+			helmMapOpts["encryption.enabled"] = "true"
 			helmMapOpts["encryption.type"] = "wireguard"
 			// TODO(gandro): Future versions of Cilium will remove the following
 			// two limitations, we will need to have set the config map values


### PR DESCRIPTION
Fixes: 77a7d30dc1c0 ("generate configmap from helm")
Signed-off-by: André Martins <andre@cilium.io>