### PR TITLE
install: don't repeat log message when waiting for test namespace to be deleted

### DIFF
--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -55,13 +55,13 @@ func (k *K8sUninstaller) Uninstall(ctx context.Context) error {
 	// cni (cilium) pods were deleted sooner, wait until test pods are deleted
 	// before moving onto deleting cilium pods.
 	if k.params.Wait {
+		k.Log("⌛ Waiting for %s namespace to be terminated...", k.params.TestNamespace)
 	retryNamespace:
 		// Wait for the test namespace to be terminated. Subsequent connectivity checks would fail
 		// if the test namespace is in Terminating state.
 		_, err := k.client.GetNamespace(ctx, k.params.TestNamespace, metav1.GetOptions{})
 		if err == nil {
 			time.Sleep(defaults.WaitRetryInterval)
-			k.Log("⌛ Waiting for %s namespace to be terminated...", k.params.TestNamespace)
 			goto retryNamespace
 		}
 	}


### PR DESCRIPTION
Avoid repeating the same log message upon test namespace deletion.

Noticed while debugging AKS failure on https://github.com/cilium/cilium/pull/19665

Fixes: b3d0e95f29bc ("install: Wait for test pods to be cleaned up")
