### PR TITLE
Add support to collect CNI config files from the system

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -106,6 +106,12 @@ func newCmdSysdump() *cobra.Command {
 	cmd.Flags().BoolVar(&sysdumpOptions.DetectGopsPID,
 		"detect-gops-pid", false,
 		"Whether to automatically detect the gops agent PID.")
+	cmd.Flags().StringVar(&sysdumpOptions.CNIConfigDirectory,
+		"cni-config-directory", sysdump.DefaultCNIConfigDirectory,
+		"Directory where CNI configs are located")
+	cmd.Flags().StringVar(&sysdumpOptions.CNIConfigMapName,
+		"cni-configmap-name", sysdump.DefaultCNIConfigMapName,
+		"The name of the CNI config map")
 
 	return cmd
 }

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -46,6 +46,8 @@ const (
 	ciliumNodesFileName                      = "ciliumnodes-<ts>.yaml"
 	ciliumOperatorDeploymentFileName         = "cilium-operator-deployment-<ts>.yaml"
 	clustermeshApiserverDeploymentFileName   = "clustermesh-apiserver-deployment-<ts>.yaml"
+	cniConfigMapFileName                     = "cni-configmap-<ts>.yaml"
+	cniConfigFileName                        = "cniconf-%s-%s-<ts>.txt"
 	eniconfigsFileName                       = "aws-eniconfigs-<ts>.yaml"
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
 	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"
@@ -74,6 +76,8 @@ const (
 	gopsPID              = "1"
 	rmCommand            = "rm"
 	timeFormat           = "20060102-150405"
+	lsCommand            = "/usr/bin/ls"
+	catCommand           = "/usr/bin/cat"
 )
 
 var (

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -31,6 +31,8 @@ const (
 	DefaultQuick                             = false
 	DefaultOutputFileName                    = "cilium-sysdump-<ts>" // "<ts>" will be replaced with the timestamp
 	DefaultDetectGopsPID                     = false
+	DefaultCNIConfigDirectory                = "/etc/cni/net.d/"
+	DefaultCNIConfigMapName                  = "cni-configuration"
 )
 
 var (


### PR DESCRIPTION
I added 2 options to the sysdump command:
- `cni-config-directory` which defaults to `/etc/cni/net.d/`. In most of our systems we do not use this default path and thought it would be useful to allow users to specify if they have a custom path
- `cni-configmap-name` which defaults to `cni-configuration`. Opted to expose this because we allow this to be configured via Helm as well. In the code I opted to not error out and just log at debug if the configmap is not present.

Also I looked at using the backing implementation of `kubectl cp` to extract the files from the machines but it seemed more overhead to deal with tgz archives.

Fixes https://github.com/cilium/cilium-cli/issues/769
Fixes https://github.com/cilium/cilium-cli/issues/766

Signed-off-by: Vlad Ungureanu <ungureanuvladvictor@gmail.com>