### PR TITLE
Add CLI argument for specifying CiliumNetworkPolicies in Performance Tests

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -39,6 +39,7 @@ type Parameters struct {
 	PerfDuration          time.Duration
 	PerfCRR               bool
 	PerfSamples           int
+	PerfPolicyFiles       []string
 	CiliumBaseVersion     string
 }
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -125,6 +125,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().DurationVar(&params.PerfDuration, "perf-duration", 10*time.Second, "Duration for the Performance test to run")
 	cmd.Flags().IntVar(&params.PerfSamples, "perf-samples", 1, "Number of Performance samples to capture (how many times to run each test)")
 	cmd.Flags().BoolVar(&params.PerfCRR, "perf-crr", false, "Run Netperf CRR Test. --perf-samples and --perf-duration ignored")
+	cmd.Flags().StringSliceVar(&params.PerfPolicyFiles, "perf-policy-file", []string{}, "Specify a set of network policy files to deploy with performance tests.")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().StringVar(&params.CiliumBaseVersion, "base-version", defaults.Version,
 		"Specify the base Cilium version for configuration purpose in case image tag doesn't indicate the actual Cilium version")


### PR DESCRIPTION
Introduces the CLI argument `--perf-policy-file`, which allows for users to specify custom CiliumNetworkPolicies when running
performance tests, for use in demos or other situations where the something besides the default is desired.

Example usage:

```
❯ ./cilium connectivity test --perf --perf-duration=1s --perf-policy-file=./my-policy.yaml --verbose
...

[=] Test [network-perf]
ℹ️  📜 Applying CiliumNetworkPolicy 'my-policy' to namespace 'cilium-test'..
[-] Scenario [network-perf/perf-pod-to-pod]
[.] Action [network-perf/perf-pod-to-pod/netperf: cilium-test/perf-client-668f667cd5-kbwsr (10.244.3.161) -> cilium-test/perf-server-84bf59fcf-q9txx (10.244.3.75:5201)]
[.] Action [network-perf/perf-pod-to-pod/netperf: cilium-test/perf-client-other-node-5699666544-cp2lw (10.244.2.189) -> cilium-test/perf-server-84bf59fcf-q9txx (10.244.3.75:5201)]
ℹ️  📜 Deleting CiliumNetworkPolicy 'my-policy' from namespace 'cilium-test'..

🔥 Performance Test Summary
-----------------------------------------------------------------------------------------------------------------------------
📋 Scenario                                           | Test            | Num Samples     | Duration        | Avg value
-----------------------------------------------------------------------------------------------------------------------------
📋 perf-client-other-node-5699666544-cp2lw            | UDP_STREAM      | 1               | 1s              | 800.36 (Mb/s)
📋 perf-client-668f667cd5-kbwsr                       | TCP_RR          | 1               | 1s              | 45366.61 (OP/s)
📋 perf-client-668f667cd5-kbwsr                       | TCP_STREAM      | 1               | 1s              | 2113.75 (Mb/s)
📋 perf-client-668f667cd5-kbwsr                       | UDP_RR          | 1               | 1s              | 44847.80 (OP/s)
📋 perf-client-668f667cd5-kbwsr                       | UDP_STREAM      | 1               | 1s              | 2594.78 (Mb/s)
📋 perf-client-other-node-5699666544-cp2lw            | TCP_RR          | 1               | 1s              | 22060.88 (OP/s)
📋 perf-client-other-node-5699666544-cp2lw            | TCP_STREAM      | 1               | 1s              | 1127.11 (Mb/s)
📋 perf-client-other-node-5699666544-cp2lw            | UDP_RR          | 1               | 1s              | 25126.35 (OP/s)
-----------------------------------------------------------------------------------------------------------------------------

✅ All 1 tests (2 actions) successful, 0 tests skipped, 0 scenarios skipped.
```

If a given policy file cannot be read, then an error is thrown and the test is cancelled:

```
❯ ./cilium connectivity test --perf --perf-duration=1s --perf-policy-file=doesnotexist.yaml --verbose
...
ℹ️  Cilium version: 1.11.3
connectivity test failed: unable to read user given policy file 'doesnotexist.yaml' for performance tests: open doesnotexist.yaml: no such file or directory
```

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>