### PR TITLE
sysdump: Log cilium-cli version and arguments

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -32,7 +32,7 @@ func newCmdSysdump() *cobra.Command {
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)
 			// Collect the sysdump.
-			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now())
+			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now(), Version)
 			if err != nil {
 				return fmt.Errorf("failed to create sysdump collector: %v", err)
 			}

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -125,7 +125,7 @@ type Collector struct {
 }
 
 // NewCollector returns a new sysdump collector.
-func NewCollector(k KubernetesClient, o Options, startTime time.Time) (*Collector, error) {
+func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion string) (*Collector, error) {
 	c := Collector{
 		Client:    k,
 		Options:   o,
@@ -143,6 +143,7 @@ func NewCollector(k KubernetesClient, o Options, startTime time.Time) (*Collecto
 		return nil, err
 	}
 	c.logDebug("Using %v as a temporary directory", c.sysdumpDir)
+	c.logTask("Collecting sysdump with cilium-cli version: %s, args: %s", cliVersion, os.Args[1:])
 
 	// Grab the Kubernetes nodes for the target cluster.
 	c.logTask("Collecting Kubernetes nodes")

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -48,7 +48,7 @@ func (b *SysdumpSuite) TestSysdumpCollector(c *check.C) {
 	}
 	startTime := time.Unix(946713600, 0)
 	timestamp := startTime.Format(timeFormat)
-	collector, err := NewCollector(&client, options, startTime)
+	collector, err := NewCollector(&client, options, startTime, "cilium-cli-version")
 	c.Assert(err, check.IsNil)
 	c.Assert(path.Base(collector.sysdumpDir), check.Equals, "my-sysdump-"+timestamp)
 	tempFile := collector.AbsoluteTempPath("my-file-<ts>")
@@ -70,7 +70,7 @@ func (b *SysdumpSuite) TestNodeList(c *check.C) {
 			},
 		},
 	}
-	collector, err := NewCollector(&client, options, time.Now())
+	collector, err := NewCollector(&client, options, time.Now(), "cilium-cli-version")
 	c.Assert(err, check.IsNil)
 	c.Assert(collector.NodeList, check.DeepEquals, []string{"node-a", "node-b", "node-c"})
 
@@ -78,7 +78,7 @@ func (b *SysdumpSuite) TestNodeList(c *check.C) {
 		Writer:   io.Discard,
 		NodeList: "node-a,node-c",
 	}
-	collector, err = NewCollector(&client, options, time.Now())
+	collector, err = NewCollector(&client, options, time.Now(), "cilium-cli-version")
 	c.Assert(err, check.IsNil)
 	c.Assert(collector.NodeList, check.DeepEquals, []string{"node-a", "node-c"})
 }
@@ -94,7 +94,7 @@ func (b *SysdumpSuite) TestAddTasks(c *check.C) {
 			},
 		},
 	}
-	collector, err := NewCollector(&client, options, time.Now())
+	collector, err := NewCollector(&client, options, time.Now(), "cilium-cli-version")
 	c.Assert(err, check.IsNil)
 	collector.AddTasks([]Task{{}, {}, {}})
 	c.Assert(len(collector.additionalTasks), check.Equals, 3)


### PR DESCRIPTION
It would be handy to have the cilium-cli version and flags used to
capture the sysdump in cilium-sysdump.log.

Sample outputs:

- No flags:

      % ./cilium sysdump
      🔍 Collecting sysdump with cilium-cli version: v0.11.5-18-gd3a523a1, args: [sysdump]

- With some flags:

      % ./cilium sysdump --hubble-flows-count 10 --hubble-flows-timeout 5s
      🔍 Collecting sysdump with cilium-cli version: v0.11.5-18-gd3a523a1, args: [sysdump --hubble-flows-count 10 --hubble-flows-timeout 5s]

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>