### PR TITLE
.github: explicitly set Cilium version in workflows

### DIFF
--- a/.github/cilium-cli-test-job-chart/templates/job.yaml
+++ b/.github/cilium-cli-test-job-chart/templates/job.yaml
@@ -20,6 +20,8 @@ spec:
           - name: test-script
             mountPath: /root/test
         env:
+          - name: CILIUM_VERSION
+            value: {{ .Values.cilium_version }}
           - name: KUBECONFIG
             value: /root/.kube/config
           - name: CLUSTER_NAME

--- a/.github/cilium-cli-test-job-chart/values.yaml
+++ b/.github/cilium-cli-test-job-chart/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 tag: latest
+cilium_version: ""
 cluster_name: test
 cluster_cidr: 10.4.0.0/14
 test_script_cm: cilium-cli-test-script

--- a/.github/in-cluster-test-scripts/aks-install.sh
+++ b/.github/in-cluster-test-scripts/aks-install.sh
@@ -5,6 +5,7 @@ set -e
 
 # Install Cilium
 cilium install \
+  --version "${CILIUM_VERSION}" \
   --disable-check=az-binary \
   --azure-subscription-id "${AZURE_SUBSCRIPTION_ID}" \
   --azure-node-resource-group "${AZURE_NODE_RESOURCE_GROUP}" \

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -5,6 +5,7 @@ set -e
 
 # Install Cilium
 cilium install \
+  --version "${CILIUM_VERSION}" \
   --cluster-name "${CLUSTER_NAME}" \
   --wait=false \
   --config monitor-aggregation=none \

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -5,6 +5,7 @@ set -e
 
 # Install Cilium
 cilium install \
+  --version "${CILIUM_VERSION}" \
   --cluster-name "${CLUSTER_NAME}" \
   --wait=false \
   --config monitor-aggregation=none

--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -5,6 +5,7 @@ set -e
 
 # Install Cilium in cluster
 cilium install \
+  --version "${CILIUM_VERSION}" \
   --cluster-name "${CLUSTER_NAME}" \
   --config monitor-aggregation=none \
   --config tunnel=vxlan \

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -5,6 +5,7 @@ set -e
 
 # Install Cilium
 cilium install \
+  --version "${CILIUM_VERSION}" \
   --cluster-name "${CLUSTER_NAME}" \
   --config monitor-aggregation=none \
   --ipv4-native-routing-cidr="${CLUSTER_CIDR}"

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -9,6 +9,7 @@ CONTEXT2=$(kubectl config view | grep "${CLUSTER_NAME_2}" | head -1 | awk '{prin
 
 # Install Cilium in cluster1
 cilium install \
+  --version "${CILIUM_VERSION}" \
   --context "${CONTEXT1}" \
   --cluster-name "${CLUSTER_NAME_1}" \
   --cluster-id 1 \
@@ -17,6 +18,7 @@ cilium install \
 
 # Install Cilium in cluster2
 cilium install \
+  --version "${CILIUM_VERSION}" \
   --context "${CONTEXT2}" \
   --cluster-name "${CLUSTER_NAME_2}" \
   --cluster-id 2 \

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -29,6 +29,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  cilium_version: v1.11.4
   kubectl_version: v1.23.6
 
 jobs:
@@ -178,6 +179,7 @@ jobs:
             --set job_name=cilium-cli-install \
             --set test_script_cm=cilium-cli-test-script-install \
             --set tag=${{ steps.vars.outputs.sha }} \
+            --set cilium_version=${{ env.cilium_version }} \
             --set azure.subscription_id=${{ steps.az.outputs.subscription-id }} \
             --set azure.node_resource_group=${{ steps.az.outputs.node-resource-group }} \
             --set azure.tenant_id=${{ steps.az.outputs.tenant-id }} \

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -28,6 +28,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-tunnel
   region: us-east-2
+  cilium_version: v1.11.4
   kubectl_version: v1.23.6
 
 jobs:
@@ -123,6 +124,7 @@ jobs:
           helm install .github/cilium-cli-test-job-chart \
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
+            --set cilium_version=${{ env.cilium_version }} \
             --set cluster_name=${{ env.clusterName }}
 
       - name: Wait for job

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -28,6 +28,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  cilium_version: v1.11.4
   kubectl_version: v1.23.6
 
 jobs:
@@ -123,6 +124,7 @@ jobs:
           helm install .github/cilium-cli-test-job-chart \
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
+            --set cilium_version=${{ env.cilium_version }} \
             --set cluster_name=${{ env.clusterName }}
 
       - name: Wait for job

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -30,6 +30,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
+  cilium_version: v1.11.4
   kubectl_version: v1.23.6
 
 jobs:
@@ -131,6 +132,7 @@ jobs:
           helm install .github/cilium-cli-test-job-chart \
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
+            --set cilium_version=${{ env.cilium_version }} \
             --set cluster_name=${{ env.clusterName }} \
             --set job_name=cilium-cli-install \
             --set test_script_cm=cilium-cli-test-script-install \

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -28,6 +28,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
+  cilium_version: v1.11.4
   kubectl_version: v1.23.6
 
 jobs:
@@ -110,6 +111,7 @@ jobs:
           helm install .github/cilium-cli-test-job-chart \
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
+            --set cilium_version=${{ env.cilium_version }} \
             --set cluster_name=${{ env.clusterName }} \
             --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }}
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -15,6 +15,7 @@ env:
   KIND_CONFIG: .github/kind-config.yaml
   TIMEOUT: 2m
   LOG_TIME: 30m
+  cilium_version: v1.11.4
   kubectl_version: v1.23.6
 
 jobs:
@@ -55,6 +56,7 @@ jobs:
       - name: Install Cilium
         run: |
           cilium install \
+            --version=${{ env.cilium_version }} \
             --wait=false \
             --config monitor-aggregation=none
 
@@ -79,7 +81,7 @@ jobs:
 
       - name: Install Cilium with IPsec Encryption
         run: |
-          cilium install --encryption=ipsec --kube-proxy-replacement=probe
+          cilium install --version=${{ env.cilium_version}} --encryption=ipsec --kube-proxy-replacement=probe
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -30,6 +30,7 @@ env:
   clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  cilium_version: v1.11.4
   kubectl_version: v1.23.6
 
 jobs:
@@ -149,6 +150,7 @@ jobs:
           helm install .github/cilium-cli-test-job-chart \
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
+            --set cilium_version=${{ env.cilium_version }} \
             --set job_name=cilium-cli \
             --set test_script_cm=cilium-cli-test-script \
             --set cluster_name_1=${{ env.clusterName1 }} \


### PR DESCRIPTION
Currently, the workflows will always install the Cilium version
specified in defaults.Version which is currently set to 1.11.4.

To ensure compatibility of changes in cilium-cli we might want to run CI
with a different Cilium version, e.g. an rc release. This change allows
specifying cilium_version in the workflows to test against a different
version.