### PR TITLE
ci: make external workload only use global DNS server in test

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -177,7 +177,7 @@ jobs:
       - name: Verify cluster DNS on VM
         run: |
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
-            --command "nslookup -norecurse clustermesh-apiserver.kube-system.svc.cluster.local"
+            --command "nslookup -d2 -retry=10 -timeout=5 -norecurse clustermesh-apiserver.kube-system.svc.cluster.local \$(systemd-resolve --status | grep -m 1 \"Current DNS Server:\" | cut -d':' -f2)"
 
       - name: Ping clustermesh-apiserver from VM
         run: |

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -182,7 +182,7 @@ jobs:
       - name: Ping clustermesh-apiserver from VM
         run: |
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
-            --command "ping -c 3 \$(cilium service list get -o jsonpath='{[?(@.spec.flags.name==\"clustermesh-apiserver\")].spec.backend-addresses[0].ip}')"
+            --command "ping -c 3 \$(sudo cilium service list get -o jsonpath='{[?(@.spec.flags.name==\"clustermesh-apiserver\")].spec.backend-addresses[0].ip}')"
 
       - name: Load cilium test script in configmap
         run: |


### PR DESCRIPTION
Follow https://github.com/cilium/cilium/pull/19483

Only use the first configured DNS server (the global one) in the
test. Also add nslookup debug and retry options in case they are needed
for further debugging and troubleshooting.

This fixes external workload CI test on master that failed like this:

```
Server:		169.254.169.254
Address:	169.254.169.254#53

** server can't find clustermesh-apiserver.kube-system.svc.cluster.local: NXDOMAIN
```

Here an incorrect nameserver is being used by nslookup. This
169.254.169.254 is configured (now) in GKE as a nameserver for some
local names. Don't know why nslookup sometimes chooses it if no server
address is given as a parameter.