### PR TITLE
ci: run `cilium status` with `sudo` in external workloads post-test phase

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -221,7 +221,7 @@ jobs:
         if: ${{ !success() }}
         run: |
           echo "=== Retrieve VM state ==="
-          gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
+          gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo cilium status"
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
 
           echo "=== Install latest stable CLI ==="


### PR DESCRIPTION
This was missed in commit c345ba2cdb51 ("ci: run `cilium service list
get` with `sudo` in external workloads ping test").