### PR TITLE
cmd: Add CLI argument for specifying image in  'connectivity test' subcommand

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -41,6 +41,9 @@ type Parameters struct {
 	PerfHostNet           bool
 	PerfSamples           int
 	CiliumBaseVersion     string
+	CurlImage             string
+	PerformanceImage      string
+	JSONMockImage         string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -258,7 +258,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			Name:   echoSameNodeDeploymentName,
 			Kind:   kindEchoName,
 			Port:   8080,
-			Image:  defaults.ConnectivityCheckJSONMockImage,
+			Image:  ct.params.JSONMockImage,
 			Labels: map[string]string{"other": "echo"},
 			Affinity: &corev1.Affinity{
 				PodAffinity: &corev1.PodAffinity{
@@ -322,7 +322,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				Name:  nm.ClientName(),
 				Kind:  kindPerfName,
 				Port:  80,
-				Image: defaults.ConnectivityPerformanceImage,
+				Image: ct.params.PerformanceImage,
 				Labels: map[string]string{
 					"client": "role",
 				},
@@ -359,7 +359,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					"server": "role",
 				},
 				Port:    5001,
-				Image:   defaults.ConnectivityPerformanceImage,
+				Image:   ct.params.PerformanceImage,
 				Command: []string{"/bin/bash", "-c", "netserver;sleep 10000000"},
 				Affinity: &corev1.Affinity{
 					NodeAffinity: &corev1.NodeAffinity{
@@ -407,7 +407,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					Labels: map[string]string{
 						"client": "role",
 					},
-					Image:   defaults.ConnectivityPerformanceImage,
+					Image:   ct.params.PerformanceImage,
 					Command: []string{"/bin/bash", "-c", "sleep 10000000"},
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
@@ -445,7 +445,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			Name:    ClientDeploymentName,
 			Kind:    kindClientName,
 			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
+			Image:   ct.params.CurlImage,
 			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
@@ -462,7 +462,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			Name:    Client2DeploymentName,
 			Kind:    kindClientName,
 			Port:    8080,
-			Image:   defaults.ConnectivityCheckAlpineCurlImage,
+			Image:   ct.params.CurlImage,
 			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
 			Labels:  map[string]string{"other": "client"},
 			Affinity: &corev1.Affinity{
@@ -510,7 +510,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				Name:  echoOtherNodeDeploymentName,
 				Kind:  kindEchoName,
 				Port:  8080,
-				Image: defaults.ConnectivityCheckJSONMockImage,
+				Image: ct.params.JSONMockImage,
 				Affinity: &corev1.Affinity{
 					PodAntiAffinity: &corev1.PodAntiAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -130,6 +130,9 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.CiliumBaseVersion, "base-version", defaults.Version,
 		"Specify the base Cilium version for configuration purpose in case image tag doesn't indicate the actual Cilium version")
 	cmd.Flags().MarkHidden("base-version")
+	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckAlpineCurlImage, "Image path to use for curl")
+	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
+	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 
 	return cmd
 }


### PR DESCRIPTION
reference 
`cilium install --agent-image quay.mirrors.ustc.edu.cn/cilium/cilium:v1.11.4`

add three argument in `cilium connectivity test` subcommand

- `--curl-image`
- `--json-mock-image`
- `--performance-image`

Example usage:


```
$ cilium connectivity test -h
Validate connectivity in cluster

Usage:
  cilium connectivity test [flags]

Flags:
      --all-flows                  Print all flows during flow validation
      --curl-image string          Image path to use for curl (default "quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956")
  -d, --debug                      Show debug messages
      --flow-validation string     Enable Hubble flow validation { disabled | warning | strict } (default "warning")
      --force-deploy               Force re-deploying test artifacts
  -h, --help                       help for test
      --host-net                   Use host networking during network performance tests
      --hubble                     Automatically use Hubble for flow validation & troubleshooting (default true)
      --hubble-server string       Address of the Hubble endpoint for flow validation (default "localhost:4245")
      --json-mock-image string     Image path to use for json mock (default "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b")
      --multi-cluster string       Test across clusters to given context
  -p, --pause-on-fail              Pause execution on test failure
      --perf                       Run network Performance tests
      --perf-crr                   Run Netperf CRR Test. --perf-samples and --perf-duration ignored
      --perf-duration duration     Duration for the Performance test to run (default 10s)
      --perf-samples int           Number of Performance samples to capture (how many times to run each test) (default 1)
      --performance-image string   Image path to use for performance (default "quay.io/cilium/network-perf:bf58fb8bc57c4933dfa6e2a9581d3925c0a0571e@sha256:9bef508b2dcaeb3e288a496b8d3f065e8636a4937ba3aebcb1732afffaccea34")
      --post-test-sleep duration   Wait time after each test before next test starts
      --print-flows                Print flow logs for each test
      --single-node                Limit to tests able to run on a single node
      --test strings               Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'
      --test-namespace string      Namespace to perform the connectivity test in (default "cilium-test")
  -v, --verbose                    Show informational messages and don't buffer any lines

Global Flags:
      --context string     Kubernetes configuration context
  -n, --namespace string   Namespace Cilium is running in (default "kube-system")

$ cilium connectivity test --curl-image quay.mirrors.ustc.edu.cn/cilium/alpine-curl:v1.4.0 --json-mock-image quay.mirrors.ustc.edu.cn/cilium/json-mock:v1.3.0
```

Fixes: #677

Signed-off-by: feifeifei <wangyufeimoon@gamil.com>