### PR TITLE
sysdump: Collect hubble observe --debug and stderr

### DIFF
--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -55,6 +55,7 @@ const (
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
 	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"
 	hubbleFlowsFileName                      = "hubble-flows-%s-<ts>.json"
+	hubbleObserveFileName                    = "hubble-observe-%s-<ts>.log"
 	hubbleRelayConfigMapFileName             = "hubble-relay-configmap-<ts>.yaml"
 	hubbleRelayDeploymentFileName            = "hubble-relay-deployment-<ts>.yaml"
 	hubbleUIDeploymentFileName               = "hubble-ui-deployment-<ts>.yaml"


### PR DESCRIPTION
Extend the hubble observe command to capture debug output and the stderr
as a logfile.

While we're at it, improve the log messages to distinguish different
errors that may occur while gathering hubble observe data.
