### PR TITLE
Add ctags/cscope target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,13 @@ test:
 bench:
 	$(GO) test -timeout=30s -bench=. $$($(GO) list ./...)
 
+clean-tags:
+	@-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
+
+tags: $$($(GO) list ./...)
+	@ctags $<
+	cscope -R -b -q
+
 ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION),$(GOLANGCILINT_VERSION)))
 check:
 	golangci-lint run
@@ -80,4 +87,4 @@ check:
 	docker run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:v$(GOLANGCILINT_WANT_VERSION) golangci-lint run
 endif
 
-.PHONY: $(TARGET) release local-release install clean test bench check
+.PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags


### PR DESCRIPTION
I use "make tags" instinctively in Cilium repos to generate databases
for navigating the codebase. Add some simple make targets here to
facilitate this workflow.
