### PR TITLE
install: Add --list-versions flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	google.golang.org/grpc v1.47.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	helm.sh/helm/v3 v3.9.0
@@ -232,7 +233,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -107,6 +107,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.HelmValuesSecretName, "helm-values-secret-name", defaults.HelmValuesSecretName, "Secret name to store the auto-generated helm values file. The namespace is the same as where Cilium will be installed")
 	cmd.Flags().StringVar(&params.ImageSuffix, "image-suffix", "", "Set all generated images with this suffix")
 	cmd.Flags().StringVar(&params.ImageTag, "image-tag", "", "Set all images with this tag")
+	cmd.Flags().BoolVar(&params.ListVersions, "list-versions", false, "List all the available versions without actually installing")
 
 	for flagName := range install.FlagsToHelmOpts {
 		// TODO(aanm) Do not mark the flags has deprecated for now.

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium-cli/internal/utils"
 
 	helm "github.com/cilium/charts"
+	"golang.org/x/mod/semver"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -270,4 +271,23 @@ func MergeVals(
 	}
 
 	return vals, nil
+}
+
+// ListVersions returns a list of available Helm chart versions (with "v" prefix) sorted by semver in ascending order.
+func ListVersions() ([]string, error) {
+	var versions []string
+	re := regexp.MustCompile(`^cilium-(.+)\.tgz$`)
+	entries, err := helm.HelmFS.ReadDir(".")
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		match := re.FindStringSubmatch(entry.Name())
+		if len(match) == 2 {
+			// semver.Sort expects a leading "v" in version strings.
+			versions = append(versions, "v"+match[1])
+		}
+	}
+	semver.Sort(versions)
+	return versions, nil
 }


### PR DESCRIPTION
When this flag is passed to "cilium install" command, it prints out all
the available versions and exits without actually installing Cilium.

Help message:

    --list-versions                        List all the available versions without actually installing

Sample output:

    % ./cilium install --list-versions
    v1.12.0-rc2
    v1.12.0-rc1
    v1.12.0-rc0
    v1.11.5 (default)
    v1.11.4
    v1.11.3
    ...

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>