### PR TITLE
Remove --base-version flag from connectivity and hubble subcommands

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -40,7 +40,6 @@ type Parameters struct {
 	PerfCRR               bool
 	PerfHostNet           bool
 	PerfSamples           int
-	CiliumBaseVersion     string
 	CurlImage             string
 	PerformanceImage      string
 	JSONMockImage         string

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -543,6 +543,6 @@ func (ct *ConnectivityTest) PostTestSleepDuration() time.Duration {
 	return ct.params.PostTestSleepDuration
 }
 
-func (ct *ConnectivityTest) CiliumBaseVersion() string {
-	return ct.params.CiliumBaseVersion
+func (ct *ConnectivityTest) K8sClient() *k8s.Client {
+	return ct.client
 }

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/internal/utils"
 )
 
 var (
@@ -54,13 +53,11 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		return err
 	}
 
-	version := ct.FetchCiliumPodImageTag()
-	ct.Debugf("Cilium image version: %v", version)
-	v, err := utils.ParseCiliumVersion(version, ct.CiliumBaseVersion())
+	helmState, err := ct.K8sClient().GetHelmState(ctx, ct.Params().CiliumNamespace, defaults.HelmValuesSecretName)
 	if err != nil {
-		v = versioncheck.MustVersion(defaults.Version)
-		ct.Warnf("Unable to parse Cilium version %q, assuming %v for connectivity tests", version, defaults.Version)
+		return err
 	}
+	v := helmState.Version
 
 	ct.Infof("Cilium version: %v", v)
 

--- a/hubble/relay_test.go
+++ b/hubble/relay_test.go
@@ -34,19 +34,18 @@ func TestK8sHubbleRelayImage(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			k := &K8sHubble{
-				ciliumVersion: tt.ciliumVersion,
 				params: Parameters{
 					RelayImage:   tt.relayImage,
 					RelayVersion: tt.relayVersion,
 				},
 			}
-			if got := k.relayImage(tt.imagePathMode); got != tt.want {
+			if got := k.relayImage(tt.imagePathMode, tt.ciliumVersion); got != tt.want {
 				t.Errorf("k.relayImage(%d) == %q, want %q", tt.imagePathMode, got, tt.want)
 			}
 		})
 	}
 }
 
-func (k *K8sHubble) relayImage(imagePathMode utils.ImagePathMode) string {
-	return utils.BuildImagePath(k.params.RelayImage, k.params.RelayVersion, defaults.RelayImage, k.ciliumVersion, imagePathMode)
+func (k *K8sHubble) relayImage(imagePathMode utils.ImagePathMode, ciliumVersion string) string {
+	return utils.BuildImagePath(k.params.RelayImage, k.params.RelayVersion, defaults.RelayImage, ciliumVersion, imagePathMode)
 }

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -24,7 +24,7 @@ func (k *K8sHubble) generateHubbleUIService() (*corev1.Service, error) {
 		svcFilename string
 	)
 
-	ciliumVer := k.semVerCiliumVersion
+	ciliumVer := k.helmState.Version
 	switch {
 	case versioncheck.MustCompile(">1.10.99")(ciliumVer):
 		svcFilename = "templates/hubble-ui/service.yaml"
@@ -46,7 +46,7 @@ func (k *K8sHubble) generateHubbleUIConfigMap() (*corev1.ConfigMap, error) {
 		cmFilename string
 	)
 
-	ciliumVer := k.semVerCiliumVersion
+	ciliumVer := k.helmState.Version
 	switch {
 	case versioncheck.MustCompile(">1.10.99")(ciliumVer):
 		cmFilename = "templates/hubble-ui/configmap.yaml"
@@ -68,7 +68,7 @@ func (k *K8sHubble) generateHubbleUIDeployment() (*appsv1.Deployment, error) {
 		deployFilename string
 	)
 
-	ciliumVer := k.semVerCiliumVersion
+	ciliumVer := k.helmState.Version
 	switch {
 	case versioncheck.MustCompile(">1.10.99")(ciliumVer):
 		deployFilename = "templates/hubble-ui/deployment.yaml"

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -127,9 +127,6 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVar(&params.PerfCRR, "perf-crr", false, "Run Netperf CRR Test. --perf-samples and --perf-duration ignored")
 	cmd.Flags().BoolVar(&params.PerfHostNet, "host-net", false, "Use host networking during network performance tests")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
-	cmd.Flags().StringVar(&params.CiliumBaseVersion, "base-version", defaults.Version,
-		"Specify the base Cilium version for configuration purpose in case image tag doesn't indicate the actual Cilium version")
-	cmd.Flags().MarkHidden("base-version")
 	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckAlpineCurlImage, "Image path to use for curl")
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -41,10 +41,13 @@ func newCmdHubbleEnable() *cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params.Namespace = namespace
-
-			h := hubble.NewK8sHubble(k8sClient, params)
-			if err := h.Enable(context.Background()); err != nil {
-				fatalf("Unable to enable Hubble:  %s", err)
+			ctx := context.Background()
+			h, err := hubble.NewK8sHubble(ctx, k8sClient, params)
+			if err != nil {
+				fatalf("Unable to enable Hubble: %s", err)
+			}
+			if err := h.Enable(ctx); err != nil {
+				fatalf("Unable to enable Hubble: %s", err)
 			}
 			return nil
 		},
@@ -71,8 +74,6 @@ func newCmdHubbleEnable() *cobra.Command {
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", defaults.StatusWaitDuration, "Maximum time to wait for status")
 
 	cmd.Flags().StringVar(&params.K8sVersion, "k8s-version", "", "Kubernetes server version in case auto-detection fails")
-	cmd.Flags().StringVar(&params.BaseVersion, "base-version", defaults.Version,
-		"Specify the base Cilium version for configuration purpose in case the --version flag doesn't indicate the actual Cilium version")
 	cmd.Flags().StringVar(&params.HelmChartDirectory, "chart-directory", "", "Helm chart directory")
 	cmd.Flags().StringSliceVar(&params.HelmOpts.ValueFiles, "helm-values", []string{}, "Specify helm values in a YAML file or a URL (can specify multiple)")
 	cmd.Flags().StringArrayVar(&params.HelmOpts.Values, "helm-set", []string{}, "Set helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
@@ -106,9 +107,13 @@ func newCmdHubbleDisable() *cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params.Namespace = namespace
+			ctx := context.Background()
 
-			h := hubble.NewK8sHubble(k8sClient, params)
-			if err := h.Disable(context.Background()); err != nil {
+			h, err := hubble.NewK8sHubble(ctx, k8sClient, params)
+			if err != nil {
+				fatalf("Unable to disable Hubble:  %s", err)
+			}
+			if err := h.Disable(ctx); err != nil {
 				fatalf("Unable to disable Hubble:  %s", err)
 			}
 			return nil
@@ -134,9 +139,13 @@ func newCmdPortForwardCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params.Context = contextName
 			params.Namespace = namespace
+			ctx := context.Background()
 
-			h := hubble.NewK8sHubble(k8sClient, params)
-			if err := h.PortForwardCommand(context.Background()); err != nil {
+			h, err := hubble.NewK8sHubble(ctx, k8sClient, params)
+			if err != nil {
+				fatalf("Unable to port forward: %s", err)
+			}
+			if err := h.PortForwardCommand(ctx); err != nil {
 				fatalf("Unable to port forward: %s", err)
 			}
 			return nil

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -27,9 +27,21 @@ import (
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/strvals"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var settings = cli.New()
+
+// State contains Helm state for the current Cilium installation. Cilium CLI retrieves this
+// information from cilium-cli-helm-values Kubernetes secret.
+type State struct {
+	// Pointer to cilium-cli-helm-values secret.
+	Secret *corev1.Secret
+	// Helm chart version.
+	Version semver2.Version
+	// Helm values used for this installation.
+	Values chartutil.Values
+}
 
 // filterManifests a map of generated manifests. The Key is the filename and the
 // Value is its manifest.

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -310,7 +310,7 @@ func ListVersions() ([]string, error) {
 func ResolveHelmChartVersion(versionFlag, chartDirectoryFlag string) (semver2.Version, error) {
 	if chartDirectoryFlag == "" {
 		// If --chart-directory flag is not specified, use the version specified with --version flag.
-		version, err := utils.ParseCiliumVersion(versionFlag, "")
+		version, err := utils.ParseCiliumVersion(versionFlag)
 		if err != nil {
 			return semver2.Version{}, err
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -22,14 +22,9 @@ func CheckVersion(version string) bool {
 	return versionRegexp(version)
 }
 
-func ParseCiliumVersion(version, baseVersion string) (semver.Version, error) {
+func ParseCiliumVersion(version string) (semver.Version, error) {
 	ersion := strings.TrimPrefix(version, "v")
-	v, err := versioncheck.Version(ersion)
-	if err != nil {
-		ersion = strings.TrimPrefix(baseVersion, "v")
-		v, err = versioncheck.Version(ersion)
-	}
-	return v, err
+	return versioncheck.Version(ersion)
 }
 
 type ImagePathMode int

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -53,10 +53,10 @@ func TestCheckVersion(t *testing.T) {
 
 func TestParseCiliumVersion(t *testing.T) {
 	tests := []struct {
-		name                 string
-		version, baseVersion string
-		want                 semver.Version
-		wantErr              bool
+		name    string
+		version string
+		want    semver.Version
+		wantErr bool
 	}{
 		{
 			name:    "empty",
@@ -72,37 +72,18 @@ func TestParseCiliumVersion(t *testing.T) {
 			version: "v1.9.99",
 			want:    semver.Version{Major: 1, Minor: 9, Patch: 99},
 		},
-		{
-			name:        "invalid-version-with-base-version",
-			version:     "invalid",
-			baseVersion: "v1.11.2",
-			want:        semver.Version{Major: 1, Minor: 11, Patch: 2},
-		},
-		{
-			name:        "valid-version-with-valid-base-version",
-			version:     "v1.11.2",
-			baseVersion: "v1.10.13",
-			want:        semver.Version{Major: 1, Minor: 11, Patch: 2},
-		},
-
-		{
-			name:        "invalid-version-with-invalid-base-version",
-			version:     "invalid",
-			baseVersion: "not-a-version",
-			wantErr:     true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseCiliumVersion(tt.version, tt.baseVersion)
+			got, err := ParseCiliumVersion(tt.version)
 			if tt.wantErr && err == nil {
-				t.Errorf("ParseCiliumVersion(%q, %q) got nil, want error", tt.version, tt.baseVersion)
+				t.Errorf("ParseCiliumVersion(%q) got nil, want error", tt.version)
 			} else if !tt.wantErr && err != nil {
-				t.Errorf("ParseCiliumVersion(%q, %q) got error, want nil", tt.version, tt.baseVersion)
+				t.Errorf("ParseCiliumVersion(%q) got error, want nil", tt.version)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("PetCiliumVersion(%qm %q) = %v, want %v", tt.version, tt.baseVersion, got, tt.want)
+				t.Errorf("PetCiliumVersion(%q) = %v, want %v", tt.version, got, tt.want)
 			}
 		})
 	}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"helm.sh/helm/v3/pkg/chartutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -40,6 +41,8 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/internal/helm"
+	"github.com/cilium/cilium-cli/internal/utils"
 )
 
 type Client struct {
@@ -813,4 +816,37 @@ func (c *Client) CreateIngressClass(ctx context.Context, ingressClass *networkin
 
 func (c *Client) DeleteIngressClass(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.Clientset.NetworkingV1().IngressClasses().Delete(ctx, name, opts)
+}
+
+// GetHelmState is a wrapper function that gets cilium-cli-helm-values secret from Kubernetes API
+// server, and converts its fields from byte array to their corresponding data types.
+func (c *Client) GetHelmState(ctx context.Context, namespace string, secretName string) (*helm.State, error) {
+	helmSecret, err := c.GetSecret(ctx, namespace, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve helm values secret %s/%s: %w", namespace, secretName, err)
+	}
+	versionBytes, ok := helmSecret.Data[defaults.HelmChartVersionSecretKeyName]
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve helm chart version from secret %s/%s: %w", namespace, secretName, err)
+	}
+	versionString := string(versionBytes)
+	version, err := utils.ParseCiliumVersion(versionString, "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse helm chart version from secret %s/%s: %s %w", namespace, secretName, versionString, err)
+	}
+
+	yamlSecret, ok := helmSecret.Data[defaults.HelmValuesSecretKeyName]
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve helm values from secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	values, err := chartutil.ReadValues(yamlSecret)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse helm values from secret %s/%s: %w", namespace, secretName, err)
+	}
+	return &helm.State{
+		Secret:  helmSecret,
+		Version: version,
+		Values:  values,
+	}, nil
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -830,7 +830,7 @@ func (c *Client) GetHelmState(ctx context.Context, namespace string, secretName 
 		return nil, fmt.Errorf("unable to retrieve helm chart version from secret %s/%s: %w", namespace, secretName, err)
 	}
 	versionString := string(versionBytes)
-	version, err := utils.ParseCiliumVersion(versionString, "")
+	version, err := utils.ParseCiliumVersion(versionString)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse helm chart version from secret %s/%s: %s %w", namespace, secretName, versionString, err)
 	}


### PR DESCRIPTION
might be easier to review commit by commit:

- add a wrapper function to read cilium-cli-helm-values secret and parse its data.
- remove --base-version from connectivity command.
- remove --base-version from hubble command.
- remove base version parameter from ParseCiliumVersion function.