### PR TITLE
Dockerfile: Bump up kubectl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN make
 FROM docker.io/library/busybox:stable-glibc@sha256:95262195a281b3756e734b3996132030d76d5bd773564ea762d49eccf006571b
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium-cli/cilium /usr/local/bin/cilium
-RUN ["wget", "-P", "/usr/local/bin", "https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubectl"]
+RUN ["wget", "-P", "/usr/local/bin", "https://dl.k8s.io/release/v1.23.6/bin/linux/amd64/kubectl"]
 RUN ["chmod", "+x", "/usr/local/bin/kubectl"]
 ENTRYPOINT []


### PR DESCRIPTION
Use the same kubectl version as the one used in CI workflows.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>