### PR TITLE
gha: Couple of changes to fix EKS failures

### DIFF
--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -13,6 +13,9 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
+# Wait for cilium and hubble relay to be ready
+cilium status --wait
+
 # Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
 [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -54,6 +54,14 @@ jobs:
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 
+      - name: Install helm
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab
+        with:
+          # Due to the below issue, v3.8.2 is pinned currently to avoid
+          # exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
+          # https://github.com/helm/helm/issues/10975
+          version: v3.8.2
+
       - name: Set up AWS CLI credentials
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2
         with:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -54,6 +54,14 @@ jobs:
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 
+      - name: Install helm
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab
+        with:
+          # Due to the below issue, v3.8.2 is pinned currently to avoid
+          # exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
+          # https://github.com/helm/helm/issues/10975
+          version: v3.8.2
+
       - name: Set up AWS CLI credentials
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN make
 FROM docker.io/library/busybox:stable-glibc@sha256:95262195a281b3756e734b3996132030d76d5bd773564ea762d49eccf006571b
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium-cli/cilium /usr/local/bin/cilium
-RUN ["wget", "-P", "/usr/local/bin", "https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubectl"]
+RUN ["wget", "-P", "/usr/local/bin", "https://dl.k8s.io/release/v1.23.6/bin/linux/amd64/kubectl"]
 RUN ["chmod", "+x", "/usr/local/bin/kubectl"]
 ENTRYPOINT []


### PR DESCRIPTION
### Description

Fixing issue with invalid apiVersion

```
Error: Kubernetes cluster unreachable: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
```

### Testing

Testing was done with temp commit, successful runs are available below

CNI: https://github.com/cilium/cilium-cli/runs/6726007799?check_suite_focus=true
Tunnel: https://github.com/cilium/cilium-cli/runs/6726008680?check_suite_focus=true