### PR TITLE
ci: create a new subnetwork for each new GKE cluster

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -83,6 +83,8 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --enable-ip-alias \
+            --create-subnetwork="" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -89,14 +89,15 @@ jobs:
           gcloud container clusters create ${{ env.clusterName2 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --enable-ip-alias \
+            --create-subnetwork="" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
-            --preemptible \
-            --enable-ip-alias
+            --preemptible
 
       - name: Get cluster 2 credentials
         run: |
@@ -112,14 +113,15 @@ jobs:
           gcloud container clusters create ${{ env.clusterName1 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --enable-ip-alias \
+            --create-subnetwork="" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
-            --preemptible \
-            --enable-ip-alias
+            --preemptible
 
       - name: Get cluster 1 credentials
         run: |


### PR DESCRIPTION
> Note: this is a CLI backport of a similar change already made a while ago on the main `cilium/cilium` repository: https://github.com/cilium/cilium/commit/04147264308ee06f4c13fa105716efbec798e07f

We sometimes hit this issue in the CI for runs involving GKE clusters:

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=This operation will exceed max secondary ranges per subnetwork (30) for subnet "default", consider reusing existing secondary ranges or use a different subnetwork.
```

As per the documentation, we can have the `gcloud` CLI create a new subnet when creating a new GKE cluster with `--create-subnetwork`. When passed `""`, it creates a new subnet with a default name and size. The goal here is to make sure that clusters don't conflict with each others in the default subnet when there are too many secondary ranges used at the same time.

The option also requires use of `--enable-ip-alias`, which should have no impact for us in most cases.

Doc: https://cloud.google.com/sdk/gcloud/reference/container/clusters/create