### PR TITLE
add support for AKS BYOCNI

### DIFF
--- a/.github/in-cluster-test-scripts/aks-install.sh
+++ b/.github/in-cluster-test-scripts/aks-install.sh
@@ -7,10 +7,6 @@ set -e
 cilium install \
   --version "${CILIUM_VERSION}" \
   --disable-check=az-binary \
-  --azure-subscription-id "${AZURE_SUBSCRIPTION_ID}" \
-  --azure-node-resource-group "${AZURE_NODE_RESOURCE_GROUP}" \
-  --azure-tenant-id "${AZURE_TENANT_ID}" \
-  --azure-client-id "${AZURE_CLIENT_ID}" \
-  --azure-client-secret "${AZURE_CLIENT_SECRET}" \
+  --datapath-mode=aks-byocni \
   --wait=false \
   --config monitor-aggregation=none

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -54,12 +54,11 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_PR_SP_CREDS }}
 
-      - name: Display Azure CLI info
-        uses: azure/CLI@7378ce2ca3c38b4b063feb7a4cbe384fef978055
-        with:
-          azcliversion: 2.34.1
-          inlineScript: |
-            az account show
+      - name: Install aks-preview CLI extension
+        run: |
+            az extension add --name aks-preview
+            az extension update --name aks-preview
+            az version
 
       - name: Set up job variables
         id: vars
@@ -92,48 +91,10 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --network-plugin azure \
-            --node-count 1 \
+            --network-plugin none \
+            --node-count 2 \
             ${{ env.cost_reduction }} \
             --generate-ssh-keys
-
-          # Get name of initial system node pool
-          nodepool_to_delete=$(az aks nodepool list --resource-group ${{ env.name }} --cluster-name ${{ env.name }} --output tsv --query "[0].name")
-
-          # Create system node pool tainted with `CriticalAddonsOnly=true:NoSchedule`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name systempool \
-            --mode system \
-            --node-count 1 \
-            --node-taints "CriticalAddonsOnly=true:NoSchedule" \
-            ${{ env.cost_reduction }} \
-            --no-wait
-
-          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name userpool \
-            --mode user \
-            --node-count 2 \
-            --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
-            ${{ env.cost_reduction }} \
-            --no-wait
-
-          # Delete the initial system node pool
-          az aks nodepool delete \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name "${nodepool_to_delete}"
-          # note: the existing AKS documentation at https://docs.cilium.io/en/latest/gettingstarted/k8s-install-default/
-          # recommends using `--no-wait` for the `delete` operation as well,
-          # however we had to drop it on `cilium-cli` due to the use of
-          # in-cluster scripts to run `cilium install`: since it runs in a pod,
-          # we must make sure it does not scheduled on the initial system node
-          # pool as the Cilium CLI does not work when `cilium install` is
-          # abruptly interrupted, cf. https://github.com/cilium/cilium-cli/issues/589
 
       - name: Get cluster credentials
         run: |
@@ -150,28 +111,6 @@ jobs:
         run: |
           kubectl create configmap cilium-cli-test-script-install -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/aks-install.sh
 
-      - name: Set up Azure-specific CLI variables since `az` is not available in-cluster
-        id: az
-        run: |
-          # Derive subscription ID from credentials
-          AZURE_SUBSCRIPTION_ID=$(az account show --query "id" --output tsv)
-
-          # Derive AKS node resource group from created cluster
-          AZURE_NODE_RESOURCE_GROUP=$(az aks show --resource-group ${{ env.name }} --name ${{ env.name }} --query "nodeResourceGroup" --output tsv)
-
-          # Create Service Principal with minimal privileges over the AKS node resource group
-          AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_NODE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
-          TENANT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant')
-          CLIENT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.appId')
-          CLIENT_SECRET=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')
-
-          echo ::set-output name=subscription-id::${AZURE_SUBSCRIPTION_ID}
-          echo ::set-output name=node-resource-group::${AZURE_NODE_RESOURCE_GROUP}
-          echo ::set-output name=tenant-id::${TENANT_ID}
-          echo ::set-output name=client-id::${CLIENT_ID}
-          echo ::add-mask::${CLIENT_SECRET}
-          echo ::set-output name=client-secret::${CLIENT_SECRET}
-
       - name: Create cilium-cli install job
         run: |
           helm install .github/cilium-cli-test-job-chart \
@@ -179,12 +118,7 @@ jobs:
             --set job_name=cilium-cli-install \
             --set test_script_cm=cilium-cli-test-script-install \
             --set tag=${{ steps.vars.outputs.sha }} \
-            --set cilium_version=${{ env.cilium_version }} \
-            --set azure.subscription_id=${{ steps.az.outputs.subscription-id }} \
-            --set azure.node_resource_group=${{ steps.az.outputs.node-resource-group }} \
-            --set azure.tenant_id=${{ steps.az.outputs.tenant-id }} \
-            --set azure.client_id=${{ steps.az.outputs.client-id }} \
-            --set azure.client_secret=${{ steps.az.outputs.client-secret }}
+            --set cilium_version=${{ env.cilium_version }}
 
       - name: Wait for install job
         env:

--- a/install/helm.go
+++ b/install/helm.go
@@ -194,9 +194,14 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 			case versioncheck.MustCompile(">=1.9.0")(k.chartVersion):
 				helmMapOpts["masquerade"] = "false"
 			}
-			helmMapOpts["azure.subscriptionID"] = k.params.Azure.SubscriptionID
-			helmMapOpts["azure.tenantID"] = k.params.Azure.TenantID
-			helmMapOpts["azure.resourceGroup"] = k.params.Azure.AKSNodeResourceGroup
+
+		case DatapathAKSBYOCNI:
+			// TODO: replace with `helmMapOpts["aksbyocni.enabled"] = true` once the
+			// new `aksbyocni` mode has made it to Helm charts on stable releases.
+			// Until then, we manually configure the same ConfigMap options as the new
+			// `aksbyocni` mode does, so that it works transparently.
+			helmMapOpts["ipam.mode"] = ipamClusterPool
+			helmMapOpts["tunnel"] = tunnelVxlan
 		}
 
 		// TODO: remove when removing "cluster-name" flag (marked as deprecated),

--- a/install/install.go
+++ b/install/install.go
@@ -35,16 +35,18 @@ import (
 )
 
 const (
-	DatapathTunnel = "tunnel"
-	DatapathAwsENI = "aws-eni"
-	DatapathGKE    = "gke"
-	DatapathAzure  = "azure"
+	DatapathTunnel    = "tunnel"
+	DatapathAwsENI    = "aws-eni"
+	DatapathGKE       = "gke"
+	DatapathAzure     = "azure"
+	DatapathAKSBYOCNI = "aks-byocni"
 )
 
 const (
-	ipamKubernetes = "kubernetes"
-	ipamENI        = "eni"
-	ipamAzure      = "azure"
+	ipamKubernetes  = "kubernetes"
+	ipamClusterPool = "cluster-pool"
+	ipamENI         = "eni"
+	ipamAzure       = "azure"
 )
 
 const (
@@ -215,6 +217,7 @@ type AzureParameters struct {
 	TenantID             string
 	ClientID             string
 	ClientSecret         string
+	IsBYOCNI             bool
 }
 
 var (
@@ -594,8 +597,11 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 		}
 
 	case k8s.KindAKS:
-		if err := k.aksSetup(ctx); err != nil {
-			return err
+		if k.params.DatapathMode == DatapathAzure {
+			// The Azure Service Principal is only needed when using Azure IPAM
+			if err := k.azureSetupServicePrincipal(ctx); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -23,7 +23,9 @@ func (k *K8sInstaller) Upgrade(ctx context.Context) error {
 
 	// no need to determine KPR setting on upgrade, keep the setting configured with the old
 	// version.
-	k.detectDatapathMode(false)
+	if err := k.detectDatapathMode(ctx, false); err != nil {
+		return err
+	}
 
 	daemonSet, err := k.client.GetDaemonSet(ctx, k.params.Namespace, defaults.AgentDaemonSetName, metav1.GetOptions{})
 	if err != nil {

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -54,7 +54,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().MarkDeprecated("cluster-name", "This can now be overridden via `helm-set` (Helm value: `cluster.name`).")
 	cmd.Flags().StringSliceVar(&params.DisableChecks, "disable-check", []string{}, "Disable a particular validation check")
 	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
-	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use { tunnel | aws-eni | gke | azure } (default: autodetected).")
+	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use { tunnel | aws-eni | gke | azure | aks-byocni } (default: autodetected).")
 	// It can be deprecated since we have a helm option for it
 	cmd.Flags().StringVar(&params.IPAM, "ipam", "", "IP Address Management (IPAM) mode")
 	cmd.Flags().MarkDeprecated("ipam", "IPAM mode is autodetected depending on `datapath-mode`. If needed, this can now be overridden via `helm-set` (Helm value: `ipam.mode`).")


### PR DESCRIPTION
Add a new datapath mode for AKS clusters created using the new BYOCNI capabilities. This datapath mode is mutually exclusive with the older Azure datapath mode, as Azure IPAM is not available when using BYOCNI.

A similar datapath mode is going to be added to the main Helm chart so that enabling Cilium for AKS BYOCNI clusters is as simple as setting `aksbyocni.enabled=true` in the Helm values, in a similar fashion to what is done for the older Azure integration via `azure.enabled=true.

However, since this new integration has not yet landed in stable releases, we temporarily manually configure the same ConfigMap options as the new `aksbyocni` mode does, so that it works transparently.

See main PR on `cilium/cilium` for more context and details: https://github.com/cilium/cilium/pull/19379

### ⚠️ Checklist

- [x] This PR depends on https://github.com/cilium/cilium-cli/pull/898 being merged.