### PR TITLE
fix(helm): support setting string slices

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -142,6 +142,22 @@ func valuesToString(prevKey string, b map[string]interface{}) string {
 }
 
 func sliceValuesToString(prevKey string, b []interface{}) string {
+	// Handle case where b is slice of strings to set it like key={v1,v2,v3}.
+	var str []string
+Iter:
+	for _, v := range b {
+		switch v := v.(type) {
+		case string:
+			str = append(str, v)
+		default:
+			// Non-homogenous slice, falling back to default logic.
+			str = nil
+			break Iter
+		}
+	}
+	if str != nil {
+		return fmt.Sprintf("%s={%s}", prevKey, strings.Join(str, ","))
+	}
 	var out []string
 	for i, v := range b {
 		switch v := v.(type) {

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -10,6 +10,26 @@ import (
 	"github.com/blang/semver/v4"
 )
 
+func TestValuesToString(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   map[string]interface{}
+		out  string
+	}{
+		{
+			name: "str-slice",
+			in:   map[string]interface{}{"hubble": map[string]interface{}{"enabled": true, "metrics": map[string]interface{}{"enabled": []interface{}{"dns", "drop", "tcp", "flow", "icmp", "http"}}}},
+			out:  "hubble.enabled=true,hubble.metrics.enabled={dns,drop,tcp,flow,icmp,http}",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := valuesToString("", tt.in); got != tt.out {
+				t.Errorf("valuesToString: %q (got) != %q (expected)", got, tt.out)
+			}
+		})
+	}
+}
+
 func TestResolveHelmChartVersion(t *testing.T) {
 	type args struct {
 		versionFlag        string


### PR DESCRIPTION
Support setting string arrays for helm, e.g. for enabling hubble metrics:
```
cilium install --helm-set=hubble.metrics.enabled={dns,drop,tcp,flow,icmp,http}
```

Currently the `hubble.metrics.enabled={dns,drop,tcp,flow,icmp,http}` setting will render as blank string.