### PR TITLE
RELEASE.md: update to reflect current release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,27 +1,60 @@
-# RELEASE
+# cilium-cli Release Process
 
 Release process and checklist for `cilium-cli`.
 
-This repository doesn't use release branches. All releases currently stem from
-the master branch.
+This repository currently uses release branches `v0.10` and `master`. All releases stem from
+the on of these branches. Refer to the [Release
+table](https://github.com/cilium/cilium-cli#releases) for the most recent supported versions.
 
-## Prepare the variables
+## Prepare environment variables
 
-These variables will be used in the commands throughout the document to allow
-copy-pasting.
+Set `RELEASE` environment variable to the new version. This variable will be
+used in the commands throughout the documenat to allow copy-pasting.
 
-### Version
-
-Set `RELEASE` environment variable to the new version. For example, if you are
-releasing `v5.4.0`:
+For example, if you are releasing `v5.4.0`:
 
     export RELEASE=v5.4.0
 
-### Commit SHA to release
+## Prepare the release
+
+### Update the README.md
+
+Update the *Releases* section of the `README.md` which lists all currently
+supported releases in a table. The version in this table needs to be updated to
+match the new release `$RELEASE`.
+
+### (Optional) Update stable.txt
+
+The CLI installation instructions in the Cilium documentation use the version
+specified in `stable.txt` in the `master` branch. Update `stable.txt` whenever
+Cilium users should pick up this new release for installation:
+
+    echo $RELEASE > stable.txt
+
+### Create release preparation branch and open PR
+
+    git checkout -b pr/prepare-$RELEASE
+    git add README.md stable.txt
+    git commit -s -m "Prepare for $RELEASE release"
+
+Then open a pull request against `master` branch. Wait for the PR to be reviewed and merged.
+
+## Tag a release
+
+Update your local checkout:
+
+    git checkout master
+		git pull origin master
+
+Set the commit you want to tag:
 
     export COMMIT_SHA=<commit-sha-to-release>
 
-## Tag a release
+Usually this is the most recent commit on `master`, i.e.
+
+    export COMMIT_SHA=$(git rev-parse origin/master)
+
+Then tag and push the release:
 
     git tag -a $RELEASE -m "$RELEASE release" $COMMIT_SHA && git push origin $RELEASE
 
@@ -31,27 +64,6 @@ When a tag is pushed, a GitHub Action job takes care of creating a new GitHub
 draft release, building artifacts and attaching them to the draft release. Once
 the draft is ready, use the "Auto-generate release notes" button to generate
 the release notes from PR titles, review them and publish the release.
-
-## Update the README.md
-
-Update the *Releases* section of the `README.md` to point to the latest GitHub
-release. This section lists all currently supported releases in a table. The
-version in this table needs to be updated to match the new release.
-
-## (OPTIONAL) Update stable.txt
-
-The CLI installation instructions in the Cilium documentation use the version
-specified in `stable.txt` in the `master` branch. Update `stable.txt` whenever
-Cilium users should pick up this new release for installation.
-
-To update `stable.txt`:
-
-    git checkout -b pr/update-stable-to-$RELEASE
-    echo $RELEASE > stable.txt
-    git add stable.txt
-    git commit -s -m "stable.txt: update to $RELEASE"
-
-Then open a pull request against `master` branch.
 
 ## (OPTIONAL) Update the Homebrew formula
 


### PR DESCRIPTION
As done for the v0.11.8 release. Includes the following changes:

- Releases are cut from `v0.10` and `master` branches, not just `master`.
- Create a preparation PR (`README.md` and `stable.txt` update) before
  tagging the release.
- Example command to set `COMMIT_SHA` to latest `master`.