### PR TITLE
ci: explicitly wait for cilium status after enabling Hubble relay

### DIFF
--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -15,6 +15,10 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
+# Wait for cilium and hubble relay to be ready
+# NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
+cilium status --wait
+
 # Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
 [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -14,6 +14,7 @@ cilium install \
 cilium hubble enable
 
 # Wait for cilium and hubble relay to be ready
+# NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
 cilium status --wait
 
 # Make sure the 'aws-node' DaemonSet exists but has no scheduled pods


### PR DESCRIPTION
Workaround for #918

On EKS we occasionally see flakes where port-forwarding fails after
enabling Hubble Relay. Adding an explicit `cilium status --wait` works
around these.

Add a comment so we don't forget to remove the workaround once #918 is
resolved.