### PR TITLE
make: run release build as regular user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /cilium \
-		--volume `pwd`:/cilium docker.io/library/golang:1.18.3-alpine3.15 \
+		--volume `pwd`:/cilium docker.io/library/golang:1.18.3-alpine3.16 \
 		sh -c "apk add --no-cache make git && \
 			addgroup -g $(RELEASE_GID) release && \
 			adduser -u $(RELEASE_UID) -D -G release release && \


### PR DESCRIPTION
Instead of adding the checkout directory to git's safe directories as
done in commit 023ccfb8466e ("make: allow running `git status` during
release build"), change the release target to create a regular user with
the same UID/GID as the current user (assumed to be the user owning the
working directory) inside the container and use it to run `make
release`.

Follows cilium/hubble#751

Also bump the alpine version used for `make release` to 3.16.