### PR TITLE
clustermesh: Update cluster-name/cluster-id validation message

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -16,14 +16,15 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/cilium/cilium/api/v1/models"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/cilium/cilium/api/v1/models"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/certs"
@@ -900,7 +901,8 @@ func (k *K8sClusterMesh) Connect(ctx context.Context) error {
 	}
 
 	if !aiLocal.validate() {
-		return fmt.Errorf("local cluster has non-unique name (%s) and/or ID (%s)", aiLocal.ClusterName, aiLocal.ClusterID)
+		return fmt.Errorf("local cluster has the default name (cluster name: %s) and/or ID 0 (cluster ID: %s)",
+			aiLocal.ClusterName, aiLocal.ClusterID)
 	}
 
 	if aiRemote.ClusterName == aiLocal.ClusterName {


### PR DESCRIPTION
This commit is to make the message clearer if default values are used.
Reported by cilium user in slack channel.

Suggested-by: André Martins <andre@cilium.io>
Signed-off-by: Tam Mach <tam.mach@cilium.io>