### PR TITLE
azure: fix BYOCNI install with Cilium >= 1.12

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -659,8 +659,8 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 	case k8s.KindAKS:
 		// We only made the secret-based azure installation available in >= 1.12.0
 		// Introduced in https://github.com/cilium/cilium/pull/18010
-		switch {
-		case versioncheck.MustCompile(">=1.12.0")(k.chartVersion):
+		// Additionally, secrets are only needed when using Azure IPAM
+		if k.params.DatapathMode == DatapathAzure && versioncheck.MustCompile(">=1.12.0")(k.chartVersion) {
 			if err := k.createAKSSecrets(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
We introduced support for BYOCNI with the `aks-byocni` datapath mode in 2e1d3b5d375e7028ffcf7900bbb155f97f58aec1, and properly guarded the previously existing Service Principal creation to only be done when using Azure IPAM (`azure` datapath mode), however we forgot to do the same for the newly-introduced AKS secrets in the Cilium 1.12 Helm chart.

This went undetected during the initial implementation as the Helm chart used was either the stable 1.11.5 or the development version 1.11.90 when directly using the Helm chart from upstream `master` branch, in both cases skipping the existing 1.12 check for creating AKS secrets.

Now, after the 1.12 branch was properly created and the development version bumped to 1.12.90, this does not work anymore, and explains why the AKS BYOCNI CI in upstream was initially working but then started to fail after the version bump.