### PR TITLE
ci: explicitly wait for cilium status after enabling Hubble relay on AKS

### DIFF
--- a/.github/in-cluster-test-scripts/aks.sh
+++ b/.github/in-cluster-test-scripts/aks.sh
@@ -6,6 +6,10 @@ set -e
 # Enable Relay
 cilium hubble enable
 
+# Wait for cilium and hubble relay to be ready
+# NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
+cilium status --wait
+
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s


### PR DESCRIPTION
It seems #918 occasionally occurs on AKS as well, e.g.
https://github.com/cilium/cilium-cli/runs/7243578074?check_suite_focus=true

Apply the same workaround as already added for EKS in commit
a0faf2510f6b ("ci: explicitly wait for cilium status after enabling
Hubble relay")