### PR TITLE
internal/helm: pass cilium version as semver.Version instead of string

### DIFF
--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -428,7 +428,7 @@ func (k *K8sHubble) generateManifestsDisable(ctx context.Context, helmValues cha
 
 func (k *K8sHubble) genManifests(ctx context.Context, printHelmTemplate bool, prevHelmValues chartutil.Values, helmMapOpts map[string]string, ciliumVer semver.Version) error {
 	// Store all the options passed by --config into helm extraConfig
-	vals, err := helm.MergeVals(k, printHelmTemplate, k.params.HelmOpts, helmMapOpts, prevHelmValues, nil, k.params.HelmChartDirectory, ciliumVer.String(), k.params.Namespace)
+	vals, err := helm.MergeVals(k, printHelmTemplate, k.params.HelmOpts, helmMapOpts, prevHelmValues, nil, k.params.HelmChartDirectory, ciliumVer, k.params.Namespace)
 	if err != nil {
 		return err
 	}
@@ -451,7 +451,7 @@ func (k *K8sHubble) genManifests(ctx context.Context, printHelmTemplate bool, pr
 		k8sVersionStr = k8sVersion.String()
 	}
 
-	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, ciliumVer.String(), k.params.Namespace, vals)
+	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, ciliumVer, k.params.Namespace, vals)
 	if err != nil {
 		return err
 	}

--- a/install/helm.go
+++ b/install/helm.go
@@ -257,7 +257,7 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 		extraConfigMap[k] = v
 	}
 
-	vals, err := helm.MergeVals(k, true, k.params.HelmOpts, helmMapOpts, nil, extraConfigMap, k.params.HelmChartDirectory, k.chartVersion.String(), k.params.Namespace)
+	vals, err := helm.MergeVals(k, true, k.params.HelmOpts, helmMapOpts, nil, extraConfigMap, k.params.HelmChartDirectory, k.chartVersion, k.params.Namespace)
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 		k8sVersionStr = k8sVersion.String()
 	}
 
-	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, k.chartVersion.String(), k.params.Namespace, vals)
+	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, k.chartVersion, k.params.Namespace, vals)
 	if err != nil {
 		return err
 	}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -173,7 +173,7 @@ func newClient(namespace, k8sVersion string) (*action.Install, error) {
 	return helmClient, nil
 }
 
-func newChartFromCiliumVersion(ciliumVersion string) (*chart.Chart, error) {
+func newChartFromCiliumVersion(ciliumVersion semver2.Version) (*chart.Chart, error) {
 	helmTgz, err := helm.HelmFS.ReadFile(fmt.Sprintf("cilium-%s.tgz", ciliumVersion))
 	if err != nil {
 		return nil, fmt.Errorf("cilium version not found: %s", err)
@@ -189,7 +189,13 @@ func newChartFromDirectory(directory string) (*chart.Chart, error) {
 
 // GenManifests returns the generated manifests in a map that maps the manifest
 // name to its contents.
-func GenManifests(ctx context.Context, helmChartDirectory, k8sVersion, ciliumVer, namespace string, helmValues map[string]interface{}) (map[string]string, error) {
+func GenManifests(
+	ctx context.Context,
+	helmChartDirectory, k8sVersion string,
+	ciliumVer semver2.Version,
+	namespace string,
+	helmValues map[string]interface{},
+) (map[string]string, error) {
 	var (
 		helmChart *chart.Chart
 		err       error
@@ -235,7 +241,9 @@ func MergeVals(
 	helmMapOpts map[string]string,
 	helmValues,
 	extraConfigMapOpts chartutil.Values,
-	helmChartDirectory, ciliumVer, namespace string,
+	helmChartDirectory string,
+	ciliumVer semver2.Version,
+	namespace string,
 ) (map[string]interface{}, error) {
 
 	// Create helm values from helmMapOpts
@@ -314,7 +322,7 @@ func ResolveHelmChartVersion(versionFlag, chartDirectoryFlag string) (semver2.Ve
 		if err != nil {
 			return semver2.Version{}, err
 		}
-		if _, err = newChartFromCiliumVersion(version.String()); err != nil {
+		if _, err = newChartFromCiliumVersion(version); err != nil {
 			return semver2.Version{}, err
 		}
 		return version, nil


### PR DESCRIPTION
Only (implicitly) convert it to a string when actually needed as such.