### PR TITLE
Update Go to 1.18.4

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
       with:
-        go-version: 1.18.3
+        go-version: 1.18.4
 
     - name: Run static checks
       uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: 1.18.3
+          go-version: 1.18.4
 
       - name: Set up Go for root
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: 1.18.3
+          go-version: 1.18.4
 
       - name: Set up job variables
         id: vars

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: 1.18.3
+          go-version: 1.18.4
 
       - name: Generate the artifacts
         run: make release

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /cilium \
-		--volume `pwd`:/cilium docker.io/library/golang:1.18.3-alpine3.16 \
+		--volume `pwd`:/cilium docker.io/library/golang:1.18.4-alpine3.16 \
 		sh -c "apk add --no-cache make git && \
 			addgroup -g $(RELEASE_GID) release && \
 			adduser -u $(RELEASE_UID) -D -G release release && \


### PR DESCRIPTION
This includes various security fixes, see
https://go.dev/doc/devel/release#go1.18.4 for details.