### PR TITLE
sysdump: Add kvstore data to dumps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 # Outputs of 'cilium sysdump'.
 cilium-sysdump-*/
 cilium-sysdump-*.zip
+
+# Editor metas
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -191,7 +191,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
+	github.com/stretchr/testify v1.8.0
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect


### PR DESCRIPTION
When running sysdump, if kvstore is detected then various kvstore paths are added to the dump.

This is intended to be used by the debug-ability tools to help diagnose issues.

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>