### PR TITLE
[connectivity tests] Support private CoreDNS image location

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -44,6 +44,7 @@ type Parameters struct {
 	PerformanceImage      string
 	JSONMockImage         string
 	AgentDaemonSetName    string
+	DNSTestServerImage    string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -33,7 +33,6 @@ const (
 	client2DeploymentName = "client2"
 
 	DNSTestServerContainerName = "dns-test-server"
-	DNSTestServerImage         = "coredns/coredns:1.9.3@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a"
 
 	echoSameNodeDeploymentName  = "echo-same-node"
 	echoOtherNodeDeploymentName = "echo-other-node"
@@ -156,7 +155,7 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 	return dep
 }
 
-func newDeploymentWithDNSTestServer(p deploymentParameters) *appsv1.Deployment {
+func newDeploymentWithDNSTestServer(p deploymentParameters, DNSTestServerImage string) *appsv1.Deployment {
 	dep := newDeployment(p)
 
 	dep.Spec.Template.Spec.Containers = append(
@@ -354,7 +353,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				},
 			},
 			ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
-		})
+		}, ct.params.DNSTestServerImage)
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoDeployment, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to create deployment %s: %s", echoSameNodeDeploymentName, err)
@@ -606,7 +605,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					},
 				},
 				ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
-			})
+			}, ct.params.DNSTestServerImage)
 			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeployment, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("unable to create deployment %s: %w", echoOtherNodeDeploymentName, err)

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -67,6 +67,7 @@ const (
 	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956"
 	ConnectivityPerformanceImage     = "quay.io/cilium/network-perf:bf58fb8bc57c4933dfa6e2a9581d3925c0a0571e@sha256:9bef508b2dcaeb3e288a496b8d3f065e8636a4937ba3aebcb1732afffaccea34"
 	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b"
+	ConnectivityDNSTestServerImage   = "docker.io/coredns/coredns:1.9.3@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a"
 
 	ConfigMapName = "cilium-config"
 	Version       = "v1.11.6"

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -129,6 +129,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckAlpineCurlImage, "Image path to use for curl")
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
+	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
 
 	return cmd
 }


### PR DESCRIPTION
https://github.com/cilium/cilium-cli/pull/854 added support for having private images however, this image is hardcoded currently. 

This PR adds support for passing in `--dns-test-server-image` allowing folks to use the connectivity tests without having to connect to any third party registry. I also updated the image to be explicitly from docker.io follow the format of the other images. 