### PR TITLE
[connectivity tests] Support custom agent daemonset name

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -43,6 +43,7 @@ type Parameters struct {
 	CurlImage             string
 	PerformanceImage      string
 	JSONMockImage         string
+	AgentDaemonSetName    string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -428,7 +428,7 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	// environment so we can skip deploying tests which depend on multiple
 	// nodes.
 	if ct.params.MultiCluster == "" && !ct.params.SingleNode {
-		daemonSet, err := ct.client.GetDaemonSet(ctx, ct.params.CiliumNamespace, defaults.AgentDaemonSetName, metav1.GetOptions{})
+		daemonSet, err := ct.client.GetDaemonSet(ctx, ct.params.CiliumNamespace, ct.params.AgentDaemonSetName, metav1.GetOptions{})
 		if err != nil {
 			ct.Fatal("Unable to determine status of Cilium DaemonSet. Run \"cilium status\" for more details")
 			return fmt.Errorf("unable to determine status of Cilium DaemonSet: %w", err)

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -111,6 +111,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVar(&params.Hubble, "hubble", true, "Automatically use Hubble for flow validation & troubleshooting")
 	cmd.Flags().StringVar(&params.HubbleServer, "hubble-server", "localhost:4245", "Address of the Hubble endpoint for flow validation")
 	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity test in")
+	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")


### PR DESCRIPTION
We currently operate cilium with a different daemonset name than the `defaults.AgentDaemonSetName` is set to. This PR adds support for passing in `--agent-daemonset-name` so that the connectivity tests can still identify the daemonset. 