### PR TITLE
clustermesh: Validate cluster-id value as per requirement

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -905,6 +905,14 @@ func (k *K8sClusterMesh) Connect(ctx context.Context) error {
 			aiLocal.ClusterName, aiLocal.ClusterID)
 	}
 
+	cid, err := strconv.Atoi(aiRemote.ClusterID)
+	if err != nil {
+		return fmt.Errorf("remote cluster has non-numeric cluster ID %s. Only numeric values 1-255 are allowed", aiRemote.ClusterID)
+	}
+	if cid < 1 || cid > 255 {
+		return fmt.Errorf("remote cluster has cluster ID %d out of acceptable range (1-255)", cid)
+	}
+
 	if aiRemote.ClusterName == aiLocal.ClusterName {
 		return fmt.Errorf("remote and local cluster have the same, non-unique name: %s", aiLocal.ClusterName)
 	}


### PR DESCRIPTION
This commit is to make sure that cluster-id is numeric and within range
of 1-255.

https://docs.cilium.io/en/stable/gettingstarted/clustermesh/clustermesh/#gs-clustermesh

> Each cluster must be assigned a unique human-readable name as well as a numeric cluster ID (1-255)

Fixes: #143
Signed-off-by: Tam Mach <tam.mach@cilium.io>