### PR TITLE
connectivity: Add --assume-cilium-version flag

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -17,6 +17,7 @@ import (
 )
 
 type Parameters struct {
+	AssumeCiliumVersion   string
 	CiliumNamespace       string
 	TestNamespace         string
 	SingleNode            bool

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -56,8 +56,14 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	}
 
 	var v semver.Version
-	helmState, err := ct.K8sClient().GetHelmState(ctx, ct.Params().CiliumNamespace, defaults.HelmValuesSecretName)
-	if err != nil {
+	if assumeCiliumVersion := ct.Params().AssumeCiliumVersion; assumeCiliumVersion != "" {
+		ct.Warnf("Assuming Cilium version %s for connectivity tests", assumeCiliumVersion)
+		var err error
+		v, err = utils.ParseCiliumVersion(assumeCiliumVersion)
+		if err != nil {
+			return err
+		}
+	} else if helmState, err := ct.K8sClient().GetHelmState(ctx, ct.Params().CiliumNamespace, defaults.HelmValuesSecretName); err != nil {
 		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests", defaults.Version)
 		v, err = utils.ParseCiliumVersion(defaults.Version)
 		if err != nil {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -116,6 +116,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
 	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
+	cmd.Flags().StringVar(&params.AssumeCiliumVersion, "assume-cilium-version", "", "Assume Cilium version for connectivity tests")
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages and don't buffer any lines")
 	cmd.Flags().BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")


### PR DESCRIPTION
The connectivity tests run depend on the Cilium version detected. In
some cases (e.g. when run against Isovalent Cilium Enterprise) the
Cilium version is not detected correctly and the connectivity tests fall
back to assuming the latest Cilium version. These tests may fail if the
actual Cilium version is too old.

This commit adds an --assume-cilium-version flag to cilium connectivity
test to allow the version to be set explicitly, rather than falling back
to the latest by default. This is useful for CI when running the
connectivity tests against older versions of Cilium.

Signed-off-by: Tom Payne <tom@isovalent.com>