### PR TITLE
ci: explicitly wait for cilium status after enabling Hubble relay on GKE

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -15,6 +15,10 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
+# Wait for cilium and hubble relay to be ready
+# NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
+cilium status --wait
+
 # Enable cluster mesh
 cilium clustermesh enable
 

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -13,6 +13,10 @@ cilium install \
 # Enable Relay
 cilium hubble enable
 
+# Wait for cilium and hubble relay to be ready
+# NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
+cilium status --wait
+
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -30,6 +30,11 @@ cilium install \
 cilium --context "${CONTEXT1}" hubble enable
 cilium --context "${CONTEXT2}" hubble enable --relay=false
 
+# Wait for cilium and hubble relay to be ready
+# NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
+cilium --context "${CONTEXT1}" status --wait
+cilium --context "${CONTEXT2}" status --wait
+
 # Enable cluster mesh
 cilium --context "${CONTEXT1}" clustermesh enable
 cilium --context "${CONTEXT2}" clustermesh enable


### PR DESCRIPTION
We're occasionally encountering #918 on GKE too, e.g.
https://github.com/cilium/cilium-cli/runs/7421447399?check_suite_focus=true

Apply the same workaround as already added for EKS in commit
a0faf2510f6b ("ci: explicitly wait for cilium status after enabling
Hubble relay") and for AKS in commit 7176ce532267 ("ci: explicitly wait
for cilium status after enabling Hubble relay on AKS").