### PR TITLE
connectivity: Detect version from cilium pods

### DIFF
--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -63,14 +63,14 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		if err != nil {
 			return err
 		}
-	} else if helmState, err := ct.K8sClient().GetHelmState(ctx, ct.Params().CiliumNamespace, defaults.HelmValuesSecretName); err != nil {
-		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests", defaults.Version)
+	} else if minVersion, err := ct.DetectMinimumCiliumVersion(ctx); err != nil {
+		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests: %s", defaults.Version, err)
 		v, err = utils.ParseCiliumVersion(defaults.Version)
 		if err != nil {
 			return err
 		}
 	} else {
-		v = helmState.Version
+		v = *minVersion
 	}
 
 	ct.Infof("Cilium version: %v", v)


### PR DESCRIPTION
This commit changes the version detection away from the version state
stored during `cilium install`, and instead relies on the actual version
reported by `cilium version` in the Cilium pods. This fixes an issue
where `cilium connectivity test` could not be used if Cilium was not
installed via CLI (e.g. via Helm).

The version of all Cilium pods is parsed, and only the minimum version
is used. This ensures that we can use the lowest common denominator in
terms of features.