### PR TITLE
Update RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,13 +64,3 @@ When a tag is pushed, a GitHub Action job takes care of creating a new GitHub
 draft release, building artifacts and attaching them to the draft release. Once
 the draft is ready, use the "Auto-generate release notes" button to generate
 the release notes from PR titles, review them and publish the release.
-
-## (Optional) Update the Homebrew formula
-
-The `cilium-cli` Homebrew formula can be updated using the command:
-
-    brew bump-formula-pr --version=${RELEASE#v} cilium-cli
-
-This will automatically create a PR against https://github.com/Homebrew/homebrew-core
-bumping the version. This assumes a GitHub access token exported in
-`$HOMEBREW_GITHUB_API_TOKEN`, see `brew bump-formula-pr --help` for details.


### PR DESCRIPTION
There is a bot that automatically opens PRs against homebrew-core on new
cilium-cli releases, so let's remove the step where we manually open PRs.

Ref: https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+is%3Aclosed+cilium-cli

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>