### PR TITLE
CODEOWNERS: update teams following removal of non-sig teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,9 +4,9 @@
 # @cilium/cli                Commandline interfaces
 # @cilium/contributing       Developer documentation & tools
 # @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
-# @cilium/hubble             Hubble integration
-# @cilium/kubernetes         K8s integration, K8s CNI plugin
 # @cilium/sig-clustermesh    Clustermesh and external workloads
+# @cilium/sig-hubble         Hubble integration
+# @cilium/sig-k8s            K8s integration, K8s CNI plugin
 # @cilium/vendor             Vendoring, dependency management
 
 # The following filepaths should be sorted so that more specific paths occur
@@ -25,10 +25,10 @@
 /cmd/ @cilium/cli
 /clustermesh/ @cilium/sig-clustermesh
 /connectivity/ @cilium/cli
-/hubble/ @cilium/hubble
+/hubble/ @cilium/sig-hubble
 /install/azure.go @cilium/azure
 /internal/cli/ @cilium/cli
-/k8s/ @cilium/kubernetes
+/k8s/ @cilium/sig-k8s
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor
 /vendor/ @cilium/vendor


### PR DESCRIPTION
Several teams were removed in favor of their sig-xxx equivalents. Update
CODEOWNERS accordingly.
