### PR TITLE
connectivity: Add node-local-dns match labels

### DIFF
--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -22,3 +22,6 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: coredns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -27,3 +27,6 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: coredns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -21,6 +21,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: coredns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
     toPorts:
     - ports:
       - port: "53"

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -32,3 +32,6 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: coredns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns


### PR DESCRIPTION
When node-local dns is deployed along with local
redirect policy [1], the DNS traffic is redirected
to node-local dns cache pods. Hence, allow such DNS
traffic in the connectivity test policy yamls.

[1] https://docs.cilium.io/en/latest/gettingstarted/local-redirect-policy/#node-local-dns-cache

Reported-by: Julien Boulanger <julien.boulanger@fr.clara.net>
Signed-off-by: Aditi Ghag <aditi@cilium.io>
