### PR TITLE
fix(connectivity): Add node-local-dns entitiy match for local ip usage case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cilium-sysdump-*.zip
 
 # Editor metas
 .vscode/
+.idea/

--- a/connectivity/manifests/allow-all-except-world-pre-v1.11.yaml
+++ b/connectivity/manifests/allow-all-except-world-pre-v1.11.yaml
@@ -13,6 +13,16 @@ spec:
     - health
   - toEndpoints:
     - {}
+  # When node-local-dns is deployed with local IP,
+  # Cilium labels its ip as world.
+  # This change prevents failing the connectivity
+  # test for such environments.
+  - toPorts:
+      - ports:
+          - port: "53"
+            protocol: UDP
+    toEntities:
+      - world
   ingress:
   - fromEntities:
     - host

--- a/connectivity/manifests/allow-all-except-world.yaml
+++ b/connectivity/manifests/allow-all-except-world.yaml
@@ -13,7 +13,17 @@ spec:
     - health
     - kube-apiserver
   - toEndpoints:
-    - {}
+      - {}
+  # When node-local-dns is deployed with local IP,
+  # Cilium labels its ip as world.
+  # This change prevents failing the connectivity
+  # test for such environments.
+  - toPorts:
+      - ports:
+          - port: "53"
+            protocol: UDP
+    toEntities:
+      - world
   ingress:
   - fromEntities:
     - host

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -15,12 +15,16 @@ spec:
         dns:
         - matchPattern: "*"
     toEndpoints:
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: kube-dns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: coredns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: node-local-dns
+      - matchExpressions:
+          - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+          - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+  # When node-local-dns is deployed with local IP,
+  # Cilium labels its ip as world.
+  # This change prevents failing the connectivity
+  # test for such environments.
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -21,5 +21,15 @@ spec:
         protocol: ANY
     toEndpoints:
     - matchExpressions:
-      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+  # When node-local-dns is deployed with local IP,
+  # Cilium labels its ip as world.
+  # This change prevents failing the connectivity
+  # test for such environments.
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -15,9 +15,19 @@ spec:
         protocol: TCP
   - toEndpoints:
     - matchExpressions:
-      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
     toPorts:
     - ports:
       - port: "53"
         protocol: ANY
+  # When node-local-dns is deployed with local IP,
+  # Cilium labels its ip as world.
+  # This change prevents failing the connectivity
+  # test for such environments.
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -26,5 +26,15 @@ spec:
         - matchPattern: "*"
     toEndpoints:
     - matchExpressions:
-      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+  # When node-local-dns is deployed with local IP,
+  # Cilium labels its ip as world.
+  # This change prevents failing the connectivity
+  # test for such environments.
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world


### PR DESCRIPTION
When node-local-dns is deployed with local IP, 
policies fail to verify that the connection goes to 
node-local-dns. This change allows such DNS 
traffics in the connectivity test policy yamls.

Signed-off-by: eminaktas <eminaktas34@gmail.com>