### PR TITLE
internal: add missing types when generating helm template command

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -154,6 +154,16 @@ func sliceValuesToString(prevKey string, b []interface{}) string {
 		case []interface{}:
 			out = append(out, sliceValuesToString(fmt.Sprintf("%s[%d]", prevKey, i), v))
 			continue
+		case string:
+			out = append(out, fmt.Sprintf("%s[%d]=%s", prevKey, i, v))
+			continue
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64:
+			out = append(out, fmt.Sprintf("%s[%d]=%d", prevKey, i, v))
+			continue
+		case float32, float64:
+			out = append(out, fmt.Sprintf("%s[%d]=%f", prevKey, i, v))
+			continue
 		}
 	}
 	sort.Strings(out)


### PR DESCRIPTION
Some types were not being printed when generated helm template command.
For example:
```
ipam:
  mode: cluster-pool
  operator:
    clusterPoolIPv4PodCIDRList:
      - "10.244.0.0/16"
      - "10.245.0.0/16"
```

Now, when running cilium install the helm template command for those
values will be correctly presented:
```
helm template [...] --set ipam.operator.clusterPoolIPv4PodCIDRList[0]=10.244.0.0/16,ipam.operator.clusterPoolIPv4PodCIDRList[1]=10.244.0.1/16 [...]
```

Signed-off-by: André Martins <andre@cilium.io>