### PR TITLE
connectivity: Add test for HostPort support

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -53,12 +53,14 @@ jobs:
           version: ${{ env.KIND_VERSION }}
           config: ${{ env.KIND_CONFIG }}
 
+      # Install Cilium with HostPort support for extended connectivity test.
       - name: Install Cilium
         run: |
           cilium install \
             --version=${{ env.cilium_version }} \
             --wait=false \
-            --config monitor-aggregation=none
+            --config monitor-aggregation=none \
+            --helm-set cni.chainingMode=portmap
 
       - name: Enable Relay
         run: |

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -419,6 +419,10 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 
 	ipRequest := filters.IP(srcIP, dstIP)
 	ipResponse := filters.IP(dstIP, srcIP)
+	if len(p.AltDstIP) != 0 && p.AltDstIP != dstIP {
+		ipRequest = filters.Or(filters.IP(srcIP, p.AltDstIP), ipRequest)
+		ipResponse = filters.Or(filters.IP(p.AltDstIP, srcIP), ipResponse)
+	}
 
 	var egress filters.FlowSetRequirement
 	var http filters.FlowSetRequirement
@@ -560,6 +564,10 @@ func (a *Action) GetIngressRequirements(p FlowParameters) []filters.FlowSetRequi
 
 	ipResponse := filters.IP(dstIP, srcIP)
 	ipRequest := filters.IP(srcIP, dstIP)
+	if len(p.AltDstIP) != 0 && p.AltDstIP != dstIP {
+		ipResponse = filters.Or(filters.IP(p.AltDstIP, srcIP), ipResponse)
+		ipRequest = filters.Or(filters.IP(srcIP, p.AltDstIP), ipRequest)
+	}
 
 	tcpRequest := filters.TCP(0, a.dst.Port())
 	tcpResponse := filters.TCP(a.dst.Port(), 0)

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -457,9 +457,9 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 	case TCP:
 		tcpRequest := filters.TCP(0, a.dst.Port())
 		tcpResponse := filters.TCP(a.dst.Port(), 0)
-		if p.NodePort != 0 && p.NodePort != a.dst.Port() {
-			tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
-			tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
+		if p.AltDstPort != 0 && p.AltDstPort != a.dst.Port() {
+			tcpRequest = filters.Or(filters.TCP(0, p.AltDstPort), tcpRequest)
+			tcpResponse = filters.Or(filters.TCP(p.AltDstPort, 0), tcpResponse)
 		}
 
 		if a.expEgress.Drop && !a.expEgress.L7Proxy {
@@ -563,9 +563,9 @@ func (a *Action) GetIngressRequirements(p FlowParameters) []filters.FlowSetRequi
 
 	tcpRequest := filters.TCP(0, a.dst.Port())
 	tcpResponse := filters.TCP(a.dst.Port(), 0)
-	if p.NodePort != 0 {
-		tcpRequest = filters.Or(filters.TCP(0, p.NodePort), tcpRequest)
-		tcpResponse = filters.Or(filters.TCP(p.NodePort, 0), tcpResponse)
+	if p.AltDstPort != 0 {
+		tcpRequest = filters.Or(filters.TCP(0, p.AltDstPort), tcpRequest)
+		tcpResponse = filters.Or(filters.TCP(p.AltDstPort, 0), tcpResponse)
 	}
 
 	switch p.Protocol {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -148,8 +148,10 @@ type FlowParameters struct {
 	// RSTAllowed is true if TCP connection may end with either RST or FIN
 	RSTAllowed bool
 
-	// NodePort, if non-zero, indicates an alternative port number for the DstPort to be matched
-	NodePort uint32
+	// AltDstPort, if non-zero, indicates an alternative port number for the
+	// DstPort to be matched. This is useful if the destination port is NATed,
+	// which is for example the case for service ports, NodePort or HostPort
+	AltDstPort uint32
 }
 
 type flowsSet []*observer.GetFlowsResponse_Flow

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -148,6 +148,12 @@ type FlowParameters struct {
 	// RSTAllowed is true if TCP connection may end with either RST or FIN
 	RSTAllowed bool
 
+	// AltDstIP, if non-empty, indicates an alternative destination address
+	// for the DstAddr to be matched. This is useful if the destination address
+	// is NATed before Hubble can observe the packet, which for example is the
+	// case with HostReachableServices
+	AltDstIP string
+
 	// AltDstPort, if non-zero, indicates an alternative port number for the
 	// DstPort to be matched. This is useful if the destination port is NATed,
 	// which is for example the case for service ports, NodePort or HostPort

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -24,6 +24,15 @@ const (
 	FeatureMonitorAggregation Feature = "monitor-aggregation"
 	FeatureL7Proxy            Feature = "l7-proxy"
 	FeatureHostFirewall       Feature = "host-firewall"
+
+	FeatureKPRMode                  Feature = "kpr-mode"
+	FeatureKPRExternalIPs           Feature = "kpr-external-ips"
+	FeatureKPRGracefulTermination   Feature = "kpr-graceful-termination"
+	FeatureKPRHostPort              Feature = "kpr-hostport"
+	FeatureKPRHostReachableServices Feature = "kpr-host-reachable-services"
+	FeatureKPRNodePort              Feature = "kpr-nodeport"
+	FeatureKPRSessionAffinity       Feature = "kpr-session-affinity"
+	FeatureKPRSocketLB              Feature = "kpr-socket-lb"
 )
 
 // FeatureStatus describes the status of a feature. Some features are either
@@ -166,6 +175,39 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 	}
 	result[FeatureHostFirewall] = FeatureStatus{
 		Enabled: status,
+	}
+
+	// Kube-Proxy Replacement
+	mode = "Disabled"
+	if kpr := st.KubeProxyReplacement; kpr != nil {
+		mode = kpr.Mode
+		if f := kpr.Features; f != nil {
+			if f.ExternalIPs != nil {
+				result[FeatureKPRExternalIPs] = FeatureStatus{Enabled: f.ExternalIPs.Enabled}
+			}
+			if f.HostPort != nil {
+				result[FeatureKPRHostPort] = FeatureStatus{Enabled: f.HostPort.Enabled}
+			}
+			if f.GracefulTermination != nil {
+				result[FeatureKPRGracefulTermination] = FeatureStatus{Enabled: f.GracefulTermination.Enabled}
+			}
+			if f.HostReachableServices != nil {
+				result[FeatureKPRHostReachableServices] = FeatureStatus{Enabled: f.HostReachableServices.Enabled}
+			}
+			if f.NodePort != nil {
+				result[FeatureKPRNodePort] = FeatureStatus{Enabled: f.NodePort.Enabled}
+			}
+			if f.SessionAffinity != nil {
+				result[FeatureKPRSessionAffinity] = FeatureStatus{Enabled: f.SessionAffinity.Enabled}
+			}
+			if f.SocketLB != nil {
+				result[FeatureKPRSocketLB] = FeatureStatus{Enabled: f.SocketLB.Enabled}
+			}
+		}
+	}
+	result[FeatureKPRMode] = FeatureStatus{
+		Enabled: mode != "Disabled",
+		Mode:    mode,
 	}
 
 	return nil

--- a/connectivity/check/scenario.go
+++ b/connectivity/check/scenario.go
@@ -13,3 +13,11 @@ type Scenario interface {
 	// Run is invoked by the testing framework to execute the Scenario.
 	Run(ctx context.Context, t *Test)
 }
+
+// ConditionalScenario is a test scenario which requires certain feature
+// requirements to be enabled. If the requirements are not met, the test
+// scenario is skipped
+type ConditionalScenario interface {
+	Scenario
+	Requirements() []FeatureRequirement
+}

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -90,6 +90,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		tests.PodToService(),
 		tests.PodToRemoteNodePort(),
 		tests.PodToLocalNodePort(),
+		tests.PodToHostPort(),
 		tests.PodToWorld(),
 		tests.PodToHost(),
 		tests.PodToExternalWorkload(),

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -35,7 +35,7 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
-					NodePort:    svc.Port(),
+					AltDstPort:  svc.Port(),
 				}))
 			})
 
@@ -136,7 +136,7 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 			// The fact that curl is hitting the NodePort instead of the
 			// backend Pod's port is specified here. This will cause the matcher
 			// to accept both the NodePort and the ClusterIP (container) port.
-			NodePort: np,
+			AltDstPort: np,
 		}))
 	})
 }


### PR DESCRIPTION
This PR adds an additional scenario to the `no-policies` test which checks connectivity to pods with a HostPort. HostPort support in Cilium can be achieved either via CNI chaining with the portmap plugin, or via Kube Proxy Replacement. I have validated this PR with both setups.

There are some changes needed to the overall code, such as support for conditional scenarios and support for alternative destination addresses in flow validation (needed for KPR HostPort). The newly introduced scenario is only run if the HostPort feature is detected.

*Review per commit*