### PR TITLE
.github: update dependabot open PR limit for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     rebase-strategy: disabled
     labels:
     - kind/enhancement
@@ -29,7 +29,7 @@ updates:
     schedule:
       interval: daily
     target-branch: "v0.10"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     rebase-strategy: disabled
     labels:
     - kind/enhancement


### PR DESCRIPTION
It's unlikely that these will cause merge conflicts. The cilium/cilium
repo also uses the same limit without any issues so far.