### PR TITLE
connectivity: Add ICMP policy test from client to client

### DIFF
--- a/connectivity/manifests/echo-ingress-icmp.yaml
+++ b/connectivity/manifests/echo-ingress-icmp.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-ingress-from-client2-icmp
+spec:
+  description: "Allow other client to contact another client via ICMP"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:other: client
+      icmps:
+        - fields:
+            - type: 8


### PR DESCRIPTION
This commit is to add new connectivity test (e.g. client-ingress-icmp)
with allowed ICMP policy.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

---

As highlighted below, CI is still with cilium 1.11, so testing was done locally with minikube cilium 1.12.0