### PR TITLE
connectivity: trim whitespaces from `cilium version` output

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -492,7 +492,7 @@ func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*se
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch cilium version on pod %q: %w", name, err)
 		}
-		v, _, _ := strings.Cut(stdout.String(), "-") // strips proprietary -releaseX suffix
+		v, _, _ := strings.Cut(strings.TrimSpace(stdout.String()), "-") // strips proprietary -releaseX suffix
 		podVersion, err := semver.Parse(v)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse cilium version on pod %q: %w", name, err)


### PR DESCRIPTION
Currently, Cilium version might not be correctly detected in all cases
due to trailing whitespaces in the stdout of the `cilium version`
command, leading to the following warning:

    ⚠️  Unable to detect Cilium version, assuming v1.12.0 for connectivity tests: unable to parse cilium version on pod "cilium-b7tng": Invalid character(s) found in patch number "6\n"

Fix this by trimming all whitespaces from the command output.