### PR TITLE
hubble: fix enable/disable command when `cilium-cli-helm-values` does…

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -101,3 +101,22 @@ var (
 	// CiliumPodSelector is the pod selector to be used for the Cilium agents.
 	CiliumPodSelector = "k8s-app=cilium"
 )
+
+// All hubble values from `cilium-config` configmap:
+// https://github.com/cilium/cilium/blob/d9a04be9d714e5f5544cbca7ef8db7a151bfce96/install/kubernetes/cilium/templates/cilium-configmap.yaml#L709-L750
+// this list is used to cherry-pick only hubble related values for configmap patch
+// when running in unknown install state (i.e. when `cilium-cli-helm-values` doesn't exist)
+var HubbleKeys = []string{
+	"enable-hubble",
+	"hubble-disable-tls",
+	"hubble-event-buffer-capacity",
+	"hubble-event-queue-size",
+	"hubble-flow-buffer-size",
+	"hubble-listen-address",
+	"hubble-metrics",
+	"hubble-metrics-server",
+	"hubble-socket-path",
+	"hubble-tls-cert-file",
+	"hubble-tls-client-ca-files",
+	"hubble-tls-key-file",
+}

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
-	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect


### PR DESCRIPTION
… not exist

This commit fixes hubble enable and disable commands which are broken
when cilium initially was not installed with cilium-cli. In these cases
`cilium-cli-helm-values` secret does not exist and all `cilium hubble`
commands fail.

Since hubble components are cherry-picked from the generated helm manifests,
it should be safe to proceed without the full helm values state.

We should not write the new helm state to the cluster so that if in the
future other components need to use it, we don't inadvertently
over shadow real installation parameters.

Fixes: #959

Signed-off-by: Olga Mirensky <5200844+olga-mir@users.noreply.github.com>