### PR TITLE
connectivity: Use agent-runtime-config.json for feature detection

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -147,14 +147,12 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 	// CNI chaining.
 	// Note: This value might be overwritten by extractFeaturesFromCiliumStatus
 	// if this information is present in `cilium status`
-	mode = ""
+	mode := "none"
 	if v, ok := cm.Data["cni-chaining-mode"]; ok {
-		if v != "none" {
-			mode = v
-		}
+		mode = v
 	}
 	result[FeatureCNIChaining] = FeatureStatus{
-		Enabled: mode != "",
+		Enabled: mode != "none",
 		Mode:    mode,
 	}
 
@@ -209,7 +207,7 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 	}
 
 	result[FeatureCNIChaining] = FeatureStatus{
-		Enabled: mode != "",
+		Enabled: len(mode) > 0 && mode != "none",
 		Mode:    mode,
 	}
 


### PR DESCRIPTION
Previously, we have been relying on the Cilium ConfigMap to detect the
presence of features. Relying on the ConfigMap has however some
downsides, as one has to know the default value of a certain feature if
the option is absent from the ConfigMap. To make things worse, this
default value is also version dependent in some cases.

This PR therefore instead tries to extract the feature status from the
agent-runtime-config.json, which is a JSON representation of the
`option.Config` struct used in Cilium Agent. It contains the actual
values determined at run-time, which is more robust than the ConfigMap
equivalent.

The agent-runtime-config.json is present since Cilium v1.10 and has been
backported to v1.8.10 and v1.9.7. See the PR for more details:
https://github.com/cilium/cilium/pull/16017

A downside of this approach is that the `DaemonConfig` struct is not
guaranteed to be stable. If there are changes to it in the future, we
will likely have to maintain version-specific copies of the struct in
the Cilium-CLI.

The second commit is a drive-by fix for the CNI chaining detection.