### PR TITLE
Add stub for datapath connectivity tests

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -47,6 +47,7 @@ type Parameters struct {
 	JSONMockImage         string
 	AgentDaemonSetName    string
 	DNSTestServerImage    string
+	Datapath              bool
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -47,6 +47,8 @@ type ConnectivityTest struct {
 	echoServices      map[string]Service
 	externalWorkloads map[string]ExternalWorkload
 
+	hostNetNSPodsByNode map[string]Pod
+
 	tests     []*Test
 	testNames map[string]struct{}
 
@@ -156,19 +158,20 @@ func NewConnectivityTest(client *k8s.Client, p Parameters) (*ConnectivityTest, e
 	}
 
 	k := &ConnectivityTest{
-		client:             client,
-		params:             p,
-		ciliumPods:         make(map[string]Pod),
-		echoPods:           make(map[string]Pod),
-		clientPods:         make(map[string]Pod),
-		perfClientPods:     make(map[string]Pod),
-		perfServerPod:      make(map[string]Pod),
-		PerfResults:        make(map[PerfTests]PerfResult),
-		echoServices:       make(map[string]Service),
-		externalWorkloads:  make(map[string]ExternalWorkload),
-		tests:              []*Test{},
-		testNames:          make(map[string]struct{}),
-		lastFlowTimestamps: make(map[string]time.Time),
+		client:              client,
+		params:              p,
+		ciliumPods:          make(map[string]Pod),
+		echoPods:            make(map[string]Pod),
+		clientPods:          make(map[string]Pod),
+		perfClientPods:      make(map[string]Pod),
+		perfServerPod:       make(map[string]Pod),
+		PerfResults:         make(map[PerfTests]PerfResult),
+		echoServices:        make(map[string]Service),
+		externalWorkloads:   make(map[string]ExternalWorkload),
+		hostNetNSPodsByNode: make(map[string]Pod),
+		tests:               []*Test{},
+		testNames:           make(map[string]struct{}),
+		lastFlowTimestamps:  make(map[string]time.Time),
 	}
 
 	return k, nil
@@ -524,6 +527,10 @@ func (ct *ConnectivityTest) CiliumPods() map[string]Pod {
 
 func (ct *ConnectivityTest) ClientPods() map[string]Pod {
 	return ct.clientPods
+}
+
+func (ct *ConnectivityTest) HostNetNSPodsByNode() map[string]Pod {
+	return ct.hostNetNSPodsByNode
 }
 
 func (ct *ConnectivityTest) PerfServerPod() map[string]Pod {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -51,6 +51,8 @@ type ConnectivityTest struct {
 	testNames map[string]struct{}
 
 	lastFlowTimestamps map[string]time.Time
+
+	nodesWithoutCilium []string
 }
 
 type PerfTests struct {
@@ -566,4 +568,10 @@ func (ct *ConnectivityTest) PostTestSleepDuration() time.Duration {
 
 func (ct *ConnectivityTest) K8sClient() *k8s.Client {
 	return ct.client
+}
+
+func (ct *ConnectivityTest) NodesWithoutCilium() []string {
+	out := make([]string, len(ct.nodesWithoutCilium))
+	copy(out, ct.nodesWithoutCilium)
+	return out
 }

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -295,3 +295,7 @@ func (t *Test) failedActions() []*Action {
 
 	return out
 }
+
+func (t *Test) NodesWithoutCilium() []string {
+	return t.ctx.NodesWithoutCilium()
+}

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -86,6 +86,17 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		return ct.Run(ctx)
 	}
 
+	// Datapath Conformance Tests
+	if ct.Params().Datapath {
+		ct.NewTest("north-south-loadbalancing").
+			WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureNodeWithoutCilium)).
+			WithScenarios(
+				tests.OutsideToNodePort(),
+			)
+
+		return ct.Run(ctx)
+	}
+
 	// Run all tests without any policies in place.
 	ct.NewTest("no-policies").WithScenarios(
 		tests.PodToPod(),

--- a/install/helm.go
+++ b/install/helm.go
@@ -251,6 +251,14 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 		return fmt.Errorf("cilium version unsupported %s", k.chartVersion)
 	}
 
+	// Set affinity to prevent Cilium from being scheduled on nodes labeled with
+	// "cilium.io/no-schedule=true"
+	if len(k.params.NodesWithoutCilium) != 0 {
+		helmMapOpts["affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key"] = "cilium.io/no-schedule"
+		helmMapOpts["affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator"] = "NotIn"
+		helmMapOpts["affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]"] = "true"
+	}
+
 	// Store all the options passed by --config into helm extraConfig
 	extraConfigMap := map[string]interface{}{}
 	for k, v := range deprecatedCfgOpts {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -132,6 +132,8 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
+	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")
+	cmd.Flags().MarkHidden("datapath")
 
 	return cmd
 }

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -110,6 +110,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.ImageSuffix, "image-suffix", "", "Set all generated images with this suffix")
 	cmd.Flags().StringVar(&params.ImageTag, "image-tag", "", "Set all images with this tag")
 	cmd.Flags().BoolVar(&params.ListVersions, "list-versions", false, "List all the available versions without actually installing")
+	cmd.Flags().StringSliceVar(&params.NodesWithoutCilium, "nodes-without-cilium", []string{}, "List of node names on which Cilium will not be installed")
 
 	for flagName := range install.FlagsToHelmOpts {
 		// TODO(aanm) Do not mark the flags has deprecated for now.

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -577,6 +577,10 @@ func (c *Client) ListNodes(ctx context.Context, options metav1.ListOptions) (*co
 	return c.Clientset.CoreV1().Nodes().List(ctx, options)
 }
 
+func (c *Client) PatchNode(ctx context.Context, nodeName string, pt types.PatchType, data []byte) (*corev1.Node, error) {
+	return c.Clientset.CoreV1().Nodes().Patch(ctx, nodeName, pt, data, metav1.PatchOptions{})
+}
+
 func (c *Client) ListCiliumExternalWorkloads(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error) {
 	return c.CiliumClientset.CiliumV2().CiliumExternalWorkloads().List(ctx, opts)
 }


### PR DESCRIPTION
This PR:
- Extends `cilium install` to accept `--nodes-without-cilium` to denote nodes on which Cilium should not be installed.
- Adds `FeatureNodeWithoutCilium` to test for such nodes.
- Adds `outside-to-nodeport` as an example test case of the DP conformance suite.

See individual commit msgs for more details.

Ref: https://github.com/cilium/cilium/issues/20606