### PR TITLE
 connectivity: Add connectivity tests for multiple policy types

### DIFF
--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -56,4 +56,4 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium --context "${CONTEXT1}" connectivity test --debug --multi-cluster "${CONTEXT2}" --test '!/pod-to-.*-nodeport' --all-flows
+cilium --context "${CONTEXT1}" connectivity test --debug --multi-cluster "${CONTEXT2}" --test '!/*-deny,!/pod-to-.*-nodeport' --all-flows

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   installation-and-connectivity:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -37,7 +37,7 @@ jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -160,7 +160,7 @@ jobs:
 
       - name: Wait for test job
         env:
-          timeout: 20m
+          timeout: 30m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -234,6 +234,22 @@ func (t *Test) WithPolicy(policy string) *Test {
 						}
 					}
 				}
+
+				for _, e := range pl[i].Spec.EgressDeny {
+					for _, es := range e.ToEndpoints {
+						if n, ok := es.MatchLabels[k]; ok && n == defaults.ConnectivityCheckNamespace {
+							es.MatchLabels[k] = t.ctx.params.TestNamespace
+						}
+					}
+				}
+
+				for _, e := range pl[i].Spec.IngressDeny {
+					for _, es := range e.FromEndpoints {
+						if n, ok := es.MatchLabels[k]; ok && n == defaults.ConnectivityCheckNamespace {
+							es.MatchLabels[k] = t.ctx.params.TestNamespace
+						}
+					}
+				}
 			}
 		}
 	}

--- a/connectivity/manifests/allow-all-egress.yaml
+++ b/connectivity/manifests/allow-all-egress.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: allow-all-egress
+spec:
+  endpointSelector: {}
+  egress:
+  - toEndpoints:
+    - {}
+  - toCIDR:
+    - 0.0.0.0/0

--- a/connectivity/manifests/allow-all-ingress.yaml
+++ b/connectivity/manifests/allow-all-ingress.yaml
@@ -1,0 +1,10 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: allow-all-ingress
+spec:
+  endpointSelector: {}
+  ingress:
+  - fromEndpoints:
+    - {}

--- a/connectivity/manifests/client-egress-l7-http-named-port.yaml
+++ b/connectivity/manifests/client-egress-l7-http-named-port.yaml
@@ -1,0 +1,39 @@
+---
+# client2 is allowed to contact one.one.one.one and the echo Pod
+# on port http-8080. HTTP introspection is enabled for client2.
+# The toFQDNs section relies on DNS introspection being performed by
+# the client-egress-only-dns policy.
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-l7-http-named-port
+spec:
+  description: "Allow GET one.one.one.one:80/ and GET <echo>:<http-80>/ from client2"
+  endpointSelector:
+    matchLabels:
+      other: client
+  egress:
+  # Allow GET / requests towards echo pods.
+  - toEndpoints:
+    - matchLabels:
+        kind: echo
+    toPorts:
+    - ports:
+      - port: "http-8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/"
+  # Allow GET / requests, only towards one.one.one.one.
+  - toFQDNs:
+    - matchName: "one.one.one.one"
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/"

--- a/connectivity/manifests/client-egress-l7-http.yaml
+++ b/connectivity/manifests/client-egress-l7-http.yaml
@@ -17,7 +17,7 @@ spec:
   # Allow GET / requests towards echo pods.
   - toEndpoints:
     - matchLabels:
-        k8s:kind: echo
+        kind: echo
     toPorts:
     - ports:
       - port: "8080"

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -17,11 +17,11 @@ spec:
         - matchPattern: "*"
     toEndpoints:
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: kube-dns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: coredns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: coredns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: node-local-dns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: node-local-dns

--- a/connectivity/manifests/client-egress-to-cidr-1111-deny.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-1111-deny.yaml
@@ -1,0 +1,19 @@
+# This policy denies packets towards 1.0.0.1, but not 1.1.1.1
+# Please note that if there is no other allowed rule, the policy
+# will be automatically denied 1.1.1.1 as well.
+#
+# Both addresses are owned by CloudFlare/APNIC.
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-cidr-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toCIDRSet:
+    - cidr: 1.0.0.0/8
+      except:
+        - 1.1.1.1/32

--- a/connectivity/manifests/client-egress-to-echo-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-deny.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-echo-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/connectivity/manifests/client-egress-to-echo-expression-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-expression-deny.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-echo-expression-deny
+spec:
+  endpointSelector:
+    matchExpressions:
+      - { key: 'name', operator: In, values: ['client'] }
+  egressDeny:
+    - toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+      toEndpoints:
+        - matchExpressions:
+            - { key: 'kind', operator: In, values: [ "echo" ] }

--- a/connectivity/manifests/client-egress-to-echo-expression.yaml
+++ b/connectivity/manifests/client-egress-to-echo-expression.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-echo-expression
+spec:
+  endpointSelector:
+    matchExpressions:
+      - {key: 'other', operator: Exists}
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/connectivity/manifests/client-egress-to-echo-named-port-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-named-port-deny.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-ingress-to-echo-named-port-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingressDeny:
+  - toPorts:
+    - ports:
+      - port: "http-8080"
+        protocol: TCP
+    fromEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        name: client

--- a/connectivity/manifests/client-egress-to-echo-service-account-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-service-account-deny.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-echo-service-account-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/connectivity/manifests/client-egress-to-echo-service-account.yaml
+++ b/connectivity/manifests/client-egress-to-echo-service-account.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-egress-to-echo-service-account
+spec:
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -21,12 +21,6 @@ spec:
       - port: "53"
         protocol: ANY
     toEndpoints:
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: kube-dns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: coredns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: node-local-dns
+    - matchExpressions:
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -14,19 +14,19 @@ spec:
         protocol: TCP
     toEndpoints:
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: cilium-test
-        k8s:kind: echo
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo
   - toPorts:
     - ports:
       - port: "53"
         protocol: ANY
     toEndpoints:
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: kube-dns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: coredns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: coredns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: node-local-dns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: node-local-dns

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -16,14 +16,14 @@ spec:
         protocol: TCP
   - toEndpoints:
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
+        io.kubernetes.pod.namespace: kube-system
         k8s-app: kube-dns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: coredns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: coredns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: node-local-dns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: node-local-dns
     toPorts:
     - ports:
       - port: "53"

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -15,15 +15,9 @@ spec:
       - port: "80"
         protocol: TCP
   - toEndpoints:
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: kube-dns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: coredns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: node-local-dns
+    - matchExpressions:
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
     toPorts:
     - ports:
       - port: "53"

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -27,11 +27,11 @@ spec:
         - matchPattern: "*"
     toEndpoints:
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: kube-dns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: coredns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: coredns
     - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
-        k8s:k8s-app: node-local-dns
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: node-local-dns

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -26,12 +26,6 @@ spec:
         dns:
         - matchPattern: "*"
     toEndpoints:
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: kube-dns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: coredns
-    - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: node-local-dns
+    - matchExpressions:
+        - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
+        - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }

--- a/connectivity/manifests/client-ingress-from-client2.yaml
+++ b/connectivity/manifests/client-ingress-from-client2.yaml
@@ -10,4 +10,4 @@ spec:
   ingress:
   - fromEndpoints:
     - matchLabels:
-        k8s:other: client
+        other: client

--- a/connectivity/manifests/echo-ingress-from-other-client-deny.yaml
+++ b/connectivity/manifests/echo-ingress-from-other-client-deny.yaml
@@ -1,0 +1,14 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: echo-ingress-from-other-client-deny
+spec:
+  description: "Deny other client to contact echo"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingressDeny:
+  - fromEndpoints:
+    - matchLabels:
+        other: client

--- a/connectivity/manifests/echo-ingress-from-other-client.yaml
+++ b/connectivity/manifests/echo-ingress-from-other-client.yaml
@@ -11,4 +11,4 @@ spec:
   ingress:
   - fromEndpoints:
     - matchLabels:
-        k8s:other: client
+        other: client

--- a/connectivity/manifests/echo-ingress-icmp-deny.yaml
+++ b/connectivity/manifests/echo-ingress-icmp-deny.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: client-ingress-from-other-client-icmp-deny
+spec:
+  description: "Deny other client to contact another client via ICMP"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingressDeny:
+    - fromEndpoints:
+        - matchLabels:
+            other: client
+      icmps:
+        - fields:
+            - type: 8

--- a/connectivity/manifests/echo-ingress-icmp.yaml
+++ b/connectivity/manifests/echo-ingress-icmp.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:other: client
+            other: client
       icmps:
         - fields:
             - type: 8

--- a/connectivity/manifests/echo-ingress-l7-http-named-port.yaml
+++ b/connectivity/manifests/echo-ingress-l7-http-named-port.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: cilium-test
+  name: echo-ingress-l7-http-named-port
+spec:
+  description: "Allow other client to GET on echo via named port"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+  # Only allow 'other' client to make a GET /public requests.
+  # Allow GET /private' only if a particular HTTP header is set.
+  # Disallow L3 traffic for now, flow matcher doesn't yet support L7 drops.
+  - fromEndpoints:
+    - matchLabels:
+        other: client
+    toPorts:
+    - ports:
+      - port: "http-8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/$"
+        - method: "GET"
+          path: "/public$"
+        - method: "GET"
+          path: "/private$"
+          headers:
+          - "X-Very-Secret-Token: 42"

--- a/connectivity/manifests/echo-ingress-l7-http.yaml
+++ b/connectivity/manifests/echo-ingress-l7-http.yaml
@@ -15,7 +15,7 @@ spec:
   # Disallow L3 traffic for now, flow matcher doesn't yet support L7 drops.
   - fromEndpoints:
     - matchLabels:
-        k8s:other: client
+        other: client
     toPorts:
     - ports:
       - port: "8080"

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -168,7 +168,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 			return check.ResultOK, check.ResultOK
 		})
 
-	// This policy allows ingress to echo only from client with a label 'other:client'.
+	// This policy allowed ICMP traffic from client to another client.
 	ct.NewTest("client-ingress-icmp").WithPolicy(echoIngressICMPPolicyYAML).
 		WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureICMPPolicy)).
 		WithScenarios(

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -10,6 +10,38 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 )
 
+type labelsContainer interface {
+	HasLabel(key, value string) bool
+}
+
+type Option func(*labelsOption)
+
+type labelsOption struct {
+	sourceLabels      map[string]string
+	destinationLabels map[string]string
+}
+
+func WithSourceLabelsOption(sourceLabels map[string]string) Option {
+	return func(option *labelsOption) {
+		option.sourceLabels = sourceLabels
+	}
+}
+
+func WithDestinationLabelsOption(destinationLabels map[string]string) Option {
+	return func(option *labelsOption) {
+		option.destinationLabels = destinationLabels
+	}
+}
+
+func hasAllLabels(labelsContainer labelsContainer, filters map[string]string) bool {
+	for k, v := range filters {
+		if !labelsContainer.HasLabel(k, v) {
+			return false
+		}
+	}
+	return true
+}
+
 func curl(peer check.TestPeer, opts ...string) []string {
 	cmd := []string{"curl",
 		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}",


### PR DESCRIPTION
### Description

This PR is to add coverage for below policy tests:

- named port
- ICMP policy
- policy with matched expression
- policy with service account rule
- denied policies

