### PR TITLE
Enable kube-proxy replacement if no kube-proxy is detected in a cluster

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -144,6 +144,7 @@ func (k *K8sInstaller) getSecretNamespace() string {
 
 type k8sInstallerImplementation interface {
 	ClusterName() string
+	GetAPIServerHostAndPort() (string, string)
 	ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error)
 	PatchNode(ctx context.Context, nodeName string, pt types.PatchType, data []byte) (*corev1.Node, error)
 	GetCiliumExternalWorkload(ctx context.Context, name string, opts metav1.GetOptions) (*ciliumv2.CiliumExternalWorkload, error)
@@ -164,6 +165,7 @@ type k8sInstallerImplementation interface {
 	CreateRoleBinding(ctx context.Context, namespace string, roleBinding *rbacv1.RoleBinding, opts metav1.CreateOptions) (*rbacv1.RoleBinding, error)
 	DeleteRoleBinding(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	CreateDaemonSet(ctx context.Context, namespace string, ds *appsv1.DaemonSet, opts metav1.CreateOptions) (*appsv1.DaemonSet, error)
+	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	DeleteDaemonSet(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	PatchDaemonSet(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.DaemonSet, error)

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -119,6 +121,20 @@ func (c *Client) ClusterName() (name string) {
 		name = context.Cluster
 	}
 	return
+}
+
+func (c *Client) GetAPIServerHostAndPort() (string, string) {
+	if context, ok := c.RawConfig.Contexts[c.ContextName()]; ok {
+		addr := c.RawConfig.Clusters[context.Cluster].Server
+		if addr != "" {
+			url, err := url.Parse(addr)
+			if err == nil {
+				host, port, _ := net.SplitHostPort(url.Host)
+				return host, port
+			}
+		}
+	}
+	return "", ""
 }
 
 func (c *Client) CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error) {


### PR DESCRIPTION
Previously, Cilium-CLI won’t enable kube-proxy by default automatically if no kube-proxy has been installed in the cluster. This patch will detect kube-proxy installation in the cluster automatically and it’ll set the helm value kubeProxyReplacement=strict if there were no kube-proxy.

Fixes: #1004
