### PR TITLE
gha: Increase timeout for GHA jobs

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -37,7 +37,7 @@ jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -141,7 +141,7 @@ jobs:
 
       - name: Wait for install job
         env:
-          timeout: 10m
+          timeout: 20m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli-install --for=condition=complete --timeout=${{ env.timeout }} &

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   installation-and-connectivity:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -37,7 +37,7 @@ jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -160,7 +160,7 @@ jobs:
 
       - name: Wait for test job
         env:
-          timeout: 20m
+          timeout: 30m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &


### PR DESCRIPTION
With increase of connectivity tests, the current timeout might not be
enough. This commit is to increase the duration to 45 mins. There is
not much of downside, as connectivity test can still fail earlier, this
is mainly to allow all the tests a long enough window to run.

Signed-off-by: Tam Mach <tam.mach@cilium.io>