### PR TITLE
Status: generate a more meaningful message if agent not running

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -426,6 +427,7 @@ type k8sClusterMeshImplementation interface {
 	GetRunningCiliumVersion(ctx context.Context, namespace string) (string, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 	GetPlatform(ctx context.Context) (*k8s.Platform, error)
+	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
 }
 
 type K8sClusterMesh struct {

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -63,6 +64,7 @@ type k8sHubbleImplementation interface {
 	GetServerVersion() (*semver.Version, error)
 	GetHelmState(ctx context.Context, namespace string, secretName string) (*helm.State, error)
 	GetService(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Service, error)
+	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
 }
 
 type K8sHubble struct {

--- a/install/install.go
+++ b/install/install.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"time"
 
@@ -199,6 +200,7 @@ type k8sInstallerImplementation interface {
 	GetServerVersion() (*semver.Version, error)
 	CreateIngressClass(ctx context.Context, r *networkingv1.IngressClass, opts metav1.CreateOptions) (*networkingv1.IngressClass, error)
 	DeleteIngressClass(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
 }
 
 type K8sInstaller struct {

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -6,6 +6,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -138,6 +139,10 @@ func (c *k8sStatusMockClient) ListPods(ctx context.Context, namespace string, op
 
 func (c *k8sStatusMockClient) ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error) {
 	return c.ciliumEndpointList[options.LabelSelector], nil
+}
+
+func (c *k8sStatusMockClient) CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error) {
+	return "[error] a sample cilium-agent error message", nil
 }
 
 func (c *k8sStatusMockClient) CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error) {


### PR DESCRIPTION
If the agent container isn't running, we still tried to do a "kubectl exec", which is guaranteed to fail. Rather, let's generate a more useful error message.

This will now report something like this:

`unable to retrieve cilium status: container cilium-agent is in
CrashLoopBackOff, exited with code 0, try 'kubectl -n kube-system logs
-c cilium-agent cilium-wls67'`

Fixes: #1026