### PR TITLE
dependabot: Monitor Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,22 @@ updates:
     rebase-strategy: disabled
     labels:
     - kind/enhancement
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    labels:
+    - kind/enhancement
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: "v0.10"
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    labels:
+    - kind/enhancement

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@
 # Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:20ff0e6b01b9e5eeeedd6f334de80718a6b54835@sha256:9b38a14ca83ce1c081013974e082d37055523ca1d47543ba5be38b3575a6dc0f
-
-FROM ${CILIUM_BUILDER_IMAGE} as builder
+FROM quay.io/cilium/cilium-builder:20ff0e6b01b9e5eeeedd6f334de80718a6b54835@sha256:9b38a14ca83ce1c081013974e082d37055523ca1d47543ba5be38b3575a6dc0f as builder
 WORKDIR /go/src/github.com/cilium/cilium-cli
 COPY . .
 RUN make


### PR DESCRIPTION
Also don't use `ARG` in the `FROM` instruction. Dependabot doesn't
handle it right now.

Ref: https://github.com/dependabot/dependabot-core/issues/2057

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>