### PR TITLE
Push workflow run results to Loki

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -1,0 +1,32 @@
+name: Push to Loki
+
+on:
+  workflow_run:
+    workflows:
+      - AKS (Azure IPAM)
+      - AKS (BYOCNI)
+      - EKS (tunnel)
+      - EKS (ENI)
+      - External Workloads
+      - GKE
+      - Go
+      - Image CI Build
+      - Kind
+      - Multicluster
+      - Create Release
+    types:
+      - completed
+
+permissions:
+  actions: read
+
+jobs:
+  push-to-loki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push to Loki
+        uses: michi-covalent/push-to-loki@v0.2.0
+        with:
+          endpoint: https://logs-prod3.grafana.net/loki/api/v1/push
+          username: ${{ secrets.LOKI_USERNAME }}
+          password: ${{ secrets.LOKI_PASSWORD }}


### PR DESCRIPTION
Use michi-covalent/push-to-loki to push workflow run results to Loki
to make it easier to monitor the overall health of the CI. My ultimate
goal is to get rid of Slack notifications.

Ref: https://github.com/michi-covalent/push-to-loki

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>