### PR TITLE
Clustermesh secrets helm inconsistency fix

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -58,10 +58,10 @@ const (
 	ClusterMeshApiserverImage             = "quay.io/cilium/clustermesh-apiserver"
 	ClusterMeshServiceName                = "clustermesh-apiserver"
 	ClusterMeshSecretName                 = "cilium-clustermesh" // Secret which contains the clustermesh configuration
-	ClusterMeshServerSecretName           = "clustermesh-apiserver-server-certs"
-	ClusterMeshAdminSecretName            = "clustermesh-apiserver-admin-certs"
-	ClusterMeshClientSecretName           = "clustermesh-apiserver-client-certs"
-	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-certs"
+	ClusterMeshServerSecretName           = "clustermesh-apiserver-server-cert"
+	ClusterMeshAdminSecretName            = "clustermesh-apiserver-admin-cert"
+	ClusterMeshClientSecretName           = "clustermesh-apiserver-client-cert"
+	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-cert"
 
 	ConnectivityCheckNamespace = "cilium-test"
 


### PR DESCRIPTION
Fixing the `cilium clustermesh status` command when Cilium is installed using Helm.
Changes clustermesh secret names to be consistent with secret names generated by Helm. Loads external workload secrets only when needed, preventing the `clustermesh status` command to fail external load secrets are not defined.