### PR TITLE
all: remove year from copyright notice

### DIFF
--- a/.github/tools/kubeconfig-merger/main.go
+++ b/.github/tools/kubeconfig-merger/main.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package main
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-# Copyright 2020-2021 Authors of Cilium
+# Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 FROM quay.io/cilium/cilium-builder:20ff0e6b01b9e5eeeedd6f334de80718a6b54835@sha256:9b38a14ca83ce1c081013974e082d37055523ca1d47543ba5be38b3575a6dc0f as builder

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
 GO := go
 GO_BUILD = CGO_ENABLED=0 $(GO) build
 GO_TAGS ?=

--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package clustermesh
 

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package clustermesh
 

--- a/cmd/cilium/main.go
+++ b/cmd/cilium/main.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package main
 

--- a/cmd/internal/add-image-digests/main.go
+++ b/cmd/internal/add-image-digests/main.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021-2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 // add-image-digests updates defaults/imagedigests.json.
 package main

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package config
 

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/features_test.go
+++ b/connectivity/check/features_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/ipcache.go
+++ b/connectivity/check/ipcache.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/scenario.go
+++ b/connectivity/check/scenario.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package check
 

--- a/connectivity/filters/filters.go
+++ b/connectivity/filters/filters.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package filters
 

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package connectivity
 

--- a/connectivity/tests/cidr.go
+++ b/connectivity/tests/cidr.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/externalworkload.go
+++ b/connectivity/tests/externalworkload.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/perfpod.go
+++ b/connectivity/tests/perfpod.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package defaults
 

--- a/defaults/imagedigests.go
+++ b/defaults/imagedigests.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021-2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package defaults
 

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package hubble
 

--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package hubble
 

--- a/hubble/relay_test.go
+++ b/hubble/relay_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package hubble
 
 import (

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package hubble
 

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/aws.go
+++ b/install/aws.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/azure.go
+++ b/install/azure.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/bgp.go
+++ b/install/bgp.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/certs.go
+++ b/install/certs.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/encryption.go
+++ b/install/encryption.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/encryption_test.go
+++ b/install/encryption_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/gke.go
+++ b/install/gke.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/helm.go
+++ b/install/helm.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 // Copyright The Helm Authors.
 
 package install

--- a/install/install.go
+++ b/install/install.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/kind.go
+++ b/install/kind.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/minikube.go
+++ b/install/minikube.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/node_init.go
+++ b/install/node_init.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/rbac.go
+++ b/install/rbac.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package install
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package certs
 

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/config.go
+++ b/internal/cli/cmd/config.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/context.go
+++ b/internal/cli/cmd/context.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/utils.go
+++ b/internal/cli/cmd/utils.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package cmd
 

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 // Copyright The Helm Authors.
 
 package helm

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package helm
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package logging
 

--- a/internal/utils/ctrlcreader.go
+++ b/internal/utils/ctrlcreader.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package utils
 

--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package utils
 

--- a/internal/utils/exec_test.go
+++ b/internal/utils/exec_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package utils
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package utils
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020-2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package utils
 

--- a/internal/utils/yaml.go
+++ b/internal/utils/yaml.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package utils
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package k8s
 

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package k8s
 
 import "testing"

--- a/k8s/copy.go
+++ b/k8s/copy.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package k8s
 

--- a/k8s/doc.go
+++ b/k8s/doc.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018 Authors of Cilium
+// Copyright Authors of Cilium
 
 // Package k8s provides various helper functions for interacting with Kubernetes
 // APIs.

--- a/k8s/exec.go
+++ b/k8s/exec.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package k8s
 

--- a/k8s/helpers.go
+++ b/k8s/helpers.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package k8s
 

--- a/k8s/pipe.go
+++ b/k8s/pipe.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package k8s
 

--- a/k8s/pipe_test.go
+++ b/k8s/pipe_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package k8s
 

--- a/k8s/tables.go
+++ b/k8s/tables.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package k8s
 

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package status
 

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package status
 

--- a/status/status.go
+++ b/status/status.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 package status
 

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package sysdump
 

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package sysdump
 

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package sysdump
 

--- a/sysdump/k8sutils.go
+++ b/sysdump/k8sutils.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package sysdump
 
 import (

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package sysdump
 

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package sysdump
 

--- a/sysdump/writers.go
+++ b/sysdump/writers.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2021 Authors of Cilium
+// Copyright Authors of Cilium
 
 package sysdump
 


### PR DESCRIPTION
Cilium source files have a header with a SPDX tag and a copyright
notice, stating that the copyright goes to the Authors of Cilium, and
containing a year or year range to specify to what period the copyright
extends.

The year or year range are not necessary in this statement. The CNCF
recommends not using the year or the copyright symbol, to keep files
easy to process [0]. The history of the source code is conserved through
the version control system, and is easily available for all to check
out.

[0] https://github.com/cncf/foundation/blob/main/copyright-notices.md#copyright-notices

Drop the year and year range for the entire codebase.

The files were processed as follows:

    $ cat years.sed
    # Skip after line 6 (branch to end so we still print the line)
    6, $ b
    # Process copyright notice preceded by a SPDX tag
    /^\(#\|\/\/\|\/\*\) *SPDX-License-Identifier: \(GPL-2\.0\|Apache-2\.0\)\( \*\/\)\?$/ {
        N; s/Copyright .* Authors of Cilium/Copyright Authors of Cilium/
    }
    # Process copyright notice followed by a SPDX tag
    /^\(#\|\/\/\|\/\*\) *Copyright .* Authors of Cilium\( \*\/\)\?$/ {
        N; {
            /\(#\|\/\/\|\/\*\) *SPDX-License-Identifier: \(GPL-2\.0\|Apache-2\.0\)\( \*\/\)\?$/ s/Copyright .* Authors of Cilium/Copyright Authors of Cilium/
        }
    }

    $ find clustermesh cmd config connectivity defaults hubble install \
    internal k8s release status sysdump .github Dockerfile Makefile \
        -type f -print0 | xargs -0 -P 8 sed -i -f years.sed

Also add copyright headers to some Go source files that were previously
missing the headers.

Follows cilium/cilium#18813