### PR TITLE
ci: bump external workloads workflow timeouts

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -37,7 +37,7 @@ jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -198,7 +198,7 @@ jobs:
 
       - name: Wait for test job
         env:
-          timeout: 10m
+          timeout: 15m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours


### PR DESCRIPTION
The workflow started timing out occassionally after more tests were
added in https://github.com/cilium/cilium-cli/pull/1028 and thus test run times increased.

Ref. https://github.com/cilium/cilium-cli/pull/1063#issuecomment-1228637644