### PR TITLE
Bump go directive version to 1.19 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium-cli
 
-go 1.18
+go 1.19
 
 // Replace directives from github.com/cilium/cilium. Keep in sync when updating Cilium!
 replace (


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/21134
Relates: https://github.com/cilium/cilium-cli/pull/1027
Signed-off-by: Tam Mach <tam.mach@cilium.io>