### PR TITLE
helm: Add support for remote chart version

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -183,7 +183,7 @@ func newClient(namespace, k8sVersion string) (*action.Install, error) {
 	return helmClient, nil
 }
 
-func newChartFromCiliumVersion(ciliumVersion semver2.Version) (*chart.Chart, error) {
+func newChartFromEmbeddedFile(ciliumVersion semver2.Version) (*chart.Chart, error) {
 	helmTgz, err := helm.HelmFS.ReadFile(fmt.Sprintf("cilium-%s.tgz", ciliumVersion))
 	if err != nil {
 		return nil, fmt.Errorf("cilium version not found: %s", err)
@@ -216,7 +216,7 @@ func GenManifests(
 			return nil, err
 		}
 	} else {
-		helmChart, err = newChartFromCiliumVersion(ciliumVer)
+		helmChart, err = newChartFromEmbeddedFile(ciliumVer)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +332,7 @@ func ResolveHelmChartVersion(versionFlag, chartDirectoryFlag string) (semver2.Ve
 		if err != nil {
 			return semver2.Version{}, err
 		}
-		if _, err = newChartFromCiliumVersion(version); err != nil {
+		if _, err = newChartFromEmbeddedFile(version); err != nil {
 			return semver2.Version{}, err
 		}
 		return version, nil


### PR DESCRIPTION
### Description

Currently, the cilium charts are embedded inside cilium cli binary,
which will require a new cilium/charts bump in go.mod and then a new
release for cilium-cli. It's making sense to do so if some other code
changes are required to make installation working for new char version,
but most of the time, only go.mod upgrade is required.

This commit is to add the capability to install new chart version without
the need of releasing or installing new cilium-cli.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

The changes are tested on top of commit 4fc8b226 (i.e. v1.13.0-rc0 is not
supported). 

```
# Trying to download invalid version v1.14.0
$ ./cilium install --version 1.14.0   
chart "cilium" version "1.14.0" not found in https://helm.cilium.io repository

# Trying to install v1.13.0-rc0
$ ./cilium install --version 1.13.0-rc0
🔮 Auto-detected Kubernetes kind: minikube
✨ Running "minikube" validation checks
✅ Detected minikube version "1.26.1"
ℹ️  Using Cilium version 1.13.0-rc0
..

$ ./cilium status
    /¯¯\
 /¯¯\__/¯¯\    Cilium:         OK
 \__/¯¯\__/    Operator:       OK
 /¯¯\__/¯¯\    Hubble:         disabled
 \__/¯¯\__/    ClusterMesh:    disabled
    \__/

Deployment        cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
DaemonSet         cilium             Desired: 1, Ready: 1/1, Available: 1/1
Containers:       cilium             Running: 1
                  cilium-operator    Running: 1
Cluster Pods:     1/1 managed by Cilium
Image versions    cilium             quay.io/cilium/cilium-ci:latest: 1
                  cilium-operator    quay.io/cilium/operator-generic-ci:latest: 1
                  
 $ ./cilium hubble enable           
🔑 Found CA in secret cilium-ca
...
✨ Patching ConfigMap cilium-config to enable Hubble...
🚀 Creating ConfigMap for Cilium version 1.13.0-rc0...
♻️  Restarted Cilium pods
               
```