### PR TITLE
ci: switch to google-github-actions/auth for GKE based workflows

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -33,6 +33,7 @@ env:
   cilium_version: v1.10.11
   cilium_cli_version: v0.10.4
   kubectl_version: v1.23.6
+  USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:
   installation-and-connectivity:
@@ -51,12 +52,20 @@ jobs:
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           kubectl version --client
 
+      - name: Set up gcloud credentials
+        id: 'auth'
+        uses: 'google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712'
+        with:
+          credentials_json: '${{ secrets.GCP_PR_SA_KEY }}'
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb
         with:
           project_id: ${{ secrets.GCP_PR_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_PR_SA_KEY }}
-          export_default_credentials: true
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
 
       - name: Display gcloud CLI info
         run: |

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -31,6 +31,7 @@ env:
   cilium_version: v1.10.11
   cilium_cli_version: v0.10.4
   kubectl_version: v1.23.6
+  USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:
   installation-and-connectivity:
@@ -49,12 +50,20 @@ jobs:
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           kubectl version --client
 
+      - name: Set up gcloud credentials
+        id: 'auth'
+        uses: 'google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712'
+        with:
+          credentials_json: '${{ secrets.GCP_PR_SA_KEY }}'
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb
         with:
           project_id: ${{ secrets.GCP_PR_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_PR_SA_KEY }}
-          export_default_credentials: true
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
 
       - name: Display gcloud CLI info
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -33,6 +33,7 @@ env:
   cilium_version: v1.10.11
   cilium_cli_version: v0.10.4
   kubectl_version: v1.23.6
+  USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:
   installation-and-connectivity:
@@ -51,12 +52,20 @@ jobs:
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           kubectl version --client
 
+      - name: Set up gcloud credentials
+        id: 'auth'
+        uses: 'google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712'
+        with:
+          credentials_json: '${{ secrets.GCP_PR_SA_KEY }}'
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb
         with:
           project_id: ${{ secrets.GCP_PR_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_PR_SA_KEY }}
-          export_default_credentials: true
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
 
       - name: Display gcloud CLI info
         run: |


### PR DESCRIPTION
[ upstream commit 1da8f1005191ddc2e7aaf0ee0f202954dbc9b621 ]

service_account_key in the google-github-actions/setup-gcloud action is deprecated, see [1], [2]. Switch to the suggested
google-github-actions/auth action instead.

[1] https://github.com/cilium/cilium-cli/actions/runs/2998471345 [2] https://github.com/google-github-actions/setup-gcloud#authorization