### PR TITLE
test/connectivity: Remove explicit namespace in policy manifest

### DIFF
--- a/connectivity/manifests/allow-all-egress.yaml
+++ b/connectivity/manifests/allow-all-egress.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: allow-all-egress
 spec:
   endpointSelector: {}

--- a/connectivity/manifests/allow-all-except-world-pre-v1.11.yaml
+++ b/connectivity/manifests/allow-all-except-world-pre-v1.11.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: allow-all-except-world
 spec:
   endpointSelector: {}

--- a/connectivity/manifests/allow-all-except-world.yaml
+++ b/connectivity/manifests/allow-all-except-world.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: allow-all-except-world
 spec:
   endpointSelector: {}

--- a/connectivity/manifests/allow-all-ingress.yaml
+++ b/connectivity/manifests/allow-all-ingress.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: allow-all-ingress
 spec:
   endpointSelector: {}

--- a/connectivity/manifests/client-egress-l7-http-method.yaml
+++ b/connectivity/manifests/client-egress-l7-http-method.yaml
@@ -6,7 +6,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-l7-http-method
 spec:
   description: "Allow POST <echo>:8080/(public|private) from client2"

--- a/connectivity/manifests/client-egress-l7-http-named-port.yaml
+++ b/connectivity/manifests/client-egress-l7-http-named-port.yaml
@@ -6,7 +6,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-l7-http-named-port
 spec:
   description: "Allow GET one.one.one.one:80/ and GET <echo>:<http-80>/ from client2"

--- a/connectivity/manifests/client-egress-l7-http.yaml
+++ b/connectivity/manifests/client-egress-l7-http.yaml
@@ -6,7 +6,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-l7-http
 spec:
   description: "Allow GET one.one.one.one:80/ and GET <echo>:8080/ from client2"

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-only-dns
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-cidr-1111-deny.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-1111-deny.yaml
@@ -6,7 +6,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-cidr-deny
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-cidr-1111.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-1111.yaml
@@ -3,7 +3,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-cidr
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-echo-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-deny.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-echo-deny
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-echo-expression-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-expression-deny.yaml
@@ -1,17 +1,16 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-echo-expression-deny
 spec:
   endpointSelector:
     matchExpressions:
-      - { key: 'name', operator: In, values: ['client'] }
+    - { key: 'name', operator: In, values: [ 'client' ] }
   egressDeny:
-    - toPorts:
-        - ports:
-            - port: "8080"
-              protocol: TCP
-      toEndpoints:
-        - matchExpressions:
-            - { key: 'kind', operator: In, values: [ "echo" ] }
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'kind', operator: In, values: [ "echo" ] }

--- a/connectivity/manifests/client-egress-to-echo-expression.yaml
+++ b/connectivity/manifests/client-egress-to-echo-expression.yaml
@@ -1,12 +1,11 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-echo-expression
 spec:
   endpointSelector:
     matchExpressions:
-      - {key: 'other', operator: Exists}
+    - { key: 'other', operator: Exists }
   egress:
   - toPorts:
     - ports:

--- a/connectivity/manifests/client-egress-to-echo-named-port-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-named-port-deny.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-ingress-to-echo-named-port-deny
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-echo-service-account-deny.yaml
+++ b/connectivity/manifests/client-egress-to-echo-service-account-deny.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-echo-service-account-deny
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-echo-service-account.yaml
+++ b/connectivity/manifests/client-egress-to-echo-service-account.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-echo-service-account
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-echo
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-entities-world
 spec:
   endpointSelector:

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-to-fqdns-one-one-one-one
 spec:
   endpointSelector:
@@ -27,5 +26,5 @@ spec:
         - matchPattern: "*"
     toEndpoints:
     - matchExpressions:
-        - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
-        - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }

--- a/connectivity/manifests/client-ingress-from-client2.yaml
+++ b/connectivity/manifests/client-ingress-from-client2.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-ingress-from-client2
 spec:
   endpointSelector:

--- a/connectivity/manifests/echo-ingress-from-other-client-deny.yaml
+++ b/connectivity/manifests/echo-ingress-from-other-client-deny.yaml
@@ -1,7 +1,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: echo-ingress-from-other-client-deny
 spec:
   description: "Deny other client to contact echo"

--- a/connectivity/manifests/echo-ingress-from-other-client.yaml
+++ b/connectivity/manifests/echo-ingress-from-other-client.yaml
@@ -1,7 +1,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: echo-ingress-from-other-client
 spec:
   description: "Allow other client to contact echo"

--- a/connectivity/manifests/echo-ingress-icmp-deny.yaml
+++ b/connectivity/manifests/echo-ingress-icmp-deny.yaml
@@ -1,7 +1,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-ingress-from-other-client-icmp-deny
 spec:
   description: "Deny other client to contact another client via ICMP"
@@ -9,9 +8,9 @@ spec:
     matchLabels:
       kind: client
   ingressDeny:
-    - fromEndpoints:
-        - matchLabels:
-            other: client
-      icmps:
-        - fields:
-            - type: 8
+  - fromEndpoints:
+    - matchLabels:
+        other: client
+    icmps:
+    - fields:
+      - type: 8

--- a/connectivity/manifests/echo-ingress-icmp.yaml
+++ b/connectivity/manifests/echo-ingress-icmp.yaml
@@ -1,7 +1,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-ingress-from-client2-icmp
 spec:
   description: "Allow other client to contact another client via ICMP"
@@ -9,9 +8,9 @@ spec:
     matchLabels:
       kind: client
   ingress:
-    - fromEndpoints:
-        - matchLabels:
-            other: client
-      icmps:
-        - fields:
-            - type: 8
+  - fromEndpoints:
+    - matchLabels:
+        other: client
+    icmps:
+    - fields:
+      - type: 8

--- a/connectivity/manifests/echo-ingress-l7-http-named-port.yaml
+++ b/connectivity/manifests/echo-ingress-l7-http-named-port.yaml
@@ -2,7 +2,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: echo-ingress-l7-http-named-port
 spec:
   description: "Allow other client to GET on echo via named port"

--- a/connectivity/manifests/echo-ingress-l7-http.yaml
+++ b/connectivity/manifests/echo-ingress-l7-http.yaml
@@ -2,7 +2,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: echo-ingress-l7-http
 spec:
   description: "Allow other client to GET on echo"


### PR DESCRIPTION
As the connectivity test can be from another namespace, which is passed by --test-namespace CLI flag, we should not have any hard coded namespace in all related policy manifests.

Fixes: #1109

Signed-off-by: Tam Mach <tam.mach@cilium.io>