### PR TITLE
test/connectivity: Add any prefix for pod namespace label

### DIFF
--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -22,6 +22,11 @@ const (
 	// indicate they are sourced from Kubernetes.
 	// NOTE: For some reason, ':' gets replaced by '.' in keys so we use that instead.
 	kubernetesSourcedLabelPrefix = "k8s."
+
+	// anySourceLabelPrefix is the optional prefix used in labels to
+	// indicate they could be from anywhere.
+	// NOTE: For some reason, ':' gets replaced by '.' in keys so we use that instead.
+	anySourceLabelPrefix = "any."
 )
 
 type Test struct {
@@ -218,8 +223,11 @@ func (t *Test) WithPolicy(policy string) *Test {
 	for i := range pl {
 		pl[i].Namespace = t.ctx.params.TestNamespace
 		if pl[i].Spec != nil {
-			// Check both 'io.kubernetes.pod.namespace' and 'k8s:io.kubernetes.pod.namespace'.
-			for _, k := range []string{k8sConst.PodNamespaceLabel, kubernetesSourcedLabelPrefix + k8sConst.PodNamespaceLabel} {
+			for _, k := range []string{
+				k8sConst.PodNamespaceLabel,
+				kubernetesSourcedLabelPrefix + k8sConst.PodNamespaceLabel,
+				anySourceLabelPrefix + k8sConst.PodNamespaceLabel,
+			} {
 				for _, e := range pl[i].Spec.Egress {
 					for _, es := range e.ToEndpoints {
 						if n, ok := es.MatchLabels[k]; ok && n == defaults.ConnectivityCheckNamespace {


### PR DESCRIPTION
This is to make sure that we can dynamically replace the value of pod namespace label (e.g. io.kubernetes.pod.namespace) to the value passed in CLI flag (e.g. --test-namespace).

Related: #1112

Signed-off-by: Tam Mach <tam.mach@cilium.io>
