### PR TITLE
config, hubble: plumb context where available

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,7 +56,7 @@ func (k *K8sConfig) Set(ctx context.Context, key, value string, params Parameter
 		return fmt.Errorf("unable to patch ConfigMap %s with patch %q: %w", defaults.ConfigMapName, patch, err)
 	}
 
-	return k.restartPodsUponConfigChange(params)
+	return k.restartPodsUponConfigChange(ctx, params)
 }
 
 func (k *K8sConfig) Delete(ctx context.Context, key string, params Parameters) error {
@@ -69,7 +69,7 @@ func (k *K8sConfig) Delete(ctx context.Context, key string, params Parameters) e
 		return fmt.Errorf("unable to patch ConfigMap %s with patch %q: %w", defaults.ConfigMapName, patch, err)
 	}
 
-	return k.restartPodsUponConfigChange(params)
+	return k.restartPodsUponConfigChange(ctx, params)
 }
 
 func (k *K8sConfig) View(ctx context.Context) (string, error) {
@@ -97,13 +97,13 @@ func (k *K8sConfig) View(ctx context.Context) (string, error) {
 	return buf.String(), nil
 }
 
-func (k *K8sConfig) restartPodsUponConfigChange(params Parameters) error {
+func (k *K8sConfig) restartPodsUponConfigChange(ctx context.Context, params Parameters) error {
 	if !params.Restart {
 		fmt.Println("⚠️  Restart Cilium pods for configmap changes to take effect")
 		return nil
 	}
 
-	if err := k.client.DeletePodCollection(context.Background(), params.Namespace,
+	if err := k.client.DeletePodCollection(ctx, params.Namespace,
 		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.CiliumPodSelector}); err != nil {
 		return fmt.Errorf("⚠️  unable to restart Cilium pods: %v", err)
 	}

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -157,7 +157,7 @@ func (p *Parameters) validateParams() error {
 }
 
 func (k *K8sHubble) generateDefaultHelmState(ctx context.Context, client k8sHubbleImplementation, namespace string) (*helm.State, error) {
-	version, err := client.GetRunningCiliumVersion(context.Background(), namespace)
+	version, err := client.GetRunningCiliumVersion(ctx, namespace)
 	if version == "" || err != nil {
 		return nil, fmt.Errorf("unable to obtain cilium version, no cilium pods found in namespace %q", namespace)
 	}


### PR DESCRIPTION
Pass the context from the caller where available instead of instantiating a background context.