### PR TITLE
test/connectivity: Add early return when deploying perf resources

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -767,9 +767,11 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 	if !ct.params.Perf {
 		srcList = []string{clientDeploymentName, client2DeploymentName, echoSameNodeDeploymentName}
 	} else {
-		perfDeploymentNameManager := newPerfDeploymentNameManager(&ct.params)
-		srcList = []string{perfDeploymentNameManager.ClientName()}
-		dstList = append(dstList, perfDeploymentNameManager.ServerName())
+		perfNm := newPerfDeploymentNameManager(&ct.params)
+		srcList = []string{perfNm.ClientName(), perfNm.ServerName()}
+		if !ct.params.SingleNode {
+			srcList = append(srcList, perfNm.ClientAcrossName())
+		}
 	}
 
 	if (ct.params.MultiCluster != "" || !ct.params.SingleNode) && !ct.params.Perf {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -817,11 +817,15 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	ct.Debug("Validating Deployments...")
 
 	srcDeployments, dstDeployments := ct.deploymentList()
-	if err := ct.waitForDeployments(ctx, ct.clients.src, srcDeployments); err != nil {
-		return err
+	if len(srcDeployments) > 0 {
+		if err := ct.waitForDeployments(ctx, ct.clients.src, srcDeployments); err != nil {
+			return err
+		}
 	}
-	if err := ct.waitForDeployments(ctx, ct.clients.dst, dstDeployments); err != nil {
-		return err
+	if len(dstDeployments) > 0 {
+		if err := ct.waitForDeployments(ctx, ct.clients.dst, dstDeployments); err != nil {
+			return err
+		}
 	}
 
 	if ct.params.Perf {


### PR DESCRIPTION
This commit reorganizes ConnectivityTest.deploy and ConnectivityTest.validateDeployment to ensure that when the `--perf` flag is given from the user, only performance-related deployments are created and validated. Prior, all resources within the connectivity test are created and validated, even though they aren't used by the performance tests. This change should lead to faster startup times for performance tests.

This commit also adjusts how perf-related deployments are returned from `ConnectivityTest.deploymentList`. Prior, client deployments were returned in `srcList` and server deployments were returned in `dstList`, implying that `srcList` and `dstList` represent deployments belonging to clients and servers respectively. After review, this is an incorrect assumption that was made, as `srcList` and `dstList` split deployments for multi-cluster uses (ie source and destination cluster). Also, a deployment used during performance tests was missing from this list.

Acts as a quick way to address the issues discussed in https://github.com/cilium/cilium-cli/issues/1111 without a refactor.

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>