### PR TITLE
test/connectivity: Run connectivity test in non-default namespace

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -74,7 +74,8 @@ jobs:
 
       - name: Connectivity Test
         run: |
-          cilium connectivity test --debug --all-flows
+          # Run the connectivity test in non-default namespace (i.e. not cilium-test)
+          cilium connectivity test --debug --all-flows --test-namespace test-namespace
 
       - name: Uninstall cilium
         run: |
@@ -97,7 +98,7 @@ jobs:
 
       - name: Connectivity test
         run: |
-          cilium connectivity test --debug --force-deploy --all-flows
+          cilium connectivity test --debug --force-deploy --all-flows --test-namespace another-test-namespace
 
       - name: Cleanup
         if: ${{ always() }}


### PR DESCRIPTION
This is to make sure that we have the coverage of running tests in a namespace other than cilium-test.

Relates: https://github.com/cilium/cilium-cli/issues/1109#issuecomment-1260777569
Signed-off-by: Tam Mach <tam.mach@cilium.io>