### PR TITLE
[connectivity] Allow configuring cilium-agent pod selector

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -48,6 +48,7 @@ type Parameters struct {
 	AgentDaemonSetName    string
 	DNSTestServerImage    string
 	Datapath              bool
+	AgentPodSelector      string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -471,7 +471,7 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 // initCiliumPods fetches the Cilium agent pod information from all clients
 func (ct *ConnectivityTest) initCiliumPods(ctx context.Context) error {
 	for _, client := range ct.clients.clients() {
-		ciliumPods, err := client.ListPods(ctx, ct.params.CiliumNamespace, metav1.ListOptions{LabelSelector: "k8s-app=cilium"})
+		ciliumPods, err := client.ListPods(ctx, ct.params.CiliumNamespace, metav1.ListOptions{LabelSelector: ct.params.AgentPodSelector})
 		if err != nil {
 			return fmt.Errorf("unable to list Cilium pods: %w", err)
 		}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -11,6 +11,7 @@ const (
 	AgentClusterRoleName    = "cilium"
 	AgentSecretsRoleName    = "cilium-secrets"
 	AgentDaemonSetName      = "cilium"
+	AgentPodSelector        = "k8s-app=cilium"
 	AgentResourceQuota      = "cilium-resource-quota"
 	AgentImage              = "quay.io/cilium/cilium"
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -112,6 +112,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.HubbleServer, "hubble-server", "localhost:4245", "Address of the Hubble endpoint for flow validation")
 	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity test in")
 	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
+	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")


### PR DESCRIPTION
Closes https://github.com/cilium/cilium-cli/issues/1125

Currently, if you have deployed the `cilium-agent` and the pods do not have the label `k8s-app=cilium`, the tests fail to find the agent pods which doesn't completely break the tests but, avoids a lot of the automatic feature detection and some additional features. 

This PR adds another parameter to allow using a custom selector while sticking with the default `k8s-app=cilium` label. 