### PR TITLE
Allow to delete cilium pods before connectivity tests

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1212,7 +1212,7 @@ func (k *K8sClusterMesh) determineStatusConnectivity(ctx context.Context) (*Conn
 		Clusters:       map[string]*ClusterStats{},
 	}
 
-	pods, err := k.client.ListPods(ctx, k.params.Namespace, metav1.ListOptions{LabelSelector: "k8s-app=cilium"})
+	pods, err := k.client.ListPods(ctx, k.params.Namespace, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector})
 	if err != nil {
 		return nil, fmt.Errorf("unable to list cilium pods: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -104,7 +104,7 @@ func (k *K8sConfig) restartPodsUponConfigChange(ctx context.Context, params Para
 	}
 
 	if err := k.client.DeletePodCollection(ctx, params.Namespace,
-		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.CiliumPodSelector}); err != nil {
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector}); err != nil {
 		return fmt.Errorf("⚠️  unable to restart Cilium pods: %v", err)
 	}
 

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -49,6 +49,12 @@ type Parameters struct {
 	DNSTestServerImage    string
 	Datapath              bool
 	AgentPodSelector      string
+
+	K8sVersion           string
+	HelmChartDirectory   string
+	HelmValuesSecretName string
+
+	DeleteCiliumOnNodes []string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/delete.go
+++ b/connectivity/check/delete.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/exp/slices"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli/values"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/internal/helm"
+	"github.com/cilium/cilium-cli/internal/utils"
+	"github.com/cilium/cilium-cli/k8s"
+	"github.com/cilium/cilium-cli/status"
+)
+
+func (ct *ConnectivityTest) generateAgentDaemonSet() *appsv1.DaemonSet {
+	dsFile := ct.manifests["templates/cilium-agent/daemonset.yaml"]
+
+	var ds appsv1.DaemonSet
+	utils.MustUnmarshalYAML([]byte(dsFile), &ds)
+	return &ds
+}
+
+func (ct *ConnectivityTest) deleteCiliumPods(ctx context.Context) error {
+	ct.Debug("Getting helm state")
+	helmState, err := ct.client.GetHelmState(ctx, ct.params.CiliumNamespace, ct.params.HelmValuesSecretName)
+	if err != nil {
+		// if cilium-cli-helm-values secret was not found (e.g. cilium was not installed with cilium-cli)
+		// or the secret parsing failed for whatever reason, then we create a default helm state.
+		ct.Logf("Error parsing helm cli secret: %s", err)
+		ct.Logf("Proceeding in unknown installation state")
+		helmState, err = ct.generateDefaultHelmState(ctx, ct.client, ct.params.CiliumNamespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	ct.Debug("Generating manifest with updated node affinity")
+	err = ct.generateManifestsNodeAffinity(ctx, helmState)
+	if err != nil {
+		return err
+	}
+
+	// If helm values secret is not present we should not write one to the cluster now
+	if helmState.Secret != nil {
+		ct.Infof("Storing helm values file in %s/%s Secret", ct.params.CiliumNamespace, ct.params.HelmValuesSecretName)
+
+		helmState.Secret.Data[defaults.HelmValuesSecretKeyName] = []byte(ct.helmYAMLValues)
+		if _, err := ct.client.UpdateSecret(ctx, ct.params.CiliumNamespace, helmState.Secret, metav1.UpdateOptions{}); err != nil {
+			ct.Logf("Unable to store helm values file %s/%s Secret", ct.params.CiliumNamespace, ct.params.HelmValuesSecretName)
+			return err
+		}
+	}
+
+	ct.Info("Deleting Agent DaemonSet...")
+	if err := ct.client.DeleteDaemonSet(ctx, ct.params.CiliumNamespace, defaults.AgentDaemonSetName, metav1.DeleteOptions{}); err != nil {
+		ct.Fatalf("Cannot delete %s DaemonSet: %s", defaults.AgentDaemonSetName, err)
+		return err
+	}
+	ct.Info("Re-creating Agent DaemonSet...")
+	if _, err := ct.client.CreateDaemonSet(ctx, ct.params.CiliumNamespace, ct.generateAgentDaemonSet(), metav1.CreateOptions{}); err != nil {
+		ct.Fatalf("Cannot re-create %s DaemonSet: %s", defaults.AgentDaemonSetName, err)
+		return err
+	}
+
+	ct.Debugf("Deleting Cilium pods from nodes %v", ct.params.DeleteCiliumOnNodes)
+	for _, node := range ct.params.DeleteCiliumOnNodes {
+		ct.Infof("  Deleting Cilium pod on node %s by setting label %q", node, defaults.CiliumNoScheduleLabel)
+		label := utils.EscapeJSONPatchString(defaults.CiliumNoScheduleLabel)
+		labelPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/labels/%s","value":"true"}]`, label)
+		_, err = ct.client.PatchNode(ctx, node, types.JSONPatchType, []byte(labelPatch))
+		if err != nil {
+			return err
+		}
+	}
+
+	collector, err := status.NewK8sStatusCollector(ct.client, status.K8sStatusParameters{
+		Namespace:       ct.params.CiliumNamespace,
+		Wait:            true,
+		WaitDuration:    defaults.StatusWaitDuration,
+		WarningFreePods: []string{defaults.AgentDaemonSetName, defaults.OperatorDeploymentName},
+	})
+	if err != nil {
+		return err
+	}
+
+	s, err := collector.Status(ctx)
+	if err != nil {
+		fmt.Print(s.Format())
+		return err
+	}
+
+	// re-initialized list of Cilium pods
+	ct.ciliumPods = make(map[string]Pod)
+	ct.initCiliumPods(ctx)
+
+	debugLogFeatures := func(header string) {
+		if ct.debug() {
+			fs := make([]Feature, 0, len(ct.features))
+			for f := range ct.features {
+				fs = append(fs, f)
+			}
+			slices.Sort(fs)
+			ct.Debug(header)
+			for _, f := range fs {
+				ct.Debugf("  %s: %s", f, ct.features[f])
+			}
+		}
+	}
+
+	debugLogFeatures("Features before update:")
+	// Update list node nodes without Cilium
+	ct.UpdateFeaturesFromNodes(ctx)
+	// Disable tests requiring L7 proxy to run, the L7 proxy isn't running anymore.
+	ct.ForceDisableFeature(FeatureL7Proxy)
+	// Disable tests requiring health checking, agent and thus cilium-health isn't running on
+	// nodes where Cilium pods were deleted.
+	ct.ForceDisableFeature(FeatureHealthChecking)
+	debugLogFeatures("Features after update:")
+
+	return nil
+}
+
+func (ct *ConnectivityTest) generateManifestsNodeAffinity(ctx context.Context, helmState *helm.State) error {
+	helmMapOpts := map[string]string{}
+
+	// Set affinity to prevent Cilium from being scheduled on nodes labeled with
+	// "cilium.io/no-schedule=true"
+	for k, v := range defaults.CiliumScheduleAffinity {
+		helmMapOpts[k] = v
+	}
+
+	vals, err := helm.MergeVals(
+		values.Options{},
+		helmMapOpts,
+		helmState.Values,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	yamlValues, err := chartutil.Values(vals).YAML()
+	if err != nil {
+		return err
+	}
+
+	k8sVersionStr := ct.Params().K8sVersion
+	if k8sVersionStr == "" {
+		k8sVersion, err := ct.client.GetServerVersion()
+		if err != nil {
+			return fmt.Errorf("error getting Kubernetes version, try --k8s-version: %s", err)
+		}
+		k8sVersionStr = k8sVersion.String()
+	}
+
+	manifests, err := helm.GenManifests(
+		ctx,
+		ct.params.HelmChartDirectory,
+		k8sVersionStr,
+		helmState.Version,
+		ct.params.CiliumNamespace,
+		vals,
+		[]string{},
+	)
+	if err != nil {
+		return err
+	}
+
+	ct.manifests = manifests
+	ct.helmYAMLValues = yamlValues
+	return nil
+}
+
+func (ct *ConnectivityTest) generateDefaultHelmState(ctx context.Context, client *k8s.Client, namespace string) (*helm.State, error) {
+	version, err := client.GetRunningCiliumVersion(ctx, namespace)
+	if version == "" || err != nil {
+		return nil, fmt.Errorf("unable to obtain cilium version, no Cilium pods found in namespace %q", namespace)
+	}
+	semVer, err := utils.ParseCiliumVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse cilium version %s: %w", version, err)
+	}
+	return &helm.State{
+		Secret:  nil,
+		Version: semVer,
+		Values:  chartutil.Values{},
+	}, nil
+}

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/option"
@@ -203,7 +204,10 @@ func (ct *ConnectivityTest) extractFeaturesFromNodes(ctx context.Context, client
 		}
 	}
 
-	result[FeatureNodeWithoutCilium] = FeatureStatus{Enabled: len(nodes) != 0}
+	result[FeatureNodeWithoutCilium] = FeatureStatus{
+		Enabled: len(nodes) != 0,
+		Mode:    strings.Join(nodes, ","),
+	}
 	ct.nodesWithoutCilium = nodes
 
 	return nil

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -343,3 +343,11 @@ func (ct *ConnectivityTest) detectFeatures(ctx context.Context) error {
 
 	return nil
 }
+
+func (ct *ConnectivityTest) UpdateFeaturesFromNodes(ctx context.Context) error {
+	return ct.extractFeaturesFromNodes(ctx, ct.client, ct.features)
+}
+
+func (ct *ConnectivityTest) ForceDisableFeature(feature Feature) {
+	ct.features[feature] = FeatureStatus{Enabled: false}
+}

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -181,5 +181,4 @@ func (s *outsideToNodePort) Run(ctx context.Context, t *check.Test) {
 			i++
 		}
 	}
-
 }

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -99,25 +99,22 @@ var (
 		"k8s-app": "clustermesh-apiserver",
 	}
 
-	// CiliumPodSelector is the pod selector to be used for the Cilium agents.
-	CiliumPodSelector = "k8s-app=cilium"
+	// HubbleKeys are all hubble values from `cilium-config` configmap:
+	// https://github.com/cilium/cilium/blob/d9a04be9d714e5f5544cbca7ef8db7a151bfce96/install/kubernetes/cilium/templates/cilium-configmap.yaml#L709-L750
+	// this list is used to cherry-pick only hubble related values for configmap patch
+	// when running in unknown install state (i.e. when `cilium-cli-helm-values` doesn't exist)
+	HubbleKeys = []string{
+		"enable-hubble",
+		"hubble-disable-tls",
+		"hubble-event-buffer-capacity",
+		"hubble-event-queue-size",
+		"hubble-flow-buffer-size",
+		"hubble-listen-address",
+		"hubble-metrics",
+		"hubble-metrics-server",
+		"hubble-socket-path",
+		"hubble-tls-cert-file",
+		"hubble-tls-client-ca-files",
+		"hubble-tls-key-file",
+	}
 )
-
-// All hubble values from `cilium-config` configmap:
-// https://github.com/cilium/cilium/blob/d9a04be9d714e5f5544cbca7ef8db7a151bfce96/install/kubernetes/cilium/templates/cilium-configmap.yaml#L709-L750
-// this list is used to cherry-pick only hubble related values for configmap patch
-// when running in unknown install state (i.e. when `cilium-cli-helm-values` doesn't exist)
-var HubbleKeys = []string{
-	"enable-hubble",
-	"hubble-disable-tls",
-	"hubble-event-buffer-capacity",
-	"hubble-event-queue-size",
-	"hubble-flow-buffer-size",
-	"hubble-listen-address",
-	"hubble-metrics",
-	"hubble-metrics-server",
-	"hubble-socket-path",
-	"hubble-tls-cert-file",
-	"hubble-tls-client-ca-files",
-	"hubble-tls-key-file",
-}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -91,6 +91,8 @@ const (
 	HelmValuesSecretName          = "cilium-cli-helm-values"
 	HelmValuesSecretKeyName       = "io.cilium.cilium-cli"
 	HelmChartVersionSecretKeyName = "io.cilium.chart-version"
+
+	CiliumNoScheduleLabel = "cilium.io/no-schedule"
 )
 
 var (
@@ -116,5 +118,13 @@ var (
 		"hubble-tls-cert-file",
 		"hubble-tls-client-ca-files",
 		"hubble-tls-key-file",
+	}
+
+	// CiliumScheduleAffinity is the node affinity to prevent Cilium from being schedule on
+	// nodes labeled with CiliumNoScheduleLabel.
+	CiliumScheduleAffinity = map[string]string{
+		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key":       CiliumNoScheduleLabel,
+		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator":  "NotIn",
+		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]": "true",
 	}
 )

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -472,7 +472,7 @@ func (k *K8sHubble) updateConfigMap(ctx context.Context) error {
 		return fmt.Errorf("unable to patch ConfigMap %s with %s: %w", defaults.ConfigMapName, cm, err)
 	}
 
-	if err := k.client.DeletePodCollection(ctx, k.params.Namespace, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.CiliumPodSelector}); err != nil {
+	if err := k.client.DeletePodCollection(ctx, k.params.Namespace, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector}); err != nil {
 		k.Log("⚠️  Unable to restart Cilium pods: %s", err)
 	} else {
 		k.Log("♻️  Restarted Cilium pods")

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -185,7 +185,7 @@ func NewK8sHubble(ctx context.Context, client k8sHubbleImplementation, p Paramet
 		// if cilium-cli-helm-values secret was not found (e.g. cilium was not installed with cilium-cli)
 		// or the secret parsing failed for whatever reason, then we create a default helm state.
 		k.Log("⚠️  Error parsing helm cli secret: %s", err)
-		k.Log("⚠️  Proceed in unknown install state")
+		k.Log("⚠️  Proceeding in unknown installation state")
 		helmState, err = k.generateDefaultHelmState(ctx, client, p.Namespace)
 		if err != nil {
 			return nil, err

--- a/install/helm.go
+++ b/install/helm.go
@@ -257,9 +257,9 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 	// Set affinity to prevent Cilium from being scheduled on nodes labeled with
 	// "cilium.io/no-schedule=true"
 	if len(k.params.NodesWithoutCilium) != 0 {
-		helmMapOpts["affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key"] = "cilium.io/no-schedule"
-		helmMapOpts["affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator"] = "NotIn"
-		helmMapOpts["affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]"] = "true"
+		for k, v := range defaults.CiliumScheduleAffinity {
+			helmMapOpts[k] = v
+		}
 	}
 
 	// Store all the options passed by --config into helm extraConfig

--- a/install/helm.go
+++ b/install/helm.go
@@ -49,9 +49,8 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 			// version from being used as the operator tag by Cilium Helm charts.
 			// This also makes k8s pod list to actually contain the image tag.
 			if imageTag == "" {
-				k.Log("ℹ️  Defaulting image tag to \"latest\" due to \"--image-suffix\" option")
-
 				imageTag = "latest"
+				k.Log("ℹ️  Defaulting image tag to %q due to --image-suffix option", imageTag)
 			}
 			colonTag := ":" + imageTag
 			helmMapOpts["image.override"] = fmt.Sprintf("quay.io/cilium/cilium%s%s", imageSuffix, colonTag)

--- a/install/install.go
+++ b/install/install.go
@@ -694,10 +694,9 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 	}
 
 	for _, nodeName := range k.params.NodesWithoutCilium {
-		k.Log("🚀 Setting \"cilium.io/no-schedule=true\" label for %q node to prevent from scheduling Cilium on it...",
-			nodeName)
-		// "~1" is the json patch escape symbol for "/"
-		labelPatch := `[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]`
+		k.Log("🚀 Setting label %q on node %q to prevent Cilium from being scheduled on it...", defaults.CiliumNoScheduleLabel, nodeName)
+		label := utils.EscapeJSONPatchString(defaults.CiliumNoScheduleLabel)
+		labelPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/labels/%s","value":"true"}]`, label)
 		_, err = k.client.PatchNode(ctx, nodeName, types.JSONPatchType, []byte(labelPatch))
 		if err != nil {
 			return err

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -115,7 +115,7 @@ func (k *K8sUninstaller) Uninstall(ctx context.Context) error {
 		k.Log("⌛ Waiting for Cilium to be uninstalled...")
 
 	retry:
-		pods, err := k.client.ListPods(ctx, k.params.Namespace, metav1.ListOptions{LabelSelector: "k8s-app=cilium"})
+		pods, err := k.client.ListPods(ctx, k.params.Namespace, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector})
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -127,6 +127,12 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")
 	cmd.Flags().MarkHidden("datapath")
 
+	cmd.Flags().StringVar(&params.K8sVersion, "k8s-version", "", "Kubernetes server version in case auto-detection fails")
+	cmd.Flags().StringVar(&params.HelmChartDirectory, "chart-directory", "", "Helm chart directory")
+	cmd.Flags().StringVar(&params.HelmValuesSecretName, "helm-values-secret-name", defaults.HelmValuesSecretName, "Secret name to store the auto-generated helm values file. The namespace is the same as where Cilium will be installed")
+
+	cmd.Flags().StringSliceVar(&params.DeleteCiliumOnNodes, "delete-cilium-pod-on-nodes", []string{}, "List of node names from which Cilium pods will be delete before running tests")
+
 	cmd.Flags().BoolVar(&params.Perf, "perf", false, "Run network Performance tests")
 	cmd.Flags().DurationVar(&params.PerfDuration, "perf-duration", 10*time.Second, "Duration for the Performance test to run")
 	cmd.Flags().IntVar(&params.PerfSamples, "perf-samples", 1, "Number of Performance samples to capture (how many times to run each test)")

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -123,18 +123,20 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Timestamp, "timestamp", "t", false, "Show timestamp in messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
+	cmd.Flags().MarkHidden("skip-ip-cache-check")
+	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")
+	cmd.Flags().MarkHidden("datapath")
+
 	cmd.Flags().BoolVar(&params.Perf, "perf", false, "Run network Performance tests")
 	cmd.Flags().DurationVar(&params.PerfDuration, "perf-duration", 10*time.Second, "Duration for the Performance test to run")
 	cmd.Flags().IntVar(&params.PerfSamples, "perf-samples", 1, "Number of Performance samples to capture (how many times to run each test)")
 	cmd.Flags().BoolVar(&params.PerfCRR, "perf-crr", false, "Run Netperf CRR Test. --perf-samples and --perf-duration ignored")
 	cmd.Flags().BoolVar(&params.PerfHostNet, "host-net", false, "Use host networking during network performance tests")
-	cmd.Flags().MarkHidden("skip-ip-cache-check")
+
 	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckAlpineCurlImage, "Image path to use for curl")
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
-	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")
-	cmd.Flags().MarkHidden("datapath")
 
 	return cmd
 }

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package utils
+
+import "strings"
+
+func EscapeJSONPatchString(str string) string {
+	// From https://www.rfc-editor.org/rfc/rfc6901#section-3:
+	// Because the characters '~' (%x7E) and '/' (%x2F) have special meanings in JSON Pointer,
+	// '~' needs to be encoded as '~0' and '/' needs to be encoded as '~1' when these characters
+	// appear in a reference token.
+	str = strings.ReplaceAll(str, "~", "~0")
+	str = strings.ReplaceAll(str, "/", "~1")
+	return str
+}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -799,7 +799,7 @@ func getCiliumVersionFromImage(image string) (string, error) {
 }
 
 func (c *Client) GetRunningCiliumVersion(ctx context.Context, namespace string) (string, error) {
-	pods, err := c.ListPods(ctx, namespace, metav1.ListOptions{LabelSelector: "k8s-app=cilium"})
+	pods, err := c.ListPods(ctx, namespace, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector})
 	if err != nil {
 		return "", fmt.Errorf("unable to list cilium pods: %w", err)
 	}

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -483,7 +483,7 @@ func (k *K8sStatusCollector) status(ctx context.Context) *Status {
 
 	// for the sake of sanity, don't get pod logs more than once
 	var agentLogsOnce = sync.Once{}
-	err := k.podStatus(ctx, status, defaults.AgentDaemonSetName, "k8s-app=cilium", func(ctx context.Context, status *Status, name string, pod *corev1.Pod) {
+	err := k.podStatus(ctx, status, defaults.AgentDaemonSetName, defaults.AgentPodSelector, func(ctx context.Context, status *Status, name string, pod *corev1.Pod) {
 		if pod.Status.Phase == corev1.PodRunning {
 			// extract container status
 			var containerStatus *corev1.ContainerStatus

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -166,7 +166,7 @@ func (b *StatusSuite) TestStatus(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(collector, check.Not(check.IsNil))
 
-	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 10, 10, 0)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, defaults.AgentPodSelector, 10, 10, 10, 0)
 	status, err := collector.Status(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Not(check.IsNil))
@@ -179,7 +179,7 @@ func (b *StatusSuite) TestStatus(c *check.C) {
 	c.Assert(len(status.CiliumStatus), check.Equals, 10)
 
 	client.reset()
-	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, defaults.AgentPodSelector, 10, 5, 5, 5)
 	status, err = collector.Status(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Not(check.IsNil))
@@ -192,7 +192,7 @@ func (b *StatusSuite) TestStatus(c *check.C) {
 	c.Assert(len(status.CiliumStatus), check.Equals, 5)
 
 	client.reset()
-	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, defaults.AgentPodSelector, 10, 5, 5, 5)
 	delete(client.status, "cilium-2")
 	status, err = collector.Status(context.Background())
 	c.Assert(err, check.IsNil)
@@ -215,7 +215,7 @@ func (b *StatusSuite) TestFormat(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(collector, check.Not(check.IsNil))
 
-	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, "k8s-app=cilium", 10, 5, 5, 5)
+	client.setDaemonSet("kube-system", defaults.AgentDaemonSetName, defaults.AgentPodSelector, 10, 5, 5, 5)
 	delete(client.status, "cilium-2")
 
 	client.addPod("kube-system", "cilium-operator-1", "k8s-app=cilium-operator", []corev1.Container{{Image: "cilium-operator:1.9"}}, corev1.PodStatus{Phase: corev1.PodRunning})


### PR DESCRIPTION
Add a `--delete-cilium-pod-on-nodes` flag to `cilium connectivity test` which will delete the Cilium pods from the specified nodes before running tests. On the specified nodes this will keep only the datapath plumbed, but no Cilium agent running.

This is implemented similar to the existing `cilium install --nodes-without-cilium` flag which will set up pod's nodeAffinity such that Cilium pods won't be scheduled on nodes with label `cilium.io/no-schedule`.

This serves to migrate the "chaos tests" currently part of Cilium in-tree tests to cilium-cli.