### PR TITLE
sysdump: auto detect namespace from list of defaults.

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -47,10 +47,10 @@ func newCmdSysdump() *cobra.Command {
 		"cilium-label-selector", sysdump.DefaultCiliumLabelSelector,
 		"The labels used to target Cilium pods")
 	cmd.Flags().StringVar(&sysdumpOptions.CiliumNamespace,
-		"cilium-namespace", sysdump.DefaultCiliumNamespace,
+		"cilium-namespace", "",
 		"The namespace Cilium is running in")
 	cmd.Flags().StringVar(&sysdumpOptions.CiliumOperatorNamespace,
-		"cilium-operator-namespace", sysdump.DefaultCiliumNamespace,
+		"cilium-operator-namespace", "",
 		"The namespace Cilium operator is running in")
 	cmd.Flags().StringVar(&sysdumpOptions.CiliumDaemonSetSelector,
 		"cilium-daemon-set-label-selector", sysdump.DefaultCiliumLabelSelector,

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -31,6 +31,7 @@ type KubernetesClient interface {
 	ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error)
 	ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error)
 	GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error)
+	GetNamespace(ctx context.Context, namespace string, options metav1.GetOptions) (*corev1.Namespace, error)
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error)
 	GetLogs(ctx context.Context, namespace, name, container string, sinceTime time.Time, limitBytes int64, previous bool) (string, error)

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -25,7 +25,6 @@ const (
 
 const (
 	DefaultCiliumLabelSelector               = labelPrefix + "cilium"
-	DefaultCiliumNamespace                   = "kube-system"
 	DefaultCiliumOperatorLabelSelector       = "io.cilium/app=operator"
 	DefaultClustermeshApiserverLabelSelector = labelPrefix + "clustermesh-apiserver"
 	DefaultDebug                             = false
@@ -51,4 +50,8 @@ const (
 var (
 	// DefaultWorkerCount is initialized to the machine's available CPUs.
 	DefaultWorkerCount = runtime.NumCPU()
+
+	// DefaultCiliumNamespaces will be used to attempt to autodetect what namespace Cilium is installed in
+	// unless otherwise specified.
+	DefaultCiliumNamespaces = []string{"kube-system", "cilium"}
 )

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -151,6 +151,15 @@ func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion
 	c.logDebug("Using %v as a temporary directory", c.sysdumpDir)
 	c.logTask("Collecting sysdump with cilium-cli version: %s, args: %s", cliVersion, os.Args[1:])
 
+	if o.CiliumNamespace == "" {
+		ns, err := detectCiliumNamespace(k)
+		if err != nil {
+			return nil, err
+		}
+		c.logDebug("Detected Cilium installation in namespace %q", ns)
+		o.CiliumNamespace = ns
+	}
+
 	// Grab the Kubernetes nodes for the target cluster.
 	c.logTask("Collecting Kubernetes nodes")
 	c.allNodes, err = c.Client.ListNodes(context.Background(), metav1.ListOptions{})
@@ -1516,4 +1525,27 @@ func isNodeInWhitelist(node corev1.Node, w []string) bool {
 // AddTasks adds extra tasks for the collector to execute. Must be called before Run().
 func (c *Collector) AddTasks(tasks []Task) {
 	c.additionalTasks = append(c.additionalTasks, tasks...)
+}
+
+func detectCiliumNamespace(k KubernetesClient) (string, error) {
+	for _, ns := range DefaultCiliumNamespaces {
+		ctx := context.Background()
+		ns, err := k.GetNamespace(ctx, ns, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to detect Cilium namespace: %w", err)
+		}
+
+		_, err = k.GetDaemonSet(ctx, ns.Name, "cilium", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to check for Cilium DaemonSet: %w", err)
+		}
+		return ns.Name, nil
+	}
+	return "", fmt.Errorf("failed to detect Cilium namespace, could not find Cilium installation in namespaces: %v", DefaultCiliumNamespaces)
 }

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -259,7 +261,7 @@ func (c *fakeClient) GetConfigMap(ctx context.Context, namespace, name string, o
 }
 
 func (c *fakeClient) GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error) {
-	panic("implement me")
+	return nil, nil
 }
 
 func (c *fakeClient) GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error) {
@@ -348,4 +350,19 @@ func (c *fakeClient) ListUnstructured(ctx context.Context, gvr schema.GroupVersi
 
 func (c *fakeClient) CreateEphemeralContainer(ctx context.Context, pod *corev1.Pod, container *corev1.EphemeralContainer) (*corev1.Pod, error) {
 	panic("implement me")
+}
+
+func (c *fakeClient) GetNamespace(_ context.Context, ns string, _ metav1.GetOptions) (*corev1.Namespace, error) {
+	if ns == "kube-system" {
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+			},
+		}, nil
+	}
+	return nil, &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Code: http.StatusNotFound,
+		},
+	}
 }


### PR DESCRIPTION
Unless specified by '--cilium-namespace', sysdump will now attempt to auto detect which namespace has a Cilium installation from a list of default namespaces.

This will make the default path coverage most Cilium installations. Installs outside of these namespaces will presumably the result of more custom installations and can be overridden per-usual with --cilium-namespace.

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>