### PR TITLE
Don't restart Cilium on cilium uninstall

### DIFF
--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -305,7 +305,7 @@ func (k *K8sHubble) disableHubble(ctx context.Context) error {
 	return k.updateConfigMap(ctx)
 }
 
-func (k *K8sHubble) Disable(ctx context.Context) error {
+func (k *K8sHubble) Disable(ctx context.Context, uninstall bool) error {
 	// Generate the manifests has if hubble was being enabled so that we can
 	// retrieve all UI and Relay's resource names.
 	k.params.UI = true
@@ -331,6 +331,12 @@ func (k *K8sHubble) Disable(ctx context.Context) error {
 	if metricsSvc := k.generateMetricsService(); metricsSvc != nil {
 		k.Log("🔥 Deleting Metrics Service...")
 		k.client.DeleteService(ctx, metricsSvc.GetNamespace(), metricsSvc.GetName(), metav1.DeleteOptions{})
+	}
+
+	// If Disable() was called as a part of "cilium uninstall" command, we don't need to
+	// update configmap and restart Cilium.
+	if uninstall {
+		return nil
 	}
 
 	// Now that we have delete all UI and Relay's resource names then we can

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -113,7 +113,7 @@ func newCmdHubbleDisable() *cobra.Command {
 			if err != nil {
 				fatalf("Unable to disable Hubble:  %s", err)
 			}
-			if err := h.Disable(ctx); err != nil {
+			if err := h.Disable(ctx, false); err != nil {
 				fatalf("Unable to disable Hubble:  %s", err)
 			}
 			return nil

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -147,7 +147,7 @@ func newCmdUninstall() *cobra.Command {
 				})
 			if err != nil {
 				fmt.Printf("⚠ ️ Failed to initialize Hubble uninstaller: %s", err)
-			} else if h.Disable(ctx) != nil {
+			} else if h.Disable(ctx, true) != nil {
 				fmt.Printf("ℹ️  Failed to disable Hubble. This is expected if Hubble is not enabled: %s", err)
 			}
 			uninstaller := install.NewK8sUninstaller(k8sClient, params)


### PR DESCRIPTION
cilium uninstall calls K8sHubble.Disable to delete resources created by Hubble. We don't need to update cilium-config and restart Cilium to actually disable Hubble since we are deleting Cilium right after.

Fixes: #255
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>