### PR TITLE
Collect logs for cilium-cli pod in test artifacts

### DIFF
--- a/.github/cilium-cli-test-job-chart/templates/job.yaml
+++ b/.github/cilium-cli-test-job-chart/templates/job.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   backoffLimit: 0
   template:
+    metadata:
+      labels:
+        k8s-app: cilium
     spec:
       containers:
       - args:


### PR DESCRIPTION
Add necessary labels to ensure the cilium-cli job logs are picked up by sysdump.

Fixes: #321  

Signed-off-by: Fernand <fernand@imhotep.io>
