### PR TITLE
Improvements for kube-proxy detection and replacement

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -174,10 +174,17 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 }
 
 func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context) error {
+	if k.params.UserSetKubeProxyReplacement {
+		return nil
+	} else if k.flavor.Kind == k8s.KindK3s {
+		return nil
+	}
+
 	kubeSysNameSpace := "kube-system"
+
 	dsList, err := k.client.ListDaemonSet(ctx, kubeSysNameSpace, metav1.ListOptions{})
 	if err != nil {
-		k.Log("⏭️ Skipping auto kube-proxy detction")
+		k.Log("⏭️ Skipping auto kube-proxy detection")
 		return nil
 	}
 

--- a/install/helm.go
+++ b/install/helm.go
@@ -227,7 +227,7 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 
 		// TODO: remove when removing "kube-proxy-replacement" flag (marked as
 		// deprecated), kept for backwards compatibility
-		if k.params.KubeProxyReplacement != "" {
+		if k.params.KubeProxyReplacement != "" && k.params.UserSetKubeProxyReplacement {
 			helmMapOpts["kubeProxyReplacement"] = k.params.KubeProxyReplacement
 		}
 

--- a/install/install.go
+++ b/install/install.go
@@ -317,6 +317,8 @@ type Parameters struct {
 	// APIVersions defines extra kubernetes api resources that can be passed to helm for capabilities validation,
 	// specifically for CRDs.
 	APIVersions []string
+	// UserSetKubeProxyReplacement will be set as true if user passes helm opt or commadline flag for the Kube-Proxy replacement.
+	UserSetKubeProxyReplacement bool
 }
 
 type rollbackStep func(context.Context)

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/hubble"
@@ -34,6 +36,14 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params.Namespace = namespace
+
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				if f.Name == "kube-proxy-replacement" {
+					params.UserSetKubeProxyReplacement = true
+				} else if f.Name == "helm-set" && strings.Contains(f.Value.String(), "kubeProxyReplacement") {
+					params.UserSetKubeProxyReplacement = true
+				}
+			})
 
 			installer, err := install.NewK8sInstaller(k8sClient, params)
 			if err != nil {


### PR DESCRIPTION
The current implementation tries to replace  the kube-proxy for k3s and doesn't honor the value set for kube-proxy replacement by users. This PR fixes those issues.

Fixes: cilium#1004
Signed-off-by: shankeerthan-kasilingam <shankeerthan1995@gmail.com>