### PR TITLE
install: Add ability to auto-fill or manually set .Capabilities.APIVersions in helm

### DIFF
--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -560,9 +560,12 @@ func (k *K8sHubble) generateManifestsDisable(ctx context.Context, helmValues cha
 
 func (k *K8sHubble) genManifests(ctx context.Context, printHelmTemplate bool, prevHelmValues chartutil.Values, helmMapOpts map[string]string, ciliumVer semver.Version) error {
 	// Store all the options passed by --config into helm extraConfig
-	vals, err := helm.MergeVals(k, printHelmTemplate, k.params.HelmOpts, helmMapOpts, prevHelmValues, nil, k.params.HelmChartDirectory, ciliumVer, k.params.Namespace)
+	vals, err := helm.MergeVals(k.params.HelmOpts, helmMapOpts, prevHelmValues, nil)
 	if err != nil {
 		return err
+	}
+	if printHelmTemplate {
+		helm.PrintHelmTemplateCommand(k, vals, k.params.HelmChartDirectory, k.params.Namespace, ciliumVer)
 	}
 
 	yamlValue, err := chartutil.Values(vals).YAML()

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -559,13 +559,17 @@ func (k *K8sHubble) generateManifestsDisable(ctx context.Context, helmValues cha
 }
 
 func (k *K8sHubble) genManifests(ctx context.Context, printHelmTemplate bool, prevHelmValues chartutil.Values, helmMapOpts map[string]string, ciliumVer semver.Version) error {
+	// Specifying extra apiVersions (ie CRDs) for hubble is not needed right now.
+	// This can be filled in the future if needed.
+	apiVersions := []string{}
+
 	// Store all the options passed by --config into helm extraConfig
 	vals, err := helm.MergeVals(k.params.HelmOpts, helmMapOpts, prevHelmValues, nil)
 	if err != nil {
 		return err
 	}
 	if printHelmTemplate {
-		helm.PrintHelmTemplateCommand(k, vals, k.params.HelmChartDirectory, k.params.Namespace, ciliumVer)
+		helm.PrintHelmTemplateCommand(k, vals, k.params.HelmChartDirectory, k.params.Namespace, ciliumVer, apiVersions)
 	}
 
 	yamlValue, err := chartutil.Values(vals).YAML()
@@ -586,7 +590,7 @@ func (k *K8sHubble) genManifests(ctx context.Context, printHelmTemplate bool, pr
 		k8sVersionStr = k8sVersion.String()
 	}
 
-	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, ciliumVer, k.params.Namespace, vals)
+	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, ciliumVer, k.params.Namespace, vals, apiVersions)
 	if err != nil {
 		return err
 	}

--- a/install/helm.go
+++ b/install/helm.go
@@ -268,10 +268,12 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 		extraConfigMap[k] = v
 	}
 
-	vals, err := helm.MergeVals(k, true, k.params.HelmOpts, helmMapOpts, nil, extraConfigMap, k.params.HelmChartDirectory, k.chartVersion, k.params.Namespace)
+	vals, err := helm.MergeVals(k.params.HelmOpts, helmMapOpts, nil, extraConfigMap)
 	if err != nil {
 		return err
 	}
+
+	helm.PrintHelmTemplateCommand(k, vals, k.params.HelmChartDirectory, k.params.Namespace, k.chartVersion)
 
 	yamlValue, err := chartutil.Values(vals).YAML()
 	if err != nil {

--- a/install/install.go
+++ b/install/install.go
@@ -201,6 +201,7 @@ type k8sInstallerImplementation interface {
 	CreateIngressClass(ctx context.Context, r *networkingv1.IngressClass, opts metav1.CreateOptions) (*networkingv1.IngressClass, error)
 	DeleteIngressClass(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
+	ListAPIResources(ctx context.Context) ([]string, error)
 }
 
 type K8sInstaller struct {
@@ -311,6 +312,10 @@ type Parameters struct {
 
 	// NodesWithoutCilium lists all nodes on which Cilium is not installed.
 	NodesWithoutCilium []string
+
+	// APIVersions defines extra kubernetes api resources that can be passed to helm for capabilities validation,
+	// specifically for CRDs.
+	APIVersions []string
 }
 
 type rollbackStep func(context.Context)

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -107,6 +107,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringArrayVar(&params.HelmOpts.FileValues, "helm-set-file", []string{}, "Set helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")
 	cmd.Flags().StringVar(&params.HelmGenValuesFile, "helm-auto-gen-values", "", "Write an auto-generated helm values into this file")
 	cmd.Flags().StringVar(&params.HelmValuesSecretName, "helm-values-secret-name", defaults.HelmValuesSecretName, "Secret name to store the auto-generated helm values file. The namespace is the same as where Cilium will be installed")
+	cmd.Flags().StringSliceVar(&params.APIVersions, "api-versions", []string{}, "Kubernetes API versions to use for helm's Capabilities.APIVersions in case discovery fails")
 	cmd.Flags().StringVar(&params.ImageSuffix, "image-suffix", "", "Set all generated images with this suffix")
 	cmd.Flags().StringVar(&params.ImageTag, "image-tag", "", "Set all images with this tag")
 	cmd.Flags().BoolVar(&params.ListVersions, "list-versions", false, "List all the available versions without actually installing")

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -301,20 +301,12 @@ func GenManifests(
 // helm values from a previous installation ('helmValues'),
 // extra options that are not defined as helm flags ('extraConfigMapOpts')
 // and returns a single map with all of these options merged.
-// It will log a message so that users can replicate the same behavior as the
-// CLI. The log message will be slightly different depending on if
-// 'helmChartDirectory' is set or not.
-// Both 'helmMapOpts', 'helmValues', 'extraConfigMapOpts' can be nil.
+// Both 'helmMapOpts', 'helmValues', 'extraConfigMapOpts', can be nil.
 func MergeVals(
-	logger utils.Logger,
-	printHelmTemplate bool,
 	helmFlagOpts values.Options,
 	helmMapOpts map[string]string,
 	helmValues,
 	extraConfigMapOpts chartutil.Values,
-	helmChartDirectory string,
-	ciliumVer semver2.Version,
-	namespace string,
 ) (map[string]interface{}, error) {
 
 	// Create helm values from helmMapOpts
@@ -353,17 +345,25 @@ func MergeVals(
 
 	vals := mergeMaps(extraConfig, userVals)
 
-	valsStr := valuesToString("", vals)
-
-	if printHelmTemplate {
-		if helmChartDirectory != "" {
-			logger.Log("ℹ️  helm template --namespace %s cilium %q --version %s --set %s", namespace, helmChartDirectory, ciliumVer, valsStr)
-		} else {
-			logger.Log("ℹ️  helm template --namespace %s cilium cilium/cilium --version %s --set %s", namespace, ciliumVer, valsStr)
-		}
-	}
-
 	return vals, nil
+}
+
+// PrintHelmTemplateCommand will log a message so that users can replicate
+// the same behavior as the CLI. The log message will be slightly different
+// depending on if 'helmChartDirectory' is set or not.
+func PrintHelmTemplateCommand(
+	logger utils.Logger,
+	helmValues map[string]any,
+	helmChartDirectory string,
+	namespace string,
+	ciliumVer semver2.Version,
+) {
+	valsStr := valuesToString("", helmValues)
+	if helmChartDirectory != "" {
+		logger.Log("ℹ️  helm template --namespace %s cilium %q --version %s --set %s", namespace, helmChartDirectory, ciliumVer, valsStr)
+	} else {
+		logger.Log("ℹ️  helm template --namespace %s cilium cilium/cilium --version %s --set %s", namespace, ciliumVer, valsStr)
+	}
 }
 
 // ListVersions returns a list of available Helm chart versions (with "v" prefix) sorted by semver in ascending order.

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -901,6 +901,18 @@ func (c *Client) GetHelmState(ctx context.Context, namespace string, secretName 
 	}, nil
 }
 
+func (c *Client) ListAPIResources(ctx context.Context) ([]string, error) {
+	lists, err := c.Clientset.Discovery().ServerPreferredResources()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list api resources: %w", err)
+	}
+	results := make([]string, len(lists))
+	for _, list := range lists {
+		results = append(results, list.GroupVersion)
+	}
+	return results, nil
+}
+
 // CreateEphemeralContainer will create a EphemeralContainer (debug container) in the specified pod.
 // EphemeralContainers are special containers which can be added after-the-fact in running pods. They're
 // useful for debugging, either when the target container image doesn't have necessary tools, or because


### PR DESCRIPTION
This is an attempt to fix https://github.com/cilium/cilium-cli/issues/1107 by introducing two ways to set `.Capabilities.APIVersions` in helm while rendering Cilium templates:

* Query the api-server to find all known needed api-resources in a cluster for verifying cilium templates, passing them to `.Capabilities.APIVersions`.
* Let a user manually set the list by using the `--api-versions` CLI argument.

I've also adjusted the code that prints out the `helm template` command to include any equivalent `--api-versions` args when setting `.Capabilities.APIVersions` using one of the above methods.

To do this, I changed following functions/interfaces:

1. `hubble/hubble.go: k8sHubble.genManifests`: Adjust for breaking changes in internal/helm.go
2. `install/helm.go: K8sInstaller.generateManifests`: Pull api versions from CLI params if available, otherwise use client to auto-populate. If auto-populate fails, log a warning to the user.
3. `install/install.go: Parameters`:  Add `ApiVersions` parameter.
4. `install/install.go: k8sInstallerImplementation`: Add `ListApiResources` method signature.
5. `k8s/client.go: Client.ListApiResources`: Add `ListApiResources` implementation.
6. `internal/helm/helm.go: newClient`: Add argument for setting `client.APIVersions`.
7. `internal/helm/helm.go: GenManifests`: Add argument for passing api versions to `newClient`.
8. `internal/helm/helm.go: MergeVals`: Move helm template logging `PrintHelmTemplateCommand`
9. `internal/helm/helm.go: PrintHelmTemplateCommand`: New function for logging the `helm template` with a parameter for setting `--api-versions`.