### PR TITLE
Pin gcloud CLI version

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -62,6 +62,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@ee9693ff89cdf73862b8a13988f6a71070e8fc58
         with:
           project_id: ${{ secrets.GCP_PR_PROJECT_ID }}
+          version: "405.0.0"
 
       - name: Install gke-gcloud-auth-plugin
         run: |

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -60,6 +60,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@ee9693ff89cdf73862b8a13988f6a71070e8fc58
         with:
           project_id: ${{ secrets.GCP_PR_PROJECT_ID }}
+          version: "405.0.0"
 
       - name: Install gke-gcloud-auth-plugin
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -62,6 +62,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@ee9693ff89cdf73862b8a13988f6a71070e8fc58
         with:
           project_id: ${{ secrets.GCP_PR_PROJECT_ID }}
+          version: "405.0.0"
 
       - name: Install gke-gcloud-auth-plugin
         run: |


### PR DESCRIPTION
Cluster creation is failing with the latest CLI. Let's pin to an older version that's known to work until we update these workflows to be compatible with the latest CLI.

Ref: https://cloud.google.com/sdk/docs/release-notes#40500_2022-10-04
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>