### PR TITLE
defaults: Update cilium/json-mock to v1.3.3

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -68,7 +68,7 @@ const (
 
 	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c"
 	ConnectivityPerformanceImage     = "quay.io/cilium/network-perf:bf58fb8bc57c4933dfa6e2a9581d3925c0a0571e@sha256:9bef508b2dcaeb3e288a496b8d3f065e8636a4937ba3aebcb1732afffaccea34"
-	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be"
+	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0"
 	ConnectivityDNSTestServerImage   = "docker.io/coredns/coredns:1.9.4@sha256:b82e294de6be763f73ae71266c8f5466e7e03c69f3a1de96efd570284d35bb18"
 
 	ConfigMapName = "cilium-config"


### PR DESCRIPTION
cilium/json-mock:v1.3.2 fails to run on arm64:

    $ docker run -it quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
    exec /bin/bash: exec format error

The new build (v1.3.3) runs fine.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>