### PR TITLE
Enable network-perf for arm64

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -67,7 +67,7 @@ const (
 	ConnectivityCheckNamespace = "cilium-test"
 
 	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.5.0@sha256:7b286939730d8af1149ef88dba15739d8330bb83d7d9853a23e5ab4043e2d33c"
-	ConnectivityPerformanceImage     = "quay.io/cilium/network-perf:bf58fb8bc57c4933dfa6e2a9581d3925c0a0571e@sha256:9bef508b2dcaeb3e288a496b8d3f065e8636a4937ba3aebcb1732afffaccea34"
+	ConnectivityPerformanceImage     = "quay.io/cilium/network-perf:a816f935930cb2b40ba43230643da4d5751a5711@sha256:679d3a370c696f63884da4557a4466f3b5569b4719bb4f86e8aac02fbe390eea"
 	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0"
 	ConnectivityDNSTestServerImage   = "docker.io/coredns/coredns:1.9.4@sha256:b82e294de6be763f73ae71266c8f5466e7e03c69f3a1de96efd570284d35bb18"
 


### PR DESCRIPTION
Bump the network-perf image to enable arm64 in accordance with https://github.com/cilium/image-tools/pull/196.

Verified with https://github.com/nickolaev/vagrant-parallels-m1-k8s-cilium

Closes #1193.

Signed-off-by: Nikolay Nikolaev <nicknickolaev@gmail.com>