### PR TITLE
test/connectivity: fix goroutine leak

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -146,11 +146,11 @@ func (a *Action) Run(f func(*Action)) {
 
 		// Start flow listener in the background.
 		go func() {
+			defer wg.Done()
 			if err := a.followFlows(ctx, ready); err != nil {
 				a.Fatalf("Receiving flows from Hubble Relay: %s", err)
 			}
 			a.Debug("Receiving flows from Hubble Relay gracefully closed down.")
-			wg.Done()
 		}()
 
 		// Wait for at least one Hubble node to signal that it's ready so we don't


### PR DESCRIPTION
I realized after merging that there was a goroutine leak added in commit 7644dcc362. Need to move the `wg.Done()` to a defer to ensure it always is called.

Fixes: 7644dcc362
Signed-off-by: Casey Callendrello <cdc@isovalent.com>