### PR TITLE
install: allow for multiple roles and rolebindings per file

### DIFF
--- a/install/rbac.go
+++ b/install/rbac.go
@@ -100,7 +100,7 @@ func (k *K8sInstaller) NewClusterRoleBinding(crbName string) *rbacv1.ClusterRole
 	return &crb
 }
 
-func (k *K8sInstaller) NewRole(name string) *rbacv1.Role {
+func (k *K8sInstaller) NewRole(name string) []*rbacv1.Role {
 	var (
 		roleFileName string
 	)
@@ -120,12 +120,17 @@ func (k *K8sInstaller) NewRole(name string) *rbacv1.Role {
 		return nil
 	}
 
-	var cr rbacv1.Role
-	utils.MustUnmarshalYAML([]byte(rFile), &cr)
-	return &cr
+	roles := utils.MustUnmarshalYAMLMulti[*rbacv1.Role]([]byte(rFile))
+	out := []*rbacv1.Role{}
+	for _, role := range roles {
+		if role != nil {
+			out = append(out, role)
+		}
+	}
+	return out
 }
 
-func (k *K8sInstaller) NewRoleBinding(crbName string) *rbacv1.RoleBinding {
+func (k *K8sInstaller) NewRoleBinding(crbName string) []*rbacv1.RoleBinding {
 	var (
 		rbFileName string
 	)
@@ -144,7 +149,13 @@ func (k *K8sInstaller) NewRoleBinding(crbName string) *rbacv1.RoleBinding {
 	if !exists {
 		return nil
 	}
-	var crb rbacv1.RoleBinding
-	utils.MustUnmarshalYAML([]byte(rbFile), &crb)
-	return &crb
+
+	rbs := utils.MustUnmarshalYAMLMulti[*rbacv1.RoleBinding]([]byte(rbFile))
+	out := []*rbacv1.RoleBinding{}
+	for _, rb := range rbs {
+		if rb != nil {
+			out = append(out, rb)
+		}
+	}
+	return out
 }

--- a/internal/utils/yaml.go
+++ b/internal/utils/yaml.go
@@ -4,7 +4,12 @@
 package utils
 
 import (
+	"bytes"
+	"io"
+
 	"sigs.k8s.io/yaml"
+
+	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func MustUnmarshalYAML(y []byte, o interface{}, opts ...yaml.JSONOpt) {
@@ -13,4 +18,25 @@ func MustUnmarshalYAML(y []byte, o interface{}, opts ...yaml.JSONOpt) {
 		// Developer mistake, this shouldn't happen
 		panic(err)
 	}
+}
+
+// MustUnmarhsalYAMLMulti unmarshals a yaml document that contains
+// one or more of the same type.
+// Note that the returned list value may contain nils, due to a quirk in the
+// yaml decoder.
+func MustUnmarshalYAMLMulti[T any](y []byte) []T {
+	out := []T{}
+	reader := bytes.NewReader(y)
+	decoder := apiyaml.NewYAMLOrJSONDecoder(reader, 4096)
+	for {
+		var v T
+		if err := decoder.Decode(&v); err != nil {
+			if err == io.EOF {
+				break
+			}
+			panic(err)
+		}
+		out = append(out, v)
+	}
+	return out
 }


### PR DESCRIPTION
Rather than having to release cilium-cli for every new object, parse multiple roles and rolebindings from a single manifest file.

Signed-off-by: Casey Callendrello <cdc@isovalent.com>