### PR TITLE
connectivity: Send request to 1.1.1.1 over TCP/443 instead of TCP/80

### DIFF
--- a/connectivity/tests/cidr.go
+++ b/connectivity/tests/cidr.go
@@ -25,8 +25,8 @@ func (s *podToCIDR) Name() string {
 
 func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 	eps := []check.TestPeer{
-		check.HTTPEndpoint("cloudflare-1001", "http://1.0.0.1"),
-		check.HTTPEndpoint("cloudflare-1111", "http://1.1.1.1"),
+		check.HTTPEndpoint("cloudflare-1001", "https://1.0.0.1"),
+		check.HTTPEndpoint("cloudflare-1111", "https://1.1.1.1"),
 	}
 
 	for _, ep := range eps {


### PR DESCRIPTION
Since Cloudflare's server redirects all HTTP connections to HTTPS, requests against TCP/80 may be rate-limited and be the cause of our frequent flakes. Martynas suggested we try to request over TCP/443. Worth a shot!