### PR TITLE
sysdump: collect CiliumEgressGatewayPolicies

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -820,6 +820,10 @@ func (c *Client) ListCiliumEgressNATPolicies(ctx context.Context, opts metav1.Li
 	return c.CiliumClientset.CiliumV2alpha1().CiliumEgressNATPolicies().List(ctx, opts)
 }
 
+func (c *Client) ListCiliumEgressGatewayPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumEgressGatewayPolicyList, error) {
+	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().List(ctx, opts)
+}
+
 func (c *Client) ListCiliumLocalRedirectPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumLocalRedirectPolicyList, error) {
 	return c.CiliumClientset.CiliumV2().CiliumLocalRedirectPolicies(namespace).List(ctx, opts)
 }

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -42,6 +42,7 @@ type KubernetesClient interface {
 	ListCiliumClusterwideEnvoyConfigs(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumClusterwideEnvoyConfigList, error)
 	ListCiliumIdentities(ctx context.Context) (*ciliumv2.CiliumIdentityList, error)
 	ListCiliumEgressNATPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumEgressNATPolicyList, error)
+	ListCiliumEgressGatewayPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumEgressGatewayPolicyList, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 	ListCiliumEnvoyConfigs(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEnvoyConfigList, error)
 	ListCiliumLocalRedirectPolicies(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumLocalRedirectPolicyList, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -38,6 +38,7 @@ const (
 	ciliumDaemonSetFileName                  = "cilium-daemonset-<ts>.yaml"
 	ciliumIngressesFileName                  = "ciliumingresses-<ts>.yaml"
 	ciliumEgressNATPoliciesFileName          = "ciliumegressnatpolicies-<ts>.yaml"
+	ciliumEgressGatewayPoliciesFileName      = "ciliumegressgatewaypolicies-<ts>.yaml"
 	ciliumEndpointsFileName                  = "ciliumendpoints-<ts>.yaml"
 	ciliumEnvoyConfigsFileName               = "ciliumenvoyconfigs-<ts>.yaml"
 	ciliumEtcdSecretFileName                 = "cilium-etcd-secrets-secret-<ts>.yaml"

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -429,6 +429,20 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting Cilium Egress Gateway policies",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.ListCiliumEgressGatewayPolicies(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect Cilium Egress Gateway policies: %w", err)
+				}
+				if err := c.WriteYAML(ciliumEgressGatewayPoliciesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect Cilium Egress Gateway policies: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting Cilium local redirect policies",
 			Quick:       true,
 			Task: func(ctx context.Context) error {

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -296,6 +296,10 @@ func (c *fakeClient) ListCiliumEgressNATPolicies(ctx context.Context, opts metav
 	panic("implement me")
 }
 
+func (c *fakeClient) ListCiliumEgressGatewayPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumEgressGatewayPolicyList, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
Cilium `v1.12` introduced CEGP as alternative way of configuring EgressGW policies. Collect them in the sysdump.

Signed-off-by: Julian Wiedmann <jwi@isovalent.com>