### PR TITLE
connectivity: collect sysdump also on test setup failure

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cilium/cilium-cli/connectivity/filters"
 	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/sysdump"
 )
 
 // Action represents an individual action (e.g. a curl call) in a Scenario
@@ -186,7 +185,7 @@ func (a *Action) Run(f func(*Action)) {
 		}
 
 		if a.test.ctx.params.CollectSysdumpOnFailure {
-			a.collectSysdump()
+			a.test.collectSysdump()
 		}
 	}
 }
@@ -886,16 +885,4 @@ r:
 	}
 
 	a.Log()
-}
-
-func (a *Action) collectSysdump() {
-	collector, err := sysdump.NewCollector(a.test.ctx.K8sClient(), a.test.ctx.params.SysdumpOptions, time.Now(), a.test.ctx.version)
-	if err != nil {
-		a.Failf("Failed to create sysdump collector: %v", err)
-		return
-	}
-
-	if err = collector.Run(); err != nil {
-		a.Failf("Failed to collect sysdump: %v", err)
-	}
 }

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -303,6 +303,9 @@ func (ct *ConnectivityTest) Run(ctx context.Context) error {
 			if err := t.Run(ctx); err != nil {
 				// We know for sure we're inside a separate goroutine, so Fatal()
 				// is safe and will properly record failure statistics.
+				if t.ctx.params.CollectSysdumpOnFailure {
+					t.collectSysdump()
+				}
 				t.Fatalf("Running test %s: %s", t.Name(), err)
 			}
 

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -15,6 +15,7 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/sysdump"
 )
 
 const (
@@ -322,4 +323,16 @@ func (t *Test) failedActions() []*Action {
 
 func (t *Test) NodesWithoutCilium() []string {
 	return t.ctx.NodesWithoutCilium()
+}
+
+func (t *Test) collectSysdump() {
+	collector, err := sysdump.NewCollector(t.ctx.K8sClient(), t.ctx.params.SysdumpOptions, time.Now(), t.ctx.version)
+	if err != nil {
+		t.Failf("Failed to create sysdump collector: %v", err)
+		return
+	}
+
+	if err = collector.Run(); err != nil {
+		t.Failf("Failed to collect sysdump: %v", err)
+	}
 }


### PR DESCRIPTION
With this change, when --collect-sysdump-on-failure is set, the CLI will collect a sysdump also for the case where the test setup logic encounters an error.