### PR TITLE
connectivity/check: fix logging in non-verbose mode with timestamps

### DIFF
--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -37,28 +37,29 @@ func (ct *ConnectivityTest) Headerf(format string, a ...interface{}) {
 	fmt.Fprintf(ct.params.Writer, "\n"+format+"\n", a...)
 }
 
-// Log logs a message.
-func (ct *ConnectivityTest) Log(a ...interface{}) {
+// Timestamps logs the current timestamp.
+func (ct *ConnectivityTest) Timestamp() {
 	if ct.timestamp() {
 		fmt.Fprint(ct.params.Writer, timestamp())
 	}
+}
+
+// Log logs a message.
+func (ct *ConnectivityTest) Log(a ...interface{}) {
+	ct.Timestamp()
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Logf logs a formatted message.
 func (ct *ConnectivityTest) Logf(format string, a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Debug logs a debug message.
 func (ct *ConnectivityTest) Debug(a ...interface{}) {
 	if ct.debug() {
-		if ct.timestamp() {
-			fmt.Fprint(ct.params.Writer, timestamp())
-		}
+		ct.Timestamp()
 		fmt.Fprint(ct.params.Writer, debug+" ")
 		fmt.Fprintln(ct.params.Writer, a...)
 	}
@@ -67,9 +68,7 @@ func (ct *ConnectivityTest) Debug(a ...interface{}) {
 // Debugf logs a formatted debug message.
 func (ct *ConnectivityTest) Debugf(format string, a ...interface{}) {
 	if ct.debug() {
-		if ct.timestamp() {
-			fmt.Fprint(ct.params.Writer, timestamp())
-		}
+		ct.Timestamp()
 		fmt.Fprint(ct.params.Writer, debug+" ")
 		fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 	}
@@ -77,72 +76,56 @@ func (ct *ConnectivityTest) Debugf(format string, a ...interface{}) {
 
 // Info logs an informational message.
 func (ct *ConnectivityTest) Info(a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, info+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Infof logs a formatted informational message.
 func (ct *ConnectivityTest) Infof(format string, a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, info+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Warn logs a warning message.
 func (ct *ConnectivityTest) Warn(a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, warn+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Warnf logs a formatted warning message.
 func (ct *ConnectivityTest) Warnf(format string, a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, warn+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Fail logs a failure message.
 func (ct *ConnectivityTest) Fail(a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fail+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Failf logs a formatted failure message.
 func (ct *ConnectivityTest) Failf(format string, a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fail+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Fatal logs an error.
 func (ct *ConnectivityTest) Fatal(a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fatal+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Fatalf logs a formatted error.
 func (ct *ConnectivityTest) Fatalf(format string, a ...interface{}) {
-	if ct.timestamp() {
-		fmt.Fprint(ct.params.Writer, timestamp())
-	}
+	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fatal+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -182,11 +182,14 @@ func (t *Test) Run(ctx context.Context) error {
 	// Store start time of the Test.
 	t.startTime = time.Now()
 
-	t.ctx.Log()
 	t.ctx.Logf("[=] Test [%s]", t.Name())
 
 	if err := t.setup(ctx); err != nil {
 		return fmt.Errorf("setting up test: %w", err)
+	}
+
+	if t.logBuf != nil {
+		t.ctx.Timestamp()
 	}
 
 	for s := range t.scenarios {
@@ -202,6 +205,10 @@ func (t *Test) Run(ctx context.Context) error {
 		t.Logf("[-] Scenario [%s]", t.scenarioName(s))
 
 		s.Run(ctx, t)
+	}
+
+	if t.logBuf != nil {
+		fmt.Fprintln(t.ctx.params.Writer)
 	}
 
 	// Don't add any more code here, as Scenario.Run() can call Fatal() and


### PR DESCRIPTION
Before (notice the timestamp logs at end of line of the progress indicators `.` instead of at the start of line):

```
[2022-11-28T13:10:25+01:00] 🏃 Running tests...
[2022-11-28T13:10:25+01:00]
[2022-11-28T13:10:25+01:00] [=] Test [no-policies]
....................................[2022-11-28T13:10:32+01:00]
[2022-11-28T13:10:32+01:00] [=] Test [allow-all-except-world]
..............[2022-11-28T13:10:38+01:00]
[2022-11-28T13:10:38+01:00] [=] Test [client-ingress]
..[2022-11-28T13:10:43+01:00]
[2022-11-28T13:10:43+01:00] [=] Test [all-ingress-deny]
........[2022-11-28T13:11:10+01:00]
```

After:

```
[2022-11-28T13:44:00+01:00] 🏃 Running tests...
[2022-11-28T13:44:00+01:00] [=] Test [no-policies]
[2022-11-28T13:44:00+01:00] ....................................
[2022-11-28T13:44:06+01:00] [=] Test [allow-all-except-world]
[2022-11-28T13:44:08+01:00] ..............
[2022-11-28T13:44:12+01:00] [=] Test [client-ingress]
[2022-11-28T13:44:13+01:00] ..
[2022-11-28T13:44:18+01:00] [=] Test [all-ingress-deny]
[2022-11-28T13:44:20+01:00] ........
```

Fixes: f232341d4e36 ("connectivity: Add -t to prefix log msg with timestamp")