### PR TITLE
status: Exclude non-running pods from total Cluster Pods count

### DIFF
--- a/status/k8s.go
+++ b/status/k8s.go
@@ -178,7 +178,7 @@ func (k *K8sStatusCollector) podCount(ctx context.Context, status *Status) error
 
 	if pods != nil && len(pods.Items) != 0 {
 		for _, pod := range pods.Items {
-			if !pod.Spec.HostNetwork {
+			if !pod.Spec.HostNetwork && pod.Status.Phase == corev1.PodRunning {
 				numberAllPod++
 			}
 		}


### PR DESCRIPTION
Since CEPs are cleaned up for Completed Pods, these pods should not be considered for total Cluster Pods count.

Fixes: #1235

Signed-off-by: flxman <felix.farjsjo@gmail.com>