### PR TITLE
connectivity, install: delete pods before deleting namespace

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -13,7 +13,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
   pull_request_target: {}
@@ -175,7 +175,7 @@ jobs:
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed
         if: ${{ success() }}
         env:
-          timeout: 2m
+          timeout: 5m
         run: |
           kubectl create configmap cilium-cli-test-script-uninstall -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/eks-uninstall.sh
           helm install .github/cilium-cli-test-job-chart \
@@ -184,7 +184,7 @@ jobs:
             --set cluster_name=${{ env.clusterName }} \
             --set job_name=cilium-cli-uninstall \
             --set test_script_cm=cilium-cli-test-script-uninstall
-          
+
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli-uninstall --for=condition=complete --timeout=${{ env.timeout }} &
           complete_pid=$!

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -13,7 +13,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
   pull_request_target: {}
@@ -175,7 +175,7 @@ jobs:
       - name: Uninstall and make sure the 'aws-node' DaemonSet blocking nodeSelector was removed
         if: ${{ success() }}
         env:
-          timeout: 2m
+          timeout: 5m
         run: |
           kubectl create configmap cilium-cli-test-script-uninstall -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/eks-uninstall.sh
           helm install .github/cilium-cli-test-job-chart \
@@ -184,7 +184,7 @@ jobs:
             --set cluster_name=${{ env.clusterName }} \
             --set job_name=cilium-cli-uninstall \
             --set test_script_cm=cilium-cli-test-script-uninstall
-          
+
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli-uninstall --for=condition=complete --timeout=${{ env.timeout }} &
           complete_pid=$!

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -526,6 +526,9 @@ func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*se
 
 // UninstallResources deletes all k8s resources created by the connectivity tests.
 func (ct *ConnectivityTest) UninstallResources(ctx context.Context, wait bool) {
+	ct.Logf("🔥 Deleting pods in %s namespace...", ct.params.TestNamespace)
+	ct.client.DeletePodCollection(ctx, ct.params.TestNamespace, metav1.DeleteOptions{}, metav1.ListOptions{})
+
 	ct.Logf("🔥 Deleting %s namespace...", ct.params.TestNamespace)
 	ct.client.DeleteNamespace(ctx, ct.params.TestNamespace, metav1.DeleteOptions{})
 

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -524,6 +524,29 @@ func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*se
 	return minVersion, nil
 }
 
+// UninstallResources deletes all k8s resources created by the connectivity tests.
+func (ct *ConnectivityTest) UninstallResources(ctx context.Context, wait bool) {
+	ct.Logf("🔥 Deleting %s namespace...", ct.params.TestNamespace)
+	ct.client.DeleteNamespace(ctx, ct.params.TestNamespace, metav1.DeleteOptions{})
+
+	// To avoid cases where test pods are stuck in terminating state because
+	// cni (cilium) pods were deleted sooner, wait until test pods are deleted
+	// before moving onto deleting cilium pods.
+	if wait {
+		ct.Logf("⌛ Waiting for %s namespace to be terminated...", ct.params.TestNamespace)
+		for {
+			// Wait for the test namespace to be terminated. Subsequent connectivity checks would fail
+			// if the test namespace is in Terminating state.
+			_, err := ct.client.GetNamespace(ctx, ct.params.TestNamespace, metav1.GetOptions{})
+			if err == nil {
+				time.Sleep(defaults.WaitRetryInterval)
+			} else {
+				break
+			}
+		}
+	}
+}
+
 func (ct *ConnectivityTest) RandomClientPod() *Pod {
 	for _, p := range ct.clientPods {
 		return &p

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -48,25 +48,8 @@ func (k *K8sUninstaller) Log(format string, a ...interface{}) {
 func (k *K8sUninstaller) Uninstall(ctx context.Context) error {
 	k.autodetect(ctx)
 
-	for _, n := range []string{k.params.TestNamespace, defaults.IngressSecretsNamespace} {
-		k.Log("🔥 Deleting %s namespace...", n)
-		k.client.DeleteNamespace(ctx, n, metav1.DeleteOptions{})
-	}
-
-	// To avoid cases where test pods are stuck in terminating state because
-	// cni (cilium) pods were deleted sooner, wait until test pods are deleted
-	// before moving onto deleting cilium pods.
-	if k.params.Wait {
-		k.Log("⌛ Waiting for %s namespace to be terminated...", k.params.TestNamespace)
-	retryNamespace:
-		// Wait for the test namespace to be terminated. Subsequent connectivity checks would fail
-		// if the test namespace is in Terminating state.
-		_, err := k.client.GetNamespace(ctx, k.params.TestNamespace, metav1.GetOptions{})
-		if err == nil {
-			time.Sleep(defaults.WaitRetryInterval)
-			goto retryNamespace
-		}
-	}
+	k.Log("🔥 Deleting %s namespace...", defaults.IngressSecretsNamespace)
+	k.client.DeleteNamespace(ctx, defaults.IngressSecretsNamespace, metav1.DeleteOptions{})
 
 	k.Log("🔥 Deleting Service accounts...")
 	k.client.DeleteServiceAccount(ctx, k.params.Namespace, defaults.AgentServiceAccountName, metav1.DeleteOptions{})


### PR DESCRIPTION
This should help to work around an issue we're seeing in cilium/cilium CI where deleting the cilium-test namespace times out, see https://github.com/cilium/cilium/issues/22368