### PR TITLE
ci, make: allow to build release as root user

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.19.3
 
       - name: Generate the artifacts
-        run: make release
+        run: RELEASE_UID=0 RELEASE_GID=0 RELEASE_USER= RELEASE_GROUP= make release
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
In local environments we usually want to keep the current behavior (i.e. release artifacts owned by the uid/gid of the user invoking `make release`). However in GitHub actions, the command recently started failing with:

    addgroup: gid '123' in use

(see https://github.com/cilium/cilium-cli/actions/runs/3572725726/jobs/6006032172)

In GitHub actions, the ownership of the release artifacts shouldn't matter since they're ephemeral anyway. We can now use the following command in the release action:

    RELEASE_UID=0 RELEASE_GID=0 RELEASER_USER= RELEASER_GROUP= make