### PR TITLE
Makefile: Fix potential uid/gid collision by using setpriv

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.19.3
 
       - name: Generate the artifacts
-        run: RELEASE_UID=0 RELEASE_GID=0 RELEASE_USER= RELEASE_GROUP= make release
+        run: make release
 
       - name: Create Release
         id: create_release

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,6 @@ VERSION=$(shell git describe --tags --always)
 TEST_TIMEOUT ?= 5s
 RELEASE_UID ?= $(shell id -u)
 RELEASE_GID ?= $(shell id -g)
-RELEASE_USER ?= release
-RELEASE_GROUP ?= release
 
 GOLANGCILINT_WANT_VERSION = 1.50.1
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
@@ -30,10 +28,8 @@ release:
 		--rm \
 		--workdir /cilium \
 		--volume `pwd`:/cilium docker.io/library/golang:1.19.3-alpine3.16 \
-		sh -c "apk add --no-cache make git && \
-			{ [ $(RELEASE_GID) -eq 0 ] || addgroup -g $(RELEASE_GID) $(RELEASE_GROUP); } && \
-			{ [ $(RELEASE_UID) -eq 0 ] || adduser -u $(RELEASE_UID) -D -G $(RELEASE_GROUP) $(RELEASE_USER); } && \
-			su $(RELEASE_USER) -c 'make local-release VERSION=${VERSION}'"
+		sh -c "apk add --no-cache setpriv make git && \
+			/usr/bin/setpriv --reuid=$(RELEASE_UID) --regid=$(RELEASE_GID) --clear-groups make GOCACHE=/tmp/gocache local-release"
 
 local-release: clean
 	set -o errexit; \
@@ -55,9 +51,7 @@ local-release: clean
 		for ARCH in $$ARCHS; do \
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
-			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) \
-				$(if $(GO_TAGS),-tags $(GO_TAGS)) \
-				-buildvcs=false \
+			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
 				-ldflags "-w -s -X 'github.com/cilium/cilium-cli/internal/cli/cmd.Version=${VERSION}'" \
 				-o release/$$OS/$$ARCH/$(TARGET)$$EXT ./cmd/cilium; \
 			tar -czf release/$(TARGET)-$$OS-$$ARCH.tar.gz -C release/$$OS/$$ARCH $(TARGET)$$EXT; \


### PR DESCRIPTION
Follows https://github.com/cilium/hubble/pull/821

The release build should run with the same numeric user and group id as the caller of the Makefile. This solves two problems:

1. The generated artefacts should be owned by the user who invoked the Makefile
2. `go build -buildvcs=true` (the default since Go 1.18) invokes git, and git requires that the .git folder is owned by the user invoking it.

Previously, we achieved this by creating a new user and group inside the container with the wanted uid/gid. The problem with that approach is it fails if the uid/gid is already taken (such as e.g. gid 123, which seems to be used by the GitHub runner as of recently). Therefore, instead of trying to create a new user, this commit now uses `setpriv` from util-linux to force the `make` process (and all its children) to run as the RELEASE_{UID/GID}. This ensures that both `git` can access the `.git` directory owned by the host user, and that the host user can access the generated artifacts. One limitation of `setpriv` is that it runs the child process without an accessible `$HOME` directory, which `go build` needs for the GOCACHE. To solve this for now, we point it to a temporary directory. In the future, we could consider using a GOCACHE owned by the host, to allow cache-reuse across builds.