### PR TITLE
clustermesh: use Cilium version extracted from helm secret if available

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -203,6 +203,7 @@ type k8sInstallerImplementation interface {
 	DeleteIngressClass(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
 	ListAPIResources(ctx context.Context) ([]string, error)
+	GetHelmState(ctx context.Context, namespace string, secretName string) (*helm.State, error)
 }
 
 type K8sInstaller struct {

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium-cli/clustermesh"
+	"github.com/cilium/cilium-cli/defaults"
 )
 
 func newCmdClusterMesh() *cobra.Command {
@@ -297,6 +298,8 @@ func newCmdExternalWorkloadInstall() *cobra.Command {
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Cilium agent config entries (key=value)")
 	cmd.Flags().IntVar(&params.Retries, "retries", 4, "Number of Cilium agent start retries")
+
+	cmd.Flags().StringVar(&params.HelmValuesSecretName, "helm-values-secret-name", defaults.HelmValuesSecretName, "Secret name to store the auto-generated helm values file. The namespace is the same as where Cilium will be installed")
 
 	return cmd
 }


### PR DESCRIPTION
This fixes the following error in the external workload workflow in cilium/cilium CI:

    Error: Unable to create external workload install script: No Major.Minor.Patch elements found

See https://github.com/cilium/cilium/pull/22441#issuecomment-1332086537

For https://github.com/cilium/cilium/issues/22451
Fixes: dcfb77269f48 ("clustermesh: Fix --bpf-lb-sock on < 1.12")