### PR TITLE
status: Include pending pods in total Cluster Pods count

### DIFF
--- a/status/k8s.go
+++ b/status/k8s.go
@@ -178,7 +178,7 @@ func (k *K8sStatusCollector) podCount(ctx context.Context, status *Status) error
 
 	if pods != nil && len(pods.Items) != 0 {
 		for _, pod := range pods.Items {
-			if !pod.Spec.HostNetwork && pod.Status.Phase == corev1.PodRunning {
+			if !pod.Spec.HostNetwork && (pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending) {
 				numberAllPod++
 			}
 		}


### PR DESCRIPTION
After some testing after merging #1236 I realized that CEPs are created already for Pods in Pending phase (which makes total sense). Due to this, these pods should be included in the total Cluster Pod count so that `cilium status` shows correct output. Without this fix, if you have 2 pods stuck in Pending, `cilium status` will output e.g. 131/129 pods managed by cilium. 

Signed-off-by: flxman <felix.farjsjo@gmail.com>