### PR TITLE
workflows: Bump timeout for EKS workflow

### DIFF
--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -35,7 +35,7 @@ jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
We've been hitting the timeout in the master CI recently, probably because the connectivity tests are now longer:
- https://github.com/cilium/cilium-cli/actions/runs/3606335838/jobs/6077572819
- https://github.com/cilium/cilium-cli/actions/runs/3599598273/jobs/6063381447
- https://github.com/cilium/cilium-cli/actions/runs/3595665407/jobs/6055434191

Time to bump it.