### PR TITLE
workflows: Collect sysdump immediately after test failures

### DIFF
--- a/.github/in-cluster-test-scripts/aks.sh
+++ b/.github/in-cluster-test-scripts/aks.sh
@@ -16,7 +16,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -28,7 +28,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows \
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure \
   --test '!dns-only,!to-fqdns,!client-egress-l7,!health'
   # workaround for nslookup issues in tunnel mode causing tests to fail reliably
   # TODO: remove once:

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -26,7 +26,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/external-workloads.sh
+++ b/.github/in-cluster-test-scripts/external-workloads.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -23,7 +23,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -56,4 +56,5 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium --context "${CONTEXT1}" connectivity test --debug --multi-cluster "${CONTEXT2}" --test '!/*-deny,!/pod-to-.*-nodeport' --all-flows
+cilium --context "${CONTEXT1}" connectivity test --debug --multi-cluster "${CONTEXT2}" --test '!/*-deny,!/pod-to-.*-nodeport' \
+  --all-flows --collect-sysdump-on-failure

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -75,7 +75,8 @@ jobs:
       - name: Connectivity Test
         run: |
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
-          cilium connectivity test --debug --all-flows --test-namespace test-namespace
+          cilium connectivity test --debug --all-flows --test-namespace test-namespace \
+            --collect-sysdump-on-failure
 
       - name: Uninstall cilium
         run: |
@@ -98,7 +99,8 @@ jobs:
 
       - name: Connectivity test
         run: |
-          cilium connectivity test --debug --force-deploy --all-flows --test-namespace another-test-namespace
+          cilium connectivity test --debug --force-deploy --all-flows --test-namespace another-test-namespace \
+            --collect-sysdump-on-failure
 
       - name: Cleanup
         if: ${{ always() }}


### PR DESCRIPTION
A new `-collect-sysdump-on-failure` option was recently introduced in the cilium connectivity test command by Jibi to collect a sysdump every time a connectivity test case fails, immediately after the failure. That ensures we get the state as it was at the time of the failure and not as it is only at the end of the full workflows.

This flag was tested on the cilium/cilium AKS workflows and this commit now extends it to all workflows in cilium/cilium-cli.