### PR TITLE
Make pod to world test configurable

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -50,6 +50,7 @@ type Parameters struct {
 	DNSTestServerImage    string
 	Datapath              bool
 	AgentPodSelector      string
+	ExternalTarget        string
 
 	K8sVersion           string
 	HelmChartDirectory   string

--- a/connectivity/manifests/client-egress-l7-http-named-port.yaml
+++ b/connectivity/manifests/client-egress-l7-http-named-port.yaml
@@ -1,5 +1,5 @@
 ---
-# client2 is allowed to contact one.one.one.one and the echo Pod
+# client2 is allowed to contact {{.ExternalTarget}} and the echo Pod
 # on port http-8080. HTTP introspection is enabled for client2.
 # The toFQDNs section relies on DNS introspection being performed by
 # the client-egress-only-dns policy.
@@ -8,7 +8,7 @@ kind: CiliumNetworkPolicy
 metadata:
   name: client-egress-l7-http-named-port
 spec:
-  description: "Allow GET one.one.one.one:80/ and GET <echo>:<http-80>/ from client2"
+  description: "Allow GET {{.ExternalTarget}}:80/ and GET <echo>:<http-80>/ from client2"
   endpointSelector:
     matchLabels:
       other: client
@@ -25,9 +25,9 @@ spec:
         http:
         - method: "GET"
           path: "/"
-  # Allow GET / requests, only towards one.one.one.one.
+  # Allow GET / requests, only towards {{.ExternalTarget}}.
   - toFQDNs:
-    - matchName: "one.one.one.one"
+    - matchName: "{{.ExternalTarget}}"
     toPorts:
     - ports:
       - port: "80"

--- a/connectivity/manifests/client-egress-l7-http.yaml
+++ b/connectivity/manifests/client-egress-l7-http.yaml
@@ -1,5 +1,5 @@
 ---
-# client2 is allowed to contact one.one.one.one/ on port 80 and the echo Pod
+# client2 is allowed to contact {{.ExternalTarget}}/ on port 80 and the echo Pod
 # on port 8080. HTTP introspection is enabled for client2.
 # The toFQDNs section relies on DNS introspection being performed by
 # the client-egress-only-dns policy.
@@ -8,7 +8,7 @@ kind: CiliumNetworkPolicy
 metadata:
   name: client-egress-l7-http
 spec:
-  description: "Allow GET one.one.one.one:80/ and GET <echo>:8080/ from client2"
+  description: "Allow GET {{.ExternalTarget}}:80/ and GET <echo>:8080/ from client2"
   endpointSelector:
     matchLabels:
       other: client
@@ -25,9 +25,9 @@ spec:
         http:
         - method: "GET"
           path: "/"
-  # Allow GET / requests, only towards one.one.one.one.
+  # Allow GET / requests, only towards {{.ExternalTarget}}.
   - toFQDNs:
-    - matchName: "one.one.one.one"
+    - matchName: "{{.ExternalTarget}}"
     toPorts:
     - ports:
       - port: "80"

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: client-egress-to-fqdns-one-one-one-one
+  name: client-egress-to-fqdns-{{.ExternalTarget}}
 spec:
   endpointSelector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
         - method: "GET"
           path: "/"
     toFQDNs:
-    - matchName: "one.one.one.one"
+    - matchName: "{{.ExternalTarget}}"
   - toPorts:
     - ports:
       - port: "53"

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -128,6 +128,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	cmd.Flags().BoolVarP(&params.Timestamp, "timestamp", "t", false, "Show timestamp in messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
+	cmd.Flags().StringVar(&params.ExternalTarget, "external-target", "one.one.one.one", "Domain name to use as external target in connectivity tests")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")

--- a/internal/utils/template.go
+++ b/internal/utils/template.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// RenderTemplate executes temp with data and returns the result
+func RenderTemplate(temp string, data any) (string, error) {
+	tm, err := template.New("template").Parse(temp)
+	if err != nil {
+		return "", err
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := tm.Execute(buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}


### PR DESCRIPTION
A configurable domain allows us to run the PodToWord test in an environment where external traffic only allowed for specific domains. This also gives us the ability to swap the domain in test environments to better handle flaky tests.
