### PR TITLE
workflows: Bump timeout for External Workload workflow

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -38,7 +38,7 @@ jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
We [sometimes reach the 30min timeout](https://github.com/cilium/cilium-cli/actions/runs/3580207167) on the External Workload workflow. This commit bumps the timeout to 45min.