### PR TITLE
.github: update get-kubeconfig.sh for k8s 1.24

### DIFF
--- a/.github/get-kubeconfig.sh
+++ b/.github/get-kubeconfig.sh
@@ -18,7 +18,7 @@
 # https://github.com/gravitational/teleport/blob/master/examples/k8s-auth/get-kubeconfig.sh
 
 # This script creates a new k8s Service Account and generates a kubeconfig with
-# its credentials. This Service Account is a cluster admin
+# its credentials. This Service Account has all the necessary permissions for
 # Teleport. The kubeconfig is written in the current directory.
 #
 # You can override the default namespace "teleport" using the
@@ -59,24 +59,73 @@ metadata:
   namespace: ${NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: teleport-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - selfsubjectaccessreviews
+  - selfsubjectrulesreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubectl-test-crb
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
-  apiGroup: ""
 subjects:
 - kind: ServiceAccount
   name: ${SA}
   namespace: ${NAMESPACE}
 EOF
-# Get the service account token and CA cert.
-SA_SECRET_NAME=$(kubectl get -n "${NAMESPACE}" sa/"${SA}" -o "jsonpath={.secrets[0]..name}")
+
+# Checks if secret entry was defined for Service account. If defined it means that Kubernetes server has a
+# version below 1.24, otherwise one must manually create the secret and bind it to the Service account to have a non expiring token.
+# After Kubernetes v1.24 Service accounts no longer generate automatic tokens/secrets.
+# We can use kubectl create token but the token has a expiration time.
+# https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes
+SA_SECRET_NAME=$(kubectl get -n ${NAMESPACE} sa/${SA} -o "jsonpath={.secrets[0]..name}")
+if [ -z $SA_SECRET_NAME ]
+then
+# Create the secret and bind it to the desired SA
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: ${SA}
+  namespace: ${NAMESPACE}
+  annotations:
+    kubernetes.io/service-account.name: "${SA}"
+EOF
+
+SA_SECRET_NAME=${SA}
+fi
+
 # Note: service account token is stored base64-encoded in the secret but must
 # be plaintext in kubeconfig.
-SA_TOKEN=$(kubectl get -n "${NAMESPACE}" secrets/"${SA_SECRET_NAME}" -o "jsonpath={.data['token']}" | base64 ${BASE64_DECODE_FLAG})
-CA_CERT=$(kubectl get -n "${NAMESPACE}" secrets/"${SA_SECRET_NAME}" -o "jsonpath={.data['ca\.crt']}")
+SA_TOKEN=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o "jsonpath={.data['token']}" | base64 ${BASE64_DECODE_FLAG})
+CA_CERT=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o "jsonpath={.data['ca\.crt']}")
 
 # Extract cluster IP from the current context
 CURRENT_CONTEXT=$(kubectl config current-context)
@@ -94,13 +143,13 @@ clusters:
 contexts:
 - context:
     cluster: ${CURRENT_CLUSTER}
-    user: ${SA}
+    user: ${CURRENT_CLUSTER}-${SA}
   name: ${CURRENT_CONTEXT}
 current-context: ${CURRENT_CONTEXT}
 kind: Config
 preferences: {}
 users:
-- name: ${SA}
+- name: ${CURRENT_CLUSTER}-${SA}
   user:
     token: ${SA_TOKEN}
 EOF
@@ -111,5 +160,8 @@ Done!
 Copy the generated kubeconfig file to your Teleport Proxy server, and set the
 kubeconfig_file parameter in your teleport.yaml config file to point to this
 kubeconfig file.
+
+If you need access to multiple kubernetes clusters, you can generate additional
+kubeconfig files using this script and then merge them using merge-kubeconfigs.sh.
 
 Note: Kubernetes RBAC rules for Teleport were created, you won't need to create them manually."


### PR DESCRIPTION
Merge latest changes from upstream
https://github.com/gravitational/teleport/blob/76d6dc82151c2ba977a119e69038a2f5bf6e8ef7/examples/k8s-auth/get-kubeconfig.sh for k8s 1.24 compatibility.

Fixes #1273