### PR TITLE
connectivity: allow to specify maximum request and connect timeout

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -57,6 +57,9 @@ type Parameters struct {
 
 	DeleteCiliumOnNodes []string
 
+	ConnectTimeout time.Duration
+	RequestTimeout time.Duration
+
 	CollectSysdumpOnFailure bool
 	SysdumpOptions          sysdump.Options
 }

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -551,6 +552,25 @@ func (ct *ConnectivityTest) UninstallResources(ctx context.Context, wait bool) {
 			}
 		}
 	}
+}
+
+func (ct *ConnectivityTest) CurlCommand(peer TestPeer, opts ...string) []string {
+	cmd := []string{"curl",
+		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}",
+		"--silent", "--fail", "--show-error",
+		"--connect-timeout", "5",
+		"--output", "/dev/null",
+	}
+	cmd = append(cmd, opts...)
+	cmd = append(cmd, fmt.Sprintf("%s://%s%s",
+		peer.Scheme(),
+		net.JoinHostPort(peer.Address(), fmt.Sprint(peer.Port())),
+		peer.Path()))
+	return cmd
+}
+
+func (ct *ConnectivityTest) PingCommand(peer TestPeer) []string {
+	return []string{"ping", "-w", "3", "-c", "1", peer.Address()}
 }
 
 func (ct *ConnectivityTest) RandomClientPod() *Pod {

--- a/connectivity/tests/cidr.go
+++ b/connectivity/tests/cidr.go
@@ -28,14 +28,15 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 		check.HTTPEndpoint("cloudflare-1001", "https://1.0.0.1"),
 		check.HTTPEndpoint("cloudflare-1111", "https://1.1.1.1"),
 	}
+	ct := t.Context()
 
 	for _, ep := range eps {
 		var i int
-		for _, src := range t.Context().ClientPods() {
+		for _, src := range ct.ClientPods() {
 			src := src // copy to avoid memory aliasing when using reference
 
 			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, curl(ep))
+				a.ExecInPod(ctx, ct.CurlCommand(ep))
 
 				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
 					RSTAllowed: true,

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -25,11 +25,12 @@ func (s *clientToClient) Name() string {
 
 func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 	var i int
+	ct := t.Context()
 
-	for _, src := range t.Context().ClientPods() {
+	for _, src := range ct.ClientPods() {
 		src := src // copy to avoid memory aliasing when using reference
 
-		for _, dst := range t.Context().ClientPods() {
+		for _, dst := range ct.ClientPods() {
 			if src.Pod.Status.PodIP == dst.Pod.Status.PodIP {
 				// Currently we only get flows once per IP,
 				// skip pings to self.
@@ -39,7 +40,7 @@ func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 			dst := dst // copy to avoid memory aliasing when using reference
 
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &src, &dst).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ping(dst))
+				a.ExecInPod(ctx, ct.PingCommand(dst))
 
 				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -3,13 +3,6 @@
 
 package tests
 
-import (
-	"fmt"
-	"net"
-
-	"github.com/cilium/cilium-cli/connectivity/check"
-)
-
 type labelsContainer interface {
 	HasLabel(key, value string) bool
 }
@@ -47,23 +40,4 @@ func hasAllLabels(labelsContainer labelsContainer, filters map[string]string) bo
 		}
 	}
 	return true
-}
-
-func curl(peer check.TestPeer, opts ...string) []string {
-	cmd := []string{"curl",
-		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}",
-		"--silent", "--fail", "--show-error",
-		"--connect-timeout", "5",
-		"--output", "/dev/null",
-	}
-	cmd = append(cmd, opts...)
-	cmd = append(cmd, fmt.Sprintf("%s://%s%s",
-		peer.Scheme(),
-		net.JoinHostPort(peer.Address(), fmt.Sprint(peer.Port())),
-		peer.Path()))
-	return cmd
-}
-
-func ping(peer check.TestPeer) []string {
-	return []string{"ping", "-w", "3", "-c", "1", peer.Address()}
 }

--- a/connectivity/tests/encryption.go
+++ b/connectivity/tests/encryption.go
@@ -34,10 +34,11 @@ func (s *podToPodEncryption) Name() string {
 }
 
 func (s *podToPodEncryption) Run(ctx context.Context, t *check.Test) {
-	client := t.Context().RandomClientPod()
+	ct := t.Context()
+	client := ct.RandomClientPod()
 
 	var server check.Pod
-	for _, pod := range t.Context().EchoPods() {
+	for _, pod := range ct.EchoPods() {
 		// Make sure that the server pod is on another node than client
 		if pod.Pod.Status.HostIP != client.Pod.Status.HostIP {
 			server = pod
@@ -49,14 +50,14 @@ func (s *podToPodEncryption) Run(ctx context.Context, t *check.Test) {
 
 	// clientHost is a pod running on the same node as the client pod, just in
 	// the host netns.
-	clientHost := t.Context().HostNetNSPodsByNode()[client.Pod.Spec.NodeName]
+	clientHost := ct.HostNetNSPodsByNode()[client.Pod.Spec.NodeName]
 
 	// Determine on which netdev iface to capture pkts. In the case of tunneling,
 	// we don't expect to see unencrypted pkts on a corresponding tunneling iface,
 	// so the choice is obvious. In the native routing mode, we run
 	// "ip route get $SERVER_POD_IP" from the client pod's node.
 	iface := ""
-	tunnelFeat, ok := t.Context().Feature(check.FeatureTunnel)
+	tunnelFeat, ok := ct.Feature(check.FeatureTunnel)
 	if ok && tunnelFeat.Enabled {
 		iface = "cilium_" + tunnelFeat.Mode // E.g. cilium_vxlan
 	} else {
@@ -124,7 +125,7 @@ func (s *podToPodEncryption) Run(ctx context.Context, t *check.Test) {
 
 	// Curl the server from the client to generate some traffic
 	t.NewAction(s, "curl", client, server).Run(func(a *check.Action) {
-		a.ExecInPod(ctx, curl(server))
+		a.ExecInPod(ctx, ct.CurlCommand(server))
 	})
 
 	// Wait until tcpdump has exited

--- a/connectivity/tests/externalworkload.go
+++ b/connectivity/tests/externalworkload.go
@@ -22,13 +22,14 @@ func (s *podToExternalWorkload) Name() string {
 
 func (s *podToExternalWorkload) Run(ctx context.Context, t *check.Test) {
 	var i int
+	ct := t.Context()
 
-	for _, pod := range t.Context().ClientPods() {
+	for _, pod := range ct.ClientPods() {
 		pod := pod // copy to avoid memory aliasing when using reference
 
-		for _, wl := range t.Context().ExternalWorkloads() {
+		for _, wl := range ct.ExternalWorkloads() {
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, wl).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ping(wl))
+				a.ExecInPod(ctx, ct.PingCommand(wl))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -100,21 +100,20 @@ func (s *podToPodWithEndpoints) Run(ctx context.Context, t *check.Test) {
 				continue
 			}
 
-			if s.method == "" {
-				curlEndpoints(ctx, s, t, fmt.Sprintf("curl-%d", i), &client, echo)
-			} else {
-				curlEndpoints(ctx, s, t, fmt.Sprintf("curl-%d", i), &client, echo, "-X", s.method)
-			}
+			s.curlEndpoints(ctx, t, fmt.Sprintf("curl-%d", i), &client, echo)
 
 			i++
 		}
 	}
 }
 
-func curlEndpoints(ctx context.Context, s check.Scenario, t *check.Test,
-	name string, client *check.Pod, echo check.TestPeer, curlOpts ...string) {
-
+func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test, name string,
+	client *check.Pod, echo check.TestPeer) {
 	baseURL := fmt.Sprintf("%s://%s:%d", echo.Scheme(), echo.Address(), echo.Port())
+	var curlOpts []string
+	if s.method != "" {
+		curlOpts = append(curlOpts, "-X", s.method)
+	}
 
 	// Manually construct an HTTP endpoint for each API endpoint.
 	for _, path := range []string{"public", "private"} {

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -34,25 +34,26 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	}
 
 	var i int
+	ct := t.Context()
 
-	for _, client := range t.Context().ClientPods() {
+	for _, client := range ct.ClientPods() {
 		client := client // copy to avoid memory aliasing when using reference
 
 		// With http, over port 80.
 		t.NewAction(s, fmt.Sprintf("http-to-one-one-one-one-%d", i), &client, http).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(http))
+			a.ExecInPod(ctx, ct.CurlCommand(http))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443.
 		t.NewAction(s, fmt.Sprintf("https-to-one-one-one-one-%d", i), &client, https).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(https))
+			a.ExecInPod(ctx, ct.CurlCommand(https))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443, index.html.
 		t.NewAction(s, fmt.Sprintf("https-to-one-one-one-one-index-%d", i), &client, httpsindex).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(httpsindex))
+			a.ExecInPod(ctx, ct.CurlCommand(httpsindex))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
@@ -82,12 +83,14 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 	}
 
 	var i int
-	for _, client := range t.Context().ClientPods() {
+	ct := t.Context()
+
+	for _, client := range ct.ClientPods() {
 		client := client // copy to avoid memory aliasing when using reference
 
 		// With https, over port 443.
 		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, curl(https))
+			a.ExecInPod(ctx, ct.CurlCommand(https))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -84,6 +84,9 @@ const (
 
 	PolicyWaitTimeout = 15 * time.Second
 
+	ConnectTimeout = 5 * time.Second
+	RequestTimeout = 20 * time.Second
+
 	IngressClassName        = "cilium"
 	IngressControllerName   = "cilium.io/ingress-controller"
 	IngressSecretsNamespace = "cilium-secrets"

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -150,6 +150,9 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
 
+	cmd.Flags().DurationVar(&params.ConnectTimeout, "connect-timeout", defaults.ConnectTimeout, "Maximum time to allow initiation of the connection to take")
+	cmd.Flags().DurationVar(&params.RequestTimeout, "request-timeout", defaults.RequestTimeout, "Maximum time to allow a request to take")
+
 	cmd.Flags().BoolVar(&params.CollectSysdumpOnFailure, "collect-sysdump-on-failure", false, "Collect sysdump after a test fails")
 
 	initSysdumpFlags(cmd, &params.SysdumpOptions, "sysdump-")


### PR DESCRIPTION
See commits for details.

The first two commits are preparatory refactoring, the third commit contains the implementation. Verbatim copy of the commit message:

    connectivity: allow to specify connect and request timeout
    
    These are used to set curl --max-time and --connect-timeout, and ping -w
    and -W, respectively. The default values are 20s for --request-timeout
    and 5s for --connect-timeout.
    
    Example usage:
        $ cilium connectivity test --request-timeout 5s --connect-timeout 2s