### PR TITLE
add help message for in-daemonset cilium CLI subcommands

### DIFF
--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -84,5 +84,14 @@ cilium connectivity test`,
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
+	cmd.AddCommand(&cobra.Command{
+		Use:     "bpf",
+		Aliases: []string{"cleanup", "debuginfo", "endpoint", "fqdn", "identity", "ip", "kvstore", "lrp", "map", "metrics", "monitor", "node", "policy", "prefilter", "preflight", "recorder", "service"},
+		Hidden:  true,
+		Long: `This command is only available in cilium pods.
+Exec into a running cilium pod to use it. 
+kubectl -n kube-system exec -it ds/cilium -- bash`,
+	})
+
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Anurag <contact.anurag7@gmail.com>
- Print a message whenever in-daemonset CLI subcommads are called for. 
```bash
$ cilium bpf 
Exec into the daemonset to use this subcommand.
To exec into the daemonset use the following command:
kubectl exec -it -n kube-system ds/cilium -- bash
$ cilium help bpf 
Exec into the daemonset to use this subcommand.
To exec into the daemonset use the following command:
kubectl exec -it -n kube-system ds/cilium -- bash
```

Fixes #1229 