### PR TITLE
workflows: Test with Cilium v1.12.4

### DIFF
--- a/.github/workflows/aks-azure-ipam.yaml
+++ b/.github/workflows/aks-azure-ipam.yaml
@@ -39,7 +39,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -39,7 +39,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -28,7 +28,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-tunnel
   region: us-east-2
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -28,7 +28,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -30,7 +30,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -28,7 +28,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -15,7 +15,7 @@ env:
   KIND_CONFIG: .github/kind-config.yaml
   TIMEOUT: 2m
   LOG_TIME: 30m
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -31,7 +31,7 @@ env:
   clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
-  cilium_version: v1.12.2
+  cilium_version: v1.12.4
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 


### PR DESCRIPTION
https://github.com/cilium/cilium-cli/pull/1272 updated the default stable version installed by the Cilium from v1.12.2 to v1.12.4, but the CI is still using v1.12.2.

This pull request updates the CI.

Passing tests:
![image](https://user-images.githubusercontent.com/1764210/206698682-5a2b8311-5bca-4559-a63e-008042683b96.png)

Fixes: https://github.com/cilium/cilium-cli/issues/1278.