### PR TITLE
README, dependabot: mark v0.10 branch as unmaintained

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,30 +24,10 @@ updates:
     labels:
     - kind/enhancement
 
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-    target-branch: "v0.10"
-    open-pull-requests-limit: 5
-    rebase-strategy: disabled
-    labels:
-    - kind/enhancement
-
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
-    rebase-strategy: disabled
-    labels:
-    - kind/enhancement
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: daily
-    target-branch: "v0.10"
     open-pull-requests-limit: 1
     rebase-strategy: disabled
     labels:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ binary releases.
 | Release                                                                | Release Date | Maintained | Supported Cilium Versions |
 |------------------------------------------------------------------------|--------------|------------|---------------------------|
 | [v0.12.11](https://github.com/cilium/cilium-cli/releases/tag/v0.12.11) | 2022-12-01   | Yes        | Cilium 1.11 and newer     |
-| [v0.10.7](https://github.com/cilium/cilium-cli/releases/tag/v0.10.7)   | 2022-05-31   | Yes        | Cilium 1.10               |
+| [v0.10.7](https://github.com/cilium/cilium-cli/releases/tag/v0.10.7)   | 2022-05-31   | No         | Cilium 1.10               |
 
 ## Capabilities
 


### PR DESCRIPTION
With the upcoming Cilium v1.13 release, Cilium v1.10 will no longer be maintained per the Cilium release policy [1]. cilium-cli v0.10 is only maintained for Cilium v1.10 compatibility, so mark it as unmaintained too.

[1] https://docs.cilium.io/en/v1.12/contributing/release/organization/