### PR TITLE
sysdump: Log detected Cilium namespace

### DIFF
--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -156,7 +156,7 @@ func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion
 		if err != nil {
 			return nil, err
 		}
-		c.logDebug("Detected Cilium installation in namespace %q", ns)
+		c.log("🔮 Detected Cilium installation in namespace %q", ns)
 		o.CiliumNamespace = ns
 	}
 


### PR DESCRIPTION
Sample output:

    🔍 Collecting sysdump with cilium-cli version: v0.12.11-13-g10617f1b, args: [sysdump]
    🔮 Detected Cilium installation in namespace "kube-system"
    🔍 Collecting Kubernetes nodes

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>