### PR TITLE
.github: pin ubuntu runners to 22.04

### DIFF
--- a/.github/workflows/aks-azure-ipam.yaml
+++ b/.github/workflows/aks-azure-ipam.yaml
@@ -45,7 +45,7 @@ env:
 jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -45,7 +45,7 @@ env:
 jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -35,7 +35,7 @@ env:
 jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   installation-and-connectivity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Checkout

--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   push-to-loki:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Push to Loki
         uses: michi-covalent/push-to-loki@v0.2.2

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -38,7 +38,7 @@ env:
 jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Create Release
     if: github.repository == 'cilium/cilium-cli'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b


### PR DESCRIPTION
Currently, we use ubuntu-latest runners which currently points to
ubuntu-20.04, but will point to ubuntu-22.04 soon [1]

[1] https://github.com/actions/runner-images/issues/6399

In order to avoid future surprises and proactives check compatibility of
our workflows, pin the version to ubuntu-22.04 already.