### PR TITLE
connectivity: Fix tunnel feature detection

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -163,12 +163,12 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 		Mode:    mode,
 	}
 
-	mode = "Disabled"
+	mode = "disabled"
 	if v, ok := cm.Data["tunnel"]; ok {
 		mode = v
 	}
 	result[FeatureTunnel] = FeatureStatus{
-		Enabled: mode != "Disabled",
+		Enabled: mode != "disabled",
 		Mode:    mode,
 	}
 


### PR DESCRIPTION
It's "disabled, not "Disabled".

Fixes: 976cf82fd ("connectivity: Add feature to detect tunneling mode")
Reported-by: Tobias Klauser <tobias@cilium.io>
Signed-off-by: Martynas Pumputis <m@lambda.lt>