### PR TITLE
.github: replace deprecated set-output commands

### DIFF
--- a/.github/workflows/aks-azure-ipam.yaml
+++ b/.github/workflows/aks-azure-ipam.yaml
@@ -85,8 +85,8 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=owner::${OWNER}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
 
       - name: Create AKS cluster
         run: |
@@ -133,12 +133,12 @@ jobs:
           TENANT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant')
           CLIENT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.appId')
           CLIENT_SECRET=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')
-          echo ::set-output name=subscription-id::${AZURE_SUBSCRIPTION_ID}
-          echo ::set-output name=node-resource-group::${AZURE_NODE_RESOURCE_GROUP}
-          echo ::set-output name=tenant-id::${TENANT_ID}
-          echo ::set-output name=client-id::${CLIENT_ID}
+          echo "subscription-id=${AZURE_SUBSCRIPTION_ID}" >> $GITHUB_OUTPUT
+          echo "node-resource-group=${AZURE_NODE_RESOURCE_GROUP}" >> $GITHUB_OUTPUT
+          echo "tenant-id=${TENANT_ID}" >> $GITHUB_OUTPUT
+          echo "client-id=${CLIENT_ID}" >> $GITHUB_OUTPUT
           echo ::add-mask::${CLIENT_SECRET}
-          echo ::set-output name=client-secret::${CLIENT_SECRET}
+          echo "client-secret=${CLIENT_SECRET}" >> $GITHUB_OUTPUT
 
       - name: Create cilium-cli install job
         run: |

--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -87,8 +87,8 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=owner::${OWNER}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
 
       - name: Create AKS cluster
         run: |

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -84,8 +84,8 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=owner::${OWNER}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
 
       - name: Create EKS cluster
         run: |

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -84,8 +84,8 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=owner::${OWNER}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
 
       - name: Create EKS cluster
         run: |

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -86,8 +86,8 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=owner::${OWNER}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
 
       - name: Create GCP VM
         uses: nick-invision/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
@@ -122,7 +122,7 @@ jobs:
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible
           CLUSTER_CIDR=$(gcloud container clusters describe ${{ env.clusterName }} --zone ${{ env.zone }} --format="value(clusterIpv4Cidr)")
-          echo ::set-output name=cluster_cidr::${CLUSTER_CIDR}
+          echo "cluster_cidr=${CLUSTER_CIDR}" >> $GITHUB_OUTPUT
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -84,8 +84,8 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=owner::${OWNER}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
 
       - name: Create GKE cluster
         id: cluster
@@ -103,7 +103,7 @@ jobs:
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible
           CLUSTER_CIDR=$(gcloud container clusters describe ${{ env.clusterName }} --zone ${{ env.zone }} --format="value(clusterIpv4Cidr)")
-          echo ::set-output name=cluster_cidr::${CLUSTER_CIDR}
+          echo "cluster_cidr=${CLUSTER_CIDR}" >> $GITHUB_OUTPUT
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -40,9 +40,9 @@ jobs:
         id: tag
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
-            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+            echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=tag::${{ github.sha }}
+            echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout Source Code

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -92,8 +92,8 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=owner::${OWNER}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
 
       - name: Create GKE cluster 2
         run: |


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Converted using:

    sed -i \
      '/::set-output/ {
        s/::set-output name=/"/;
        s/::/=/;
        s/$/" >> $GITHUB_OUTPUT/;
      }' \
    .github/workflows/*.yaml