### PR TITLE
k8s: Bring back TTY to Exec

### DIFF
--- a/internal/utils/ctrlcreader.go
+++ b/internal/utils/ctrlcreader.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package utils
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+// CtrlCReader implements a simple Reader/Closer that returns Ctrl-C and EOF
+// on Read() after it has been closed, and nothing before it.
+type CtrlCReader struct {
+	ctx       context.Context
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+// NewCtrlCReader returns a new CtrlCReader instance
+func NewCtrlCReader(ctx context.Context) *CtrlCReader {
+	return &CtrlCReader{
+		ctx:    ctx,
+		closed: make(chan struct{}),
+	}
+}
+
+// Read implements io.Reader.
+// Blocks until we are done.
+func (cc *CtrlCReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	select {
+	case <-cc.closed:
+		// Graceful close, EOF without any data
+		return 0, io.EOF
+	case <-cc.ctx.Done():
+		// Context cancelled, send Ctrl-C/Ctrl-D
+		p[0] = byte(3) // Ctrl-C
+		if len(p) > 1 {
+			// Add Ctrl-D for the case Ctrl-C alone is ineffective.
+			// We skip this in the odd case where the buffer is too small.
+			p[1] = byte(4) // Ctrl-D
+			return 2, io.EOF
+		}
+		return 1, io.EOF
+	}
+}
+
+// Close implements io.Closer. Note that we do not return an error on
+// second close, not do we wait for the close to have any effect.
+func (cc *CtrlCReader) Close() error {
+	cc.closeOnce.Do(func() {
+		close(cc.closed)
+	})
+	return nil
+}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -403,13 +403,17 @@ func (c *Client) ExecInPod(ctx context.Context, namespace, pod, container string
 	return result.Stdout, nil
 }
 
-func (c *Client) ExecInPodWithWriters(ctx context.Context, namespace, pod, container string, command []string, stdout, stderr io.Writer) error {
-	err := c.execInPodWithWriters(ctx, ExecParameters{
+func (c *Client) ExecInPodWithWriters(connCtx, killCmdCtx context.Context, namespace, pod, container string, command []string, stdout, stderr io.Writer) error {
+	execParams := ExecParameters{
 		Namespace: namespace,
 		Pod:       pod,
 		Container: container,
 		Command:   command,
-	}, stdout, stderr)
+	}
+	if killCmdCtx != nil {
+		execParams.TTY = true
+	}
+	err := c.execInPodWithWriters(connCtx, killCmdCtx, execParams, stdout, stderr)
 	if err != nil {
 		return err
 	}

--- a/k8s/copy.go
+++ b/k8s/copy.go
@@ -37,7 +37,7 @@ func (c *Client) CopyFromPod(ctx context.Context, namespace, pod, container stri
 func readFromPod(ctx context.Context, client *Client, namespace, pod, container, srcFile string) ReadFunc {
 	return func(offset uint64, writer io.Writer) error {
 		command := []string{"sh", "-c", fmt.Sprintf(defaultReadFromByteCmd, offset, srcFile)}
-		return client.execInPodWithWriters(ctx, ExecParameters{
+		return client.execInPodWithWriters(ctx, nil, ExecParameters{
 			Namespace: namespace,
 			Pod:       pod,
 			Container: container,


### PR DESCRIPTION
This is a partial revert of commit 30310b18 ("connectivity, k8s, internal/utils: drop ExecInPodWithTTY and CtrlCReader").

Unfortunately, using the same context as StreamWithContext() to indicate a cancellation of a program running via Exec doesn't work as expected. From quick experimentation, it only closes a connection which doesn't necessarily send SIGTERM to a remote program. As a result, the tcpdump kept dangling in the encryption tests.

Bring back the ctrlreader, and use a separate context for it.

Signed-off-by: Martynas Pumputis <m@lambda.lt>