### PR TITLE
Honor global namespace flag in sysdump command

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -29,6 +29,10 @@ func newCmdSysdump() *cobra.Command {
 		Short: "Collects information required to troubleshoot issues with Cilium and Hubble",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Honor --namespace global flag in case it is set and --cilium-namespace is not set
+			if sysdumpOptions.CiliumNamespace == "" && cmd.Flags().Changed("namespace") {
+				sysdumpOptions.CiliumNamespace = namespace
+			}
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)
 			// Collect the sysdump.
@@ -54,7 +58,7 @@ func initSysdumpFlags(cmd *cobra.Command, options *sysdump.Options, optionPrefix
 		"The labels used to target Cilium pods")
 	cmd.Flags().StringVar(&options.CiliumNamespace,
 		optionPrefix+"cilium-namespace", "",
-		"The namespace Cilium is running in")
+		"The namespace Cilium is running in. If not provided then the --namespace global flag is used (if provided)")
 	cmd.Flags().StringVar(&options.CiliumOperatorNamespace,
 		optionPrefix+"cilium-operator-namespace", "",
 		"The namespace Cilium operator is running in")

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -161,6 +161,8 @@ func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion
 		}
 		c.log("🔮 Detected Cilium installation in namespace %q", ns)
 		c.Options.CiliumNamespace = ns
+	} else {
+		c.log("ℹ️  Cilium namespace: %s", c.Options.CiliumNamespace)
 	}
 
 	if c.Options.CiliumOperatorNamespace == "" {
@@ -168,8 +170,10 @@ func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion
 		if err != nil {
 			return nil, err
 		}
-		c.log("Detected Cilium operator in namespace %q", ns)
+		c.log("🔮 Detected Cilium operator in namespace %q", ns)
 		c.Options.CiliumOperatorNamespace = ns
+	} else {
+		c.log("ℹ️  Cilium operator namespace: %s", c.Options.CiliumOperatorNamespace)
 	}
 
 	// Grab the Kubernetes nodes for the target cluster.


### PR DESCRIPTION
As reported at https://github.com/cilium/cilium-cli/issues/1079 the global `--namespace` flag is not honored in `sysdump` command. 

This PR honors the global `--namespace` flag in `sysdump` commad by making `--namespace` flag equivalent to the `--cilium-namespace` flag.

If both flags are set, then the  `--namespace` global flag comes with priority.

Closes https://github.com/cilium/cilium-cli/issues/1079

Signed-off-by: ChrsMark <chrismarkou92@gmail.com>