### PR TITLE
connectivity: Fix iface derivation in encrypt tests

### DIFF
--- a/connectivity/tests/encryption.go
+++ b/connectivity/tests/encryption.go
@@ -59,8 +59,8 @@ func (s *podToPodEncryption) Run(ctx context.Context, t *check.Test) {
 		iface = "cilium_" + tunnelFeat.Mode // E.g. cilium_vxlan
 	} else {
 		cmd := []string{"/bin/sh", "-c",
-			fmt.Sprintf("ip -o r g %s from %s | grep -oP '(?<=dev )[^ ]+'",
-				server.Pod.Status.PodIP, client.Pod.Status.PodIP)}
+			fmt.Sprintf("ip -o r g %s | grep -oE 'dev [^ ]*' | cut -d' ' -f2",
+				server.Pod.Status.PodIP)}
 		t.Debugf("Running %s", strings.Join(cmd, " "))
 		dev, err := clientHost.K8sClient.ExecInPod(ctx, clientHost.Pod.Namespace,
 			clientHost.Pod.Name, "", cmd)


### PR DESCRIPTION
This commit fixes two issues:

* grep's "-P" is not available on busybox.
* In the direct routing mode, "ip r g $DST_POD_IP from $SRC_POD_IP" fails with "RTNETLINK answers: Network unreachable".

Fixes: 998ef8ab15e ("connectivity: Add encryption test")
Signed-off-by: Martynas Pumputis <m@lambda.lt>