### PR TITLE
all: fix spacing with ℹ️  logs

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1391,7 +1391,7 @@ func (k *K8sClusterMesh) DeleteExternalWorkload(ctx context.Context, names []str
 	if count > 0 {
 		k.Log("✅ Removed %d external workload resources.", count)
 	} else {
-		k.Log("ℹ️ No external workload resources to remove.")
+		k.Log("ℹ️  No external workload resources to remove.")
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, ", "))

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -55,7 +55,7 @@ func (k *K8sUninstaller) autodetect(ctx context.Context) {
 
 func (k *K8sInstaller) detectDatapathMode(ctx context.Context, withKPR bool) error {
 	if k.params.DatapathMode != "" {
-		k.Log("ℹ️ Custom datapath mode: %s", k.params.DatapathMode)
+		k.Log("ℹ️  Custom datapath mode: %s", k.params.DatapathMode)
 		return nil
 	}
 
@@ -146,7 +146,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 	// TODO: remove when removing "ipam" flag (marked as deprecated), kept for
 	// backwards compatibility
 	if k.params.IPAM != "" {
-		k.Log("ℹ️ Custom IPAM mode: %s", k.params.IPAM)
+		k.Log("ℹ️  Custom IPAM mode: %s", k.params.IPAM)
 	}
 
 	if strings.Contains(k.params.ClusterName, ".") {
@@ -196,7 +196,7 @@ func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context) error {
 	}
 	apiServerHost, apiServerPort := k.client.GetAPIServerHostAndPort()
 	if k.flavor.Kind == k8s.KindKind {
-		k.Log("ℹ️ Detecting real Kubernetes API server addr and port on Kind")
+		k.Log("ℹ️  Detecting real Kubernetes API server addr and port on Kind")
 
 		// When we are using Kind, the API server addr & port is port forwarded
 		eps, err := k.client.GetEndpoints(ctx, "default", "kubernetes", metav1.GetOptions{})
@@ -229,7 +229,7 @@ func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context) error {
 
 	if apiServerHost != "" && apiServerPort != "" {
 		k.Log("🔮 Auto-detected kube-proxy has not been installed")
-		k.Log("ℹ️ Cilium will fully replace all functionalities of kube-proxy")
+		k.Log("ℹ️  Cilium will fully replace all functionalities of kube-proxy")
 		// Use HelmOpts to set auto kube-proxy installation
 		k.params.HelmOpts.Values = append(k.params.HelmOpts.Values,
 			"kubeProxyReplacement=strict",

--- a/install/azure.go
+++ b/install/azure.go
@@ -74,7 +74,7 @@ func (k *K8sInstaller) azureAutodetect(ctx context.Context) error {
 // If provided, it bypasses auto-detection and `--azure-subscription`.
 func (k *K8sInstaller) azureRetrieveSubscriptionID(ctx context.Context) error {
 	if k.params.Azure.SubscriptionID != "" {
-		k.Log("ℹ️ Using manually configured Azure subscription ID %s", k.params.Azure.SubscriptionID)
+		k.Log("ℹ️  Using manually configured Azure subscription ID %s", k.params.Azure.SubscriptionID)
 		return nil
 	}
 
@@ -123,7 +123,7 @@ func (k *K8sInstaller) azureRetrieveAKSClusterInfo(ctx context.Context) error {
 	// user know what they're doing and we are not in BYOCNI mode because this
 	// flag is not necessary for BYOCNI, so we skip auto-detection.
 	if k.params.Azure.AKSNodeResourceGroup != "" {
-		k.Log("ℹ️ Using manually configured Azure AKS node resource group %s", k.params.Azure.AKSNodeResourceGroup)
+		k.Log("ℹ️  Using manually configured Azure AKS node resource group %s", k.params.Azure.AKSNodeResourceGroup)
 		return nil
 	}
 
@@ -191,7 +191,7 @@ func (k *K8sInstaller) azureSetupServicePrincipal(ctx context.Context) error {
 		}
 
 		k.Log("✅ Created Azure Service Principal for Cilium Azure operator with App ID %s and Tenant ID %s", p.AppID, p.Tenant)
-		k.Log("ℹ️ Its RBAC privileges are restricted to the AKS node resource group %s", k.params.Azure.AKSNodeResourceGroup)
+		k.Log("ℹ️  Its RBAC privileges are restricted to the AKS node resource group %s", k.params.Azure.AKSNodeResourceGroup)
 		k.params.Azure.TenantID = p.Tenant
 		k.params.Azure.ClientID = p.AppID
 		k.params.Azure.ClientSecret = p.Password
@@ -204,7 +204,7 @@ func (k *K8sInstaller) azureSetupServicePrincipal(ctx context.Context) error {
 			return fmt.Errorf("missing at least one of Azure Service Principal parameters")
 		}
 
-		k.Log("ℹ️ Using manually configured Azure Service Principal for Cilium Azure operator with App ID %s and Tenant ID %s",
+		k.Log("ℹ️  Using manually configured Azure Service Principal for Cilium Azure operator with App ID %s and Tenant ID %s",
 			k.params.Azure.ClientID, k.params.Azure.TenantID)
 	}
 

--- a/install/install.go
+++ b/install/install.go
@@ -427,7 +427,7 @@ func (k *K8sInstaller) generateConfigMap() (*corev1.ConfigMap, error) {
 	k.Log("🚀 Creating ConfigMap for Cilium version %s...", k.chartVersion)
 
 	for key, value := range k.params.configOverwrites {
-		k.Log("ℹ️ Manual overwrite in ConfigMap: %s=%s", key, value)
+		k.Log("ℹ️  Manual overwrite in ConfigMap: %s=%s", key, value)
 		cm.Data[key] = value
 	}
 


### PR DESCRIPTION
Some logs have 1 space after ℹ️ , causing mis-alignments in the logs (eg. `ℹ️Cilium will fully replace all functionalities of kube-proxy`):

![image](https://user-images.githubusercontent.com/2110851/208657576-f17d643a-0407-46a3-b001-77686849ad27.png)

This PR standardize the logs to 2 spaces after ℹ️ 


Signed-off-by: Benjamin Gentil <benjamin.gentil@infomaniak.com>