### PR TITLE
cli: Support client only in version sub-command

### DIFF
--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -38,6 +38,7 @@ func getLatestStableVersion() string {
 }
 
 func newCmdVersion() *cobra.Command {
+	var clientOnly bool
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Display detailed version information",
@@ -46,6 +47,9 @@ func newCmdVersion() *cobra.Command {
 			fmt.Printf("cilium-cli: %s compiled with %v on %v/%v\n", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 			fmt.Printf("cilium image (default): %s\n", defaults.Version)
 			fmt.Printf("cilium image (stable): %s\n", getLatestStableVersion())
+			if clientOnly {
+				return nil
+			}
 			version, err := k8sClient.GetRunningCiliumVersion(context.Background(), namespace)
 			if version == "" || err != nil {
 				fmt.Printf("cilium image (running): unknown. Unable to obtain cilium version, no cilium pods found in namespace %q\n", namespace)
@@ -56,5 +60,6 @@ func newCmdVersion() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&clientOnly, "client", false, "If true, shows client version only (no server required)")
 	return cmd
 }


### PR DESCRIPTION
## Description

This is similar to what kubectl offers (i.e. kubectl version --client). One benefit is to have faster response time if the current kubernetes context is not valid or no cilium installed.

Thanks to Shane O'Donnell for suggestion.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Testing

Testing was done locally as per below

```bash
$ ./cilium version --client       
cilium-cli: v0.12.8 compiled with go1.19.4 on linux/amd64
cilium image (default): v1.12.2
cilium image (stable): v1.12.5

$ ./cilium version --client=true 
cilium-cli: v0.12.8 compiled with go1.19.4 on linux/amd64
cilium image (default): v1.12.2
cilium image (stable): v1.12.5

$ ./cilium version         
cilium-cli: v0.12.8 compiled with go1.19.4 on linux/amd64
cilium image (default): v1.12.2
cilium image (stable): v1.12.5
cilium image (running): unknown. Unable to obtain cilium version, no cilium pods found in namespace "kube-system"

$ ./cilium version --client=false
cilium-cli: v0.12.8 compiled with go1.19.4 on linux/amd64
cilium image (default): v1.12.2
cilium image (stable): v1.12.5
cilium image (running): unknown. Unable to obtain cilium version, no cilium pods found in namespace "kube-system"

```

