### PR TITLE
hubble: port-forward only to localhost

### DIFF
--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -261,8 +261,8 @@ func (p *Parameters) RelayPortForwardCommand(ctx context.Context, client k8sHubb
 		"port-forward",
 		"-n", p.Namespace,
 		"svc/hubble-relay",
-		"--address", "0.0.0.0",
-		"--address", "::",
+		"--address", "127.0.0.1",
+		"--address", "::1",
 		fmt.Sprintf("%d:%d", p.PortForward, relaySvc.Spec.Ports[0].Port)}
 
 	if p.Context != "" {

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -236,8 +236,8 @@ func (p *Parameters) UIPortForwardCommand(ctx context.Context) error {
 		"port-forward",
 		"-n", p.Namespace,
 		"svc/hubble-ui",
-		"--address", "0.0.0.0",
-		"--address", "::",
+		"--address", "127.0.0.1",
+		"--address", "::1",
 		fmt.Sprintf("%d:80", p.UIPortForward)}
 
 	if p.Context != "" {


### PR DESCRIPTION
Avoid exposing Hubble Relay and UI to the network, restrict to localhost. After the patch:

```console
% ./cilium hubble port-forward
% ss -l -t 'sport = :4245'
State           Recv-Q          Send-Q                    Local Address:Port                     Peer Address:Port          Process
LISTEN          0               4096                          127.0.0.1:4245                          0.0.0.0:*
LISTEN          0               4096                              [::1]:4245                             [::]:*
```
and
```console
% ./cilium hubble ui port-forward
% ss -l -t 'sport = :12000'
State           Recv-Q          Send-Q                   Local Address:Port                        Peer Address:Port         Process
LISTEN          0               4096                         127.0.0.1:entextxid                        0.0.0.0:*
LISTEN          0               4096                             [::1]:entextxid                           [::]:*
```