### PR TITLE
Increase copy retries

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -124,4 +124,7 @@ func initSysdumpFlags(cmd *cobra.Command, options *sysdump.Options, optionPrefix
 	cmd.Flags().StringVar(&options.TetragonLabelSelector,
 		optionPrefix+"tetragon-label-selector", sysdump.DefaultTetragonLabelSelector,
 		"The labels used to target Tetragon pods")
+	cmd.Flags().IntVar(&options.CopyRetryLimit,
+		optionPrefix+"copy-retry-limit", sysdump.DefaultCopyRetryLimit,
+		"Retry limit for file copying operations. If set to -1, copying will be retried indefinitely. Useful for collecting sysdump while on unreliable connection.")
 }

--- a/k8s/copy.go
+++ b/k8s/copy.go
@@ -12,14 +12,13 @@ import (
 
 const (
 	defaultReadFromByteCmd = "tail -c+%d %s"
-	defaultMaxTries        = 5
 )
 
 // CopyFromPod is to copy srcFile in a given pod to local destFile with defaultMaxTries.
-func (c *Client) CopyFromPod(ctx context.Context, namespace, pod, container string, srcFile, destFile string) error {
+func (c *Client) CopyFromPod(ctx context.Context, namespace, pod, container, fromFile, destFile string, retryLimit int) error {
 	pipe := newPipe(&CopyOptions{
-		MaxTries: defaultMaxTries,
-		ReadFunc: readFromPod(ctx, c, namespace, pod, container, srcFile),
+		MaxTries: retryLimit,
+		ReadFunc: readFromPod(ctx, c, namespace, pod, container, fromFile),
 	})
 
 	outFile, err := os.OpenFile(destFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -24,7 +24,7 @@ import (
 
 type KubernetesClient interface {
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
-	CopyFromPod(ctx context.Context, namespace, pod, container string, fromFile, destFile string) error
+	CopyFromPod(ctx context.Context, namespace, pod, container, fromFile, destFile string, retryLimit int) error
 	CreateEphemeralContainer(ctx context.Context, pod *corev1.Pod, ec *corev1.EphemeralContainer) (*corev1.Pod, error)
 	CreatePod(ctx context.Context, namespace string, pod *corev1.Pod, opts metav1.CreateOptions) (*corev1.Pod, error)
 	GetPod(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Pod, error)

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -51,6 +51,9 @@ var (
 	// DefaultWorkerCount is initialized to the machine's available CPUs.
 	DefaultWorkerCount = runtime.NumCPU()
 
+	// DefaultCopyRetryLimit limits retries done while copying files from pods
+	DefaultCopyRetryLimit = 100
+
 	// DefaultCiliumNamespaces will be used to attempt to autodetect what namespace Cilium is installed in
 	// unless otherwise specified.
 	DefaultCiliumNamespaces = []string{"kube-system", "cilium"}

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -92,6 +92,8 @@ type Options struct {
 	TetragonLabelSelector string
 	// The namespace Namespace is running in.
 	TetragonNamespace string
+	// Retry limit for copying files from pods
+	CopyRetryLimit int
 }
 
 // Task defines a task for the sysdump collector to execute.
@@ -1149,7 +1151,7 @@ func (c *Collector) submitTetragonBugtoolTasks(ctx context.Context, pods []*core
 
 			// Dump the resulting file's contents to the temporary directory.
 			f := c.AbsoluteTempPath(fmt.Sprintf("%s-%s-<ts>.tar.gz", tetragonBugtoolPrefix, p.Name))
-			err = c.Client.CopyFromPod(ctx, p.Namespace, p.Name, containerName, tarGzFile, f)
+			err = c.Client.CopyFromPod(ctx, p.Namespace, p.Name, containerName, tarGzFile, f, c.Options.CopyRetryLimit)
 			if err != nil {
 				return fmt.Errorf("failed to collect 'tetragon-bugtool' output for %q: %w", p.Name, err)
 			}
@@ -1225,7 +1227,7 @@ func (c *Collector) submitCiliumBugtoolTasks(ctx context.Context, pods []*corev1
 
 			// Dump the resulting file's contents to the temporary directory.
 			f := c.AbsoluteTempPath(fmt.Sprintf(ciliumBugtoolFileName, p.Name))
-			err = c.Client.CopyFromPod(ctx, p.Namespace, p.Name, containerName, tarGzFile, f)
+			err = c.Client.CopyFromPod(ctx, p.Namespace, p.Name, containerName, tarGzFile, f, c.Options.CopyRetryLimit)
 			if err != nil {
 				return fmt.Errorf("failed to collect 'cilium-bugtool' output for %q: %w", p.Name, err)
 			}

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -214,7 +214,7 @@ func (c *fakeClient) ListIngresses(ctx context.Context, o metav1.ListOptions) (*
 	panic("implement me")
 }
 
-func (c *fakeClient) CopyFromPod(ctx context.Context, namespace, pod, container string, fromFile, destFile string) error {
+func (c *fakeClient) CopyFromPod(ctx context.Context, namespace, pod, container, fromFile, destFile string, retryLimit int) error {
 	panic("implement me")
 }
 


### PR DESCRIPTION
If a user wants to get bugtool output while they are on unreliable network, it makes sense to increase retry count to make their experience better.