### PR TITLE
introduce --open-browser flag on cilium hubble UI

### DIFF
--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -136,6 +136,9 @@ type Parameters struct {
 
 	// RedactHelmCertKeys does not print helm certificate keys into the terminal.
 	RedactHelmCertKeys bool
+
+	// UIOpenBrowser will automatically open browser if true
+	UIOpenBrowser bool
 }
 
 func (p *Parameters) Log(format string, a ...interface{}) {

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -248,11 +248,15 @@ func (p *Parameters) UIPortForwardCommand(ctx context.Context) error {
 		time.Sleep(5 * time.Second)
 		url := fmt.Sprintf("http://localhost:%d", p.UIPortForward)
 
-		// avoid cluttering stdout/stderr when opening the browser
-		browser.Stdout = io.Discard
-		browser.Stderr = io.Discard
-		p.Log("ℹ️  Opening %q in your browser...", url)
-		browser.OpenURL(url)
+		if p.UIOpenBrowser {
+			// avoid cluttering stdout/stderr when opening the browser
+			browser.Stdout = io.Discard
+			browser.Stderr = io.Discard
+			p.Log("ℹ️  Opening %q in your browser...", url)
+			browser.OpenURL(url)
+		} else {
+			p.Log("ℹ️  Hubble UI is available at %q", url)
+		}
 	}()
 
 	_, err := utils.Exec(p, "kubectl", args...)

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -175,6 +175,7 @@ func newCmdUI() *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&params.UIPortForward, "port-forward", 12000, "Local port to use for the port forward")
+	cmd.Flags().BoolVar(&params.UIOpenBrowser, "open-browser", true, "When --open-browser=false is supplied, cilium Hubble UI will not open the browser")
 
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>

open new PR because https://github.com/cilium/cilium-cli/pull/1313 accidentally closed.

add the flag --open-browser, When --open-browser is supplied as false, cilium hubble ui will not open the browser. The default is true which means cilium hubble ui will always open a browser to view the UI. (default true)

```
(⎈ |home-lab-kubernetes-01:kube-system) [31/12/22 | 8:04:58]
cilium-cli $ ./cilium hubble ui --open-browser=false
ℹ️  Hubble UI is available on "http://localhost:12000"
^C
(⎈ |home-lab-kubernetes-01:kube-system) [31/12/22 | 8:05:28]
cilium-cli $ ./cilium hubble ui 
ℹ️  Opening "http://localhost:12000" in your browser...
^C
```

Fixes #1312 