### PR TITLE
hubble: port-forward only on IPv4

### DIFF
--- a/hubble/relay.go
+++ b/hubble/relay.go
@@ -262,7 +262,6 @@ func (p *Parameters) RelayPortForwardCommand(ctx context.Context, client k8sHubb
 		"-n", p.Namespace,
 		"svc/hubble-relay",
 		"--address", "127.0.0.1",
-		"--address", "::1",
 		fmt.Sprintf("%d:%d", p.PortForward, relaySvc.Spec.Ports[0].Port)}
 
 	if p.Context != "" {

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -237,7 +237,6 @@ func (p *Parameters) UIPortForwardCommand(ctx context.Context) error {
 		"-n", p.Namespace,
 		"svc/hubble-ui",
 		"--address", "127.0.0.1",
-		"--address", "::1",
 		fmt.Sprintf("%d:80", p.UIPortForward)}
 
 	if p.Context != "" {


### PR DESCRIPTION
Before this patch, cilium hubble port-forward and cilium hubble ui would fail when the host didn't have IPv6 enabled.

After this patch we have:
```console
% ./cilium hubble port-forward
% ss -l -t 'sport = :4245'
State           Recv-Q          Send-Q                    Local Address:Port                     Peer Address:Port          Process
LISTEN          0               4096                          127.0.0.1:4245                          0.0.0.0:*
```
and
```console
% ./cilium hubble ui
% ss -l -t 'sport = :12000'
State           Recv-Q          Send-Q                   Local Address:Port                        Peer Address:Port         Process
LISTEN          0               4096                         127.0.0.1:entextxid                        0.0.0.0:*
```

Fix #1093