### PR TITLE
Prepare for v0.12.12 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ binary releases.
 
 | Release                                                                | Release Date | Maintained | Supported Cilium Versions |
 |------------------------------------------------------------------------|--------------|------------|---------------------------|
-| [v0.12.11](https://github.com/cilium/cilium-cli/releases/tag/v0.12.11) | 2022-12-01   | Yes        | Cilium 1.11 and newer     |
+| [v0.12.12](https://github.com/cilium/cilium-cli/releases/tag/v0.12.12) | 2023-01-10   | Yes        | Cilium 1.11 and newer     |
 | [v0.10.7](https://github.com/cilium/cilium-cli/releases/tag/v0.10.7)   | 2022-05-31   | No         | Cilium 1.10               |
 
 ## Capabilities


### PR DESCRIPTION
Note: #1324 should be merged before this one, so the tag points to the preparation commit.