### PR TITLE
Update Go to 1.19.5

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
       with:
-        go-version: 1.19.4
+        go-version: 1.19.5
 
     - name: Run static checks
       uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: 1.19.4
+          go-version: 1.19.5
 
       - name: Set up Go for root
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: 1.19.4
+          go-version: 1.19.5
 
       - name: Set up job variables
         id: vars

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: 1.19.4
+          go-version: 1.19.5
 
       - name: Generate the artifacts
         run: make release

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /cilium \
-		--volume `pwd`:/cilium docker.io/library/golang:1.19.4-alpine3.16 \
+		--volume `pwd`:/cilium docker.io/library/golang:1.19.5-alpine3.17 \
 		sh -c "apk add --no-cache setpriv make git && \
 			/usr/bin/setpriv --reuid=$(RELEASE_UID) --regid=$(RELEASE_GID) --clear-groups make GOCACHE=/tmp/gocache local-release"
 


### PR DESCRIPTION
> go1.19.5 (released 2023-01-10) includes fixes to the compiler, the
> linker, and the crypto/x509, net/http, sync/atomic, and syscall
> packages. See the Go 1.19.5 milestone on our issue tracker for
> details.

Release milestone:
https://github.com/golang/go/issues?q=milestone%3AGo1.19.5+label%3ACherryPickApproved

Also update the docker base image used for release build to alpine 3.17.