### PR TITLE
connectivity: Allow egress to DNS by CIDR

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -54,6 +54,7 @@ type Parameters struct {
 	ExternalCIDR          string
 	ExternalIP            string
 	ExternalOtherIP       string
+	DNSCIDR               string
 
 	K8sVersion           string
 	HelmChartDirectory   string

--- a/connectivity/manifests/allow-all-except-world.yaml
+++ b/connectivity/manifests/allow-all-except-world.yaml
@@ -14,16 +14,14 @@ spec:
     - kube-apiserver
   - toEndpoints:
       - {}
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  {{- if .DNSCIDR }}
   - toPorts:
       - ports:
           - port: "53"
-            protocol: UDP
-    toEntities:
-      - world
+            protocol: ANY
+    toCIDR:
+      - "{{.DNSCIDR}}"
+  {{- end }}
   ingress:
   - fromEntities:
     - host

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -18,13 +18,14 @@ spec:
       - matchExpressions:
           - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
           - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  {{- if .DNSCIDR }}
   - toPorts:
     - ports:
       - port: "53"
-        protocol: UDP
-    toEntities:
-    - world
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toCIDR:
+    - "{{.DNSCIDR}}"
+  {{- end }}

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -23,13 +23,11 @@ spec:
     - matchExpressions:
       - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  {{- if .DNSCIDR }}
   - toPorts:
     - ports:
       - port: "53"
-        protocol: UDP
-    toEntities:
-    - world
+        protocol: ANY
+    toCIDR:
+    - "{{.DNSCIDR}}"
+  {{- end }}

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -21,13 +21,11 @@ spec:
     - ports:
       - port: "53"
         protocol: ANY
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  {{- if .DNSCIDR }}
   - toPorts:
     - ports:
       - port: "53"
-        protocol: UDP
-    toEntities:
-    - world
+        protocol: ANY
+    toCIDR:
+    - "{{.DNSCIDR}}"
+  {{- end }}

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -28,13 +28,14 @@ spec:
     - matchExpressions:
       - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  {{- if .DNSCIDR }}
   - toPorts:
     - ports:
       - port: "53"
-        protocol: UDP
-    toEntities:
-    - world
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+    toCIDR:
+    - "{{.DNSCIDR}}"
+  {{- end }}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -132,6 +132,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalIP, "external-ip", "1.1.1.1", "IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")
+	cmd.Flags().StringVar(&params.DNSCIDR, "dns-cidr", "", "CIDR for DNS queries. Example: 169.254.25.10/32")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")


### PR DESCRIPTION
This is needed for node-local-dns installed by kubespray, using `hostNetwork`.

See
https://github.com/kubernetes-sigs/kubespray/blob/039205560a5a38dac7e180ec4c46ce4edd404d39/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2

See also #995 and https://github.com/cilium/cilium-cli/pull/997.