### PR TITLE
[connectivity] add container name for health tests

### DIFF
--- a/connectivity/tests/health.go
+++ b/connectivity/tests/health.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/util/jsonpath"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/defaults"
 )
 
 func CiliumHealth() check.Scenario {
@@ -43,7 +44,7 @@ func runHealthProbe(ctx context.Context, t *check.ConnectivityTest, pod *check.P
 	for {
 		retryTimer := time.After(time.Second)
 
-		stdout, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, "", cmd)
+		stdout, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, cmd)
 		if err != nil {
 			t.Warnf("cilium-health probe failed: %q, stdout: %q, retrying...", err, stdout)
 			continue


### PR DESCRIPTION
In some environments it is possible to use ds cilium with multiple containers (e.g. kube-rbac-proxy) in these cases the health tests do not work correctly.
For example:

```
⚠️ cilium-health probe failed: "a container name must be specified for pod agent-gtrg7, choose one of: [check-linux-kernel mount-cgroup clean-cilium-state cilium-agent kube-rbac-proxy]", stdout: {" '\x00' '\x00'}, retrying...
```