### PR TITLE
status: rename Hubble status to Hubble Relay

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -320,7 +320,7 @@ func (s *Status) Format() string {
 	fmt.Fprintf(w, Yellow+"    /¯¯\\\n")
 	fmt.Fprintf(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\tCilium:\t"+s.statusSummary(defaults.AgentDaemonSetName)+"\n")
 	fmt.Fprintf(w, Cyan+" \\__"+Red+"/¯¯\\"+Green+"__/"+Reset+"\tOperator:\t"+s.statusSummary(defaults.OperatorDeploymentName)+"\n")
-	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tHubble:\t"+s.statusSummary(defaults.RelayDeploymentName)+"\n")
+	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tHubble Relay:\t"+s.statusSummary(defaults.RelayDeploymentName)+"\n")
 	fmt.Fprintf(w, Green+" \\__"+Blue+"/¯¯\\"+Magenta+"__/"+Reset+"\tClusterMesh:\t"+s.statusSummary(defaults.ClusterMeshDeploymentName)+"\n")
 	fmt.Fprintf(w, Blue+"    \\__/\n"+Reset)
 	fmt.Fprintf(w, "\n")


### PR DESCRIPTION
Before this patch, after `cilium install` we get

    % ./cilium config view | grep enable-hubble
    enable-hubble                              true

But

    % cilium status | grep Hubble:
    Hubble:         disabled

Because `cilium status` reports whether Hubble Relay is deployed.