### PR TITLE
clustermesh: adapt global service annotations

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -540,6 +540,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			ct.Logf("✨ [%s] Deploying %s service...", ct.clients.src.ClusterName(), echoOtherNodeDeploymentName)
 			svc := newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, serviceLabels, "http", 8080)
 			svc.ObjectMeta.Annotations = map[string]string{}
+			svc.ObjectMeta.Annotations["service.cilium.io/global"] = "true"
 			svc.ObjectMeta.Annotations["io.cilium/global-service"] = "true"
 
 			_, err = ct.clients.src.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
@@ -688,6 +689,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 
 			if ct.params.MultiCluster != "" {
 				svc.ObjectMeta.Annotations = map[string]string{}
+				svc.ObjectMeta.Annotations["service.cilium.io/global"] = "true"
 				svc.ObjectMeta.Annotations["io.cilium/global-service"] = "true"
 			}
 


### PR DESCRIPTION
Follow-up of cilium/cilium#23298, adding the new clustermesh service.cilium.io/global annotation alongside the previous one.

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>