### PR TITLE
clustermesh: Add missing brackets of etcd option

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -231,8 +231,10 @@ func (k *K8sClusterMesh) generateDeployment(clustermeshApiserverArgs []string) *
 								"--trusted-ca-file=/var/lib/etcd-secrets/ca.crt",
 								"--cert-file=/var/lib/etcd-secrets/tls.crt",
 								"--key-file=/var/lib/etcd-secrets/tls.key",
-								"--listen-client-urls=https://127.0.0.1:2379,https://$(HOSTNAME_IP):2379",
-								"--advertise-client-urls=https://$(HOSTNAME_IP):2379",
+								// Surrounding the IPv4 address with brackets works in this case, since etcd
+								// uses net.SplitHostPort() internally and it accepts that format.
+								"--listen-client-urls=https://127.0.0.1:2379,https://[$(HOSTNAME_IP)]:2379",
+								"--advertise-client-urls=https://[$(HOSTNAME_IP)]:2379",
 								"--initial-cluster-token=clustermesh-apiserver",
 								"--auto-compaction-retention=1",
 							},


### PR DESCRIPTION
When clustermesh-apiserver Pod is deployed on the IPv6 single-stack cluster, etcd fails to startup with the error like this.

```
invalid value "https://127.0.0.1:2379,https://a:1:0:3::fc75:2379" for flag -listen-client-urls: URL address does not have the form "host:port": https://a:1:0:3::fc75:2379
```

This happens because we don't put brackets around the IPv6 address. Fix deployment template to correctly handle that.

Related: cilium/cilium#22962

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>