### PR TITLE
ci: use cloud provider specific external target for pod-to-world tests

### DIFF
--- a/.github/in-cluster-test-scripts/aks.sh
+++ b/.github/in-cluster-test-scripts/aks.sh
@@ -16,7 +16,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target bing.com
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -28,7 +28,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows --collect-sysdump-on-failure \
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target amazon.com \
   --test '!dns-only,!to-fqdns,!client-egress-l7,!health'
   # workaround for nslookup issues in tunnel mode causing tests to fail reliably
   # TODO: remove once:

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -26,7 +26,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target amazon.com
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/external-workloads.sh
+++ b/.github/in-cluster-test-scripts/external-workloads.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target google.com
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -23,7 +23,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows --collect-sysdump-on-failure
+cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target google.com
 
 # Run performance test
 cilium connectivity test --perf --perf-duration 1s

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -57,4 +57,4 @@ sleep 10s
 
 # Run connectivity test
 cilium --context "${CONTEXT1}" connectivity test --debug --multi-cluster "${CONTEXT2}" --test '!/*-deny,!/pod-to-.*-nodeport' \
-  --all-flows --collect-sysdump-on-failure
+  --all-flows --collect-sysdump-on-failure --external-target google.com


### PR DESCRIPTION
Follows https://github.com/cilium/cilium/pull/23103, quoting its commit message:

> With the configurable --external-target flag we are configuring different targets per cloud provider. Targets were chosen to be the least hops from the clusters. They were determined by experimenting with connection times from cloud providers. Splitting targets also has the advantage of not overloading a single target.

/cc @brlbil