### PR TITLE
operator installation: maxUnavailable=100% in case of a single replica

### DIFF
--- a/install/helm_test.go
+++ b/install/helm_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package install
+
+import (
+	"reflect"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+func Test_operatorDeploymentValues(t *testing.T) {
+	type args struct {
+		mergedUserHelmValues chartutil.Values
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "no user input",
+			args: args{
+				mergedUserHelmValues: map[string]interface{}{},
+			},
+			want: map[string]string{
+				"operator.replicas": "1",
+				"operator.updateStrategy.rollingUpdate.maxUnavailable": "100%",
+			},
+			wantErr: false,
+		},
+		{
+			name: "user provided replica 1",
+			args: args{
+				mergedUserHelmValues: map[string]interface{}{
+					"operator": map[string]interface{}{
+						"replicas": "1",
+					},
+				},
+			},
+			want: map[string]string{
+				"operator.updateStrategy.rollingUpdate.maxUnavailable": "100%",
+			},
+			wantErr: false,
+		},
+		{
+			name: "user provided replica 2",
+			args: args{
+				mergedUserHelmValues: map[string]interface{}{
+					"operator": map[string]interface{}{
+						"replicas": "2",
+					},
+				},
+			},
+			want:    map[string]string{},
+			wantErr: false,
+		},
+		{
+			name: "user provided update strategy",
+			args: args{
+				mergedUserHelmValues: map[string]interface{}{
+					"operator": map[string]interface{}{
+						"updateStrategy": nil,
+					},
+				},
+			},
+			want: map[string]string{
+				"operator.replicas": "1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := operatorDeploymentValues(tt.args.mergedUserHelmValues)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("operatorDeploymentValues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("operatorDeploymentValues() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -301,6 +301,16 @@ func GenManifests(
 	return filterManifests(rel.Manifest), nil
 }
 
+func MergedValues(helmOptions values.Options) (chartutil.Values, error) {
+	p := getter.All(settings)
+	userVals, err := helmOptions.MergeValues(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return userVals, nil
+}
+
 // MergeVals merges all values from flag options ('helmFlagOpts'),
 // auto-generated helm options based on environment ('helmMapOpts'),
 // helm values from a previous installation ('helmValues'),
@@ -312,7 +322,7 @@ func MergeVals(
 	helmMapOpts map[string]string,
 	helmValues,
 	extraConfigMapOpts chartutil.Values,
-) (map[string]interface{}, error) {
+) (chartutil.Values, error) {
 
 	// Create helm values from helmMapOpts
 	var helmOpts []string


### PR DESCRIPTION
The rolling update of the Cilium Operator deployment gets stuck on single node k8s clusters if the default helm chart values with readinessprobe, rolling update with maxUnavailable=50% and podAntiAffinity (which disallows operator pods on the same node) are applied. The newly createed Pod can't get scheduled before the old replcia gets terminated.

This has been introduced with https://github.com/cilium/cilium/pull/23589.

This change configures the Cilium Operators rolling update to use maxUnavailable=100% if only one replica is configured and no userprovided update strategy is provided. This leads to an immediate termination of the existing Pod on a rolling update.

in addition i tried to refactor `generateManifests` and moved some part into separate methods instead of having everything in one big method.