### PR TITLE
install: fix support for multi-object files

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -84,7 +84,11 @@ func filterManifests(manifest string) map[string]string {
 		// well as macOS/linux
 		manifestPath := strings.Join(manifestPathSplit, "/")
 
-		manifestsToRender[manifestPath] = manifest
+		if existing, ok := manifestsToRender[manifestPath]; ok {
+			manifestsToRender[manifestPath] = existing + "\n---\n" + manifest
+		} else {
+			manifestsToRender[manifestPath] = manifest
+		}
 	}
 	return manifestsToRender
 }


### PR DESCRIPTION
We did all the work to support this, but somehow I missed an important little detail. Namely, that it doesn't work at all.

So, *correctly* support parsing when a single file generates multiple values in Helm.

Fixes: https://github.com/cilium/cilium/issues/23315

Signed-off-by: Casey Callendrello <cdc@isovalent.com>