### PR TITLE
defaults: Lower connectivity timeouts

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -85,8 +85,8 @@ const (
 
 	PolicyWaitTimeout = 15 * time.Second
 
-	ConnectTimeout = 5 * time.Second
-	RequestTimeout = 20 * time.Second
+	ConnectTimeout = 2 * time.Second
+	RequestTimeout = 10 * time.Second
 
 	IngressClassName        = "cilium"
 	IngressControllerName   = "cilium.io/ingress-controller"


### PR DESCRIPTION
The timeouts are extensively used in connectivity tests which checks whether a policy has denied a connection. Obviously, this leads to waiting 20s.

Before (with the upcoming IPv6 connectivity tests):

    ./cilium connectivity test  6.99s user 1.42s system 1% cpu 11:48.72
    total

After:

    ./cilium connectivity test  7.06s user 1.40s system 2% cpu 6:14.97
    total