### PR TITLE
fix(connectivity): add dns rules and change protocol to ANY

### DIFF
--- a/connectivity/manifests/allow-all-except-world.yaml
+++ b/connectivity/manifests/allow-all-except-world.yaml
@@ -19,9 +19,11 @@ spec:
   # This change prevents failing the connectivity
   # test for such environments.
   - toPorts:
-      - ports:
-          - port: "53"
-            protocol: UDP
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
     toEntities:
       - world
   ingress:

--- a/connectivity/manifests/client-egress-l7-tls.yaml
+++ b/connectivity/manifests/client-egress-l7-tls.yaml
@@ -12,7 +12,9 @@ specs:
   - toPorts:
     - ports:
       - port: "53"
-        protocol: ANY
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
       rules:
         dns:
           - matchPattern: "*"

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -10,7 +10,9 @@ spec:
   - toPorts:
     - ports:
       - port: "53"
-        protocol: ANY
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
       rules:
         dns:
         - matchPattern: "*"
@@ -26,5 +28,10 @@ spec:
     - ports:
       - port: "53"
         protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
     toEntities:
     - world

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -18,7 +18,9 @@ spec:
   - toPorts:
     - ports:
       - port: "53"
-        protocol: ANY
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
     toEndpoints:
     - matchExpressions:
       - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
@@ -31,5 +33,7 @@ spec:
     - ports:
       - port: "53"
         protocol: UDP
+      - port: "53"
+        protocol: TCP
     toEntities:
     - world

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -20,7 +20,9 @@ spec:
     toPorts:
     - ports:
       - port: "53"
-        protocol: ANY
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
   # When node-local-dns is deployed with local IP,
   # Cilium labels its ip as world.
   # This change prevents failing the connectivity
@@ -29,5 +31,7 @@ spec:
     - ports:
       - port: "53"
         protocol: UDP
+      - port: "53"
+        protocol: TCP
     toEntities:
     - world

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -20,7 +20,9 @@ spec:
   - toPorts:
     - ports:
       - port: "53"
-        protocol: ANY
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
       rules:
         dns:
         - matchPattern: "*"
@@ -36,5 +38,10 @@ spec:
     - ports:
       - port: "53"
         protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
     toEntities:
     - world


### PR DESCRIPTION
Connectivity tests fail with the `node-local-dns` environment. This PR adds missing `DNS` rules and changes protocol from `UDP` to `ANY`