### PR TITLE
connectivity tests: support IPv6 in ICMP-related netpols

### DIFF
--- a/connectivity/manifests/echo-ingress-icmp-deny.yaml
+++ b/connectivity/manifests/echo-ingress-icmp-deny.yaml
@@ -13,4 +13,7 @@ spec:
         other: client
     icmps:
     - fields:
-      - type: 8
+      - family: IPv4
+        type: 8
+      - family: IPv6
+        type: 128

--- a/connectivity/manifests/echo-ingress-icmp.yaml
+++ b/connectivity/manifests/echo-ingress-icmp.yaml
@@ -13,4 +13,7 @@ spec:
         other: client
     icmps:
     - fields:
-      - type: 8
+      - family: IPv4
+        type: 8
+      - family: IPv6
+        type: 128


### PR DESCRIPTION
This PR expands the ICMP-related netpols used for the connectivity tests to allow both IPv4 ICMP Echo Requests (type 8) and IPV6 ICMP Echo Requests (type 128), to ensure that the tests run correctly also on IPv6-only clusters.