### PR TITLE
ingress: Create Ingress Service if required

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -111,7 +111,7 @@ func (k *K8sInstaller) generateIngressClass() *networkingv1.IngressClass {
 
 	switch {
 	case versioncheck.MustCompile(">=1.12.0")(k.chartVersion):
-		ingressFileName = "templates/cilium-operator-deployment.yaml"
+		ingressFileName = "templates/cilium-ingress-class.yaml"
 	}
 
 	ingressClassFile, exists := k.manifests[ingressFileName]


### PR DESCRIPTION
This is to make sure that the shared ingress service can be created if
required.

Reported-by: Xiao Song
Signed-off-by: Tam Mach <tam.mach@cilium.io>
