### PR TITLE
connectivity tests: fix issue on IPv6-only clusters

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1061,7 +1061,7 @@ func (ct *ConnectivityTest) waitForPodDNS(ctx context.Context, srcPod, dstPod Po
 		// See https://coredns.io/plugins/local/ for more info.
 		target := "localhost"
 		stdout, err := srcPod.K8sClient.ExecInPod(ctx, srcPod.Pod.Namespace, srcPod.Pod.Name,
-			"", []string{"nslookup", target, dstPod.Address(IPFamilyV4)})
+			"", []string{"nslookup", target, dstPod.Address(IPFamilyAny)})
 
 		if err == nil {
 			return nil

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -83,10 +83,10 @@ func (p Pod) Path() string {
 func (p Pod) Address(family IPFamily) string {
 	for _, addr := range p.Pod.Status.PodIPs {
 		ip := net.ParseIP(addr.IP)
-		if (family == IPFamilyV4 || family == IPFamilyNone) && ip.To4() != nil {
+		if (family == IPFamilyV4 || family == IPFamilyAny) && ip.To4() != nil {
 			return addr.IP
 		}
-		if family == IPFamilyV6 && ip.To4() == nil && ip.To16() != nil {
+		if (family == IPFamilyV6 || family == IPFamilyAny) && ip.To4() == nil && ip.To16() != nil {
 			return addr.IP
 		}
 	}

--- a/connectivity/check/utils.go
+++ b/connectivity/check/utils.go
@@ -8,16 +8,17 @@ import "net"
 type IPFamily int
 
 const (
-	// IPFamilyNone is used for non-IP based endpoints (e.g., HTTP URL)
-	IPFamilyNone IPFamily = iota
+	// IPFamilyAny is used for non-IP based endpoints (e.g., HTTP URL),
+	// and when any IP family could be used.
+	IPFamilyAny IPFamily = iota
 	IPFamilyV4
 	IPFamilyV6
 )
 
 func (f IPFamily) String() string {
 	switch f {
-	case IPFamilyNone:
-		return "none"
+	case IPFamilyAny:
+		return "any"
 	case IPFamilyV4:
 		return "ipv4"
 	case IPFamilyV6:
@@ -37,5 +38,5 @@ func GetIPFamily(addr string) IPFamily {
 		return IPFamilyV6
 	}
 
-	return IPFamilyNone
+	return IPFamilyAny
 }

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -683,7 +683,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 			tests.PodToWorld2(), // resolves cilium.io
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.IPFamilyNone) == "cilium.io" {
+			if a.Destination().Address(check.IPFamilyAny) == "cilium.io" {
 				if a.Destination().Path() == "/" || a.Destination().Path() == "" {
 					egress = check.ResultDNSOK
 					egress.HTTP = check.HTTP{

--- a/connectivity/tests/cidr.go
+++ b/connectivity/tests/cidr.go
@@ -35,8 +35,8 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 		for _, src := range ct.ClientPods() {
 			src := src // copy to avoid memory aliasing when using reference
 
-			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep, check.IPFamilyNone).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(ep, check.IPFamilyNone))
+			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep, check.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(ep, check.IPFamilyAny))
 
 				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
 					RSTAllowed: true,

--- a/connectivity/tests/dummy.go
+++ b/connectivity/tests/dummy.go
@@ -27,13 +27,13 @@ func (s *dummy) Name() string {
 }
 
 func (s *dummy) Run(ctx context.Context, t *check.Test) {
-	t.NewAction(s, "action-1", nil, nil, check.IPFamilyNone).Run(func(a *check.Action) {
+	t.NewAction(s, "action-1", nil, nil, check.IPFamilyAny).Run(func(a *check.Action) {
 		a.Log("logging")
 		a.Debug("debugging")
 		a.Info("informing")
 	})
 
-	t.NewAction(s, "action-2", nil, nil, check.IPFamilyNone).Run(func(a *check.Action) {
+	t.NewAction(s, "action-2", nil, nil, check.IPFamilyAny).Run(func(a *check.Action) {
 		a.Log("logging")
 		a.Fatal("killing :(")
 		a.Fail("failing (this should not be printed)")

--- a/connectivity/tests/health.go
+++ b/connectivity/tests/health.go
@@ -30,7 +30,7 @@ func (s *ciliumHealth) Name() string {
 func (s *ciliumHealth) Run(ctx context.Context, t *check.Test) {
 	for name, pod := range t.Context().CiliumPods() {
 		pod := pod
-		t.NewAction(s, name, &pod, nil, check.IPFamilyNone).Run(func(a *check.Action) {
+		t.NewAction(s, name, &pod, nil, check.IPFamilyAny).Run(func(a *check.Action) {
 			runHealthProbe(ctx, t.Context(), &pod)
 		})
 	}

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -90,14 +90,14 @@ func (s *podToHostPort) Run(ctx context.Context, t *check.Test) {
 
 			baseURL := fmt.Sprintf("%s://%s:%d%s", echo.Scheme(), echo.Pod.Status.HostIP, check.EchoServerHostPort, echo.Path())
 			ep := check.HTTPEndpoint(echo.Name(), baseURL)
-			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, ep, check.IPFamilyNone).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(ep, check.IPFamilyNone))
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, ep, check.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(ep, check.IPFamilyAny))
 
 				a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
 					// Because the HostPort request is NATed, we might only
 					// observe flows after DNAT has been applied (e.g. by
 					// HostReachableServices),
-					AltDstIP:   echo.Address(check.IPFamilyNone),
+					AltDstIP:   echo.Address(check.IPFamilyAny),
 					AltDstPort: echo.Port(),
 				}))
 			})

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -49,8 +49,8 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 				continue
 			}
 
-			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, check.IPFamilyNone).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(svc, check.IPFamilyNone))
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, check.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(svc, check.IPFamilyAny))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
@@ -179,8 +179,8 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 
 			// Create the Action with the original svc as this will influence what the
 			// flow matcher looks for in the flow logs.
-			t.NewAction(s, name, pod, svc, check.IPFamilyNone).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, t.Context().CurlCommand(ep, check.IPFamilyNone))
+			t.NewAction(s, name, pod, svc, check.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, t.Context().CurlCommand(ep, check.IPFamilyAny))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					// The fact that curl is hitting the NodePort instead of the

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -42,20 +42,20 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		client := client // copy to avoid memory aliasing when using reference
 
 		// With http, over port 80.
-		t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &client, http, check.IPFamilyNone).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(http, check.IPFamilyNone))
+		t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &client, http, check.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(http, check.IPFamilyAny))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443.
-		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, check.IPFamilyNone).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyNone))
+		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, check.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyAny))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443, index.html.
-		t.NewAction(s, fmt.Sprintf("https-to-%s-index-%d", extTarget, i), &client, httpsindex, check.IPFamilyNone).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(httpsindex, check.IPFamilyNone))
+		t.NewAction(s, fmt.Sprintf("https-to-%s-index-%d", extTarget, i), &client, httpsindex, check.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(httpsindex, check.IPFamilyAny))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
@@ -91,8 +91,8 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 		client := client // copy to avoid memory aliasing when using reference
 
 		// With https, over port 443.
-		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https, check.IPFamilyNone).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyNone))
+		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https, check.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyAny))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 


### PR DESCRIPTION
This PR changes the behavior of `IPFamilyNone` (now renamed to `IPFamilyAny` for consistency) to allow both IPv4 and IPv6 addresses, and switches the "waitForPodDNS" check to use it is order to prevent issues on IPv6-only clusters.