### PR TITLE
connectivity: New flags skip-ipv4/6 to skip IPv4/6 checks

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -38,6 +38,8 @@ type Parameters struct {
 	Timestamp             bool
 	PauseOnFail           bool
 	SkipIPCacheCheck      bool
+	SkipIPv4              bool
+	SkipIPv6              bool
 	Perf                  bool
 	PerfDuration          time.Duration
 	PerfCRR               bool

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -347,13 +347,20 @@ func (t *Test) collectSysdump() {
 func (t *Test) ForEachIPFamily(do func(IPFamily)) {
 	ipFams := []IPFamily{IPFamilyV4, IPFamilyV6}
 
-	// TODO(brb):
-	// The per-endpoint routes feature is broken with IPv6 when there are any
-	// netpols installed (tracked in https://github.com/cilium/cilium/issues/23852
-	// and https://github.com/cilium/cilium/issues/23910). Once both issues
-	// are resolved, we can start testing IPv6 with netpols.
-	if f, ok := t.Context().Feature(FeatureEndpointRoutes); ok && f.Enabled && len(t.cnps) > 0 {
+	if t.ctx.params.SkipIPv4 {
+		ipFams = []IPFamily{IPFamilyV6}
+	}
+	if t.ctx.params.SkipIPv6 {
 		ipFams = []IPFamily{IPFamilyV4}
+	} else {
+		// TODO(brb):
+		// The per-endpoint routes feature is broken with IPv6 when there are any
+		// netpols installed (tracked in https://github.com/cilium/cilium/issues/23852
+		// and https://github.com/cilium/cilium/issues/23910). Once both issues
+		// are resolved, we can start testing IPv6 with netpols.
+		if f, ok := t.Context().Feature(FeatureEndpointRoutes); ok && f.Enabled && len(t.cnps) > 0 {
+			ipFams = []IPFamily{IPFamilyV4}
+		}
 	}
 
 	for _, ipFam := range ipFams {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -136,6 +136,8 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")
 	cmd.Flags().MarkHidden("datapath")
+	cmd.Flags().BoolVar(&params.SkipIPv4, "skip-ipv4", false, "Skip IPv4 checks")
+	cmd.Flags().BoolVar(&params.SkipIPv6, "skip-ipv6", false, "Skip IPv6 checks")
 
 	cmd.Flags().StringVar(&params.K8sVersion, "k8s-version", "", "Kubernetes server version in case auto-detection fails")
 	cmd.Flags().StringVar(&params.HelmChartDirectory, "chart-directory", "", "Helm chart directory")


### PR DESCRIPTION
In some cases, we may want to test only one of IPv4 or IPv6 even if both are enabled in the cluster. That could be because e.g. we're only interested in IPv6 at the moment or because IPv4 is know to be broken. Whatever the reason may be, it's useful to have a quick way to skip an IP family in all checks.

This pull request introduces new flags `--skip-ipv4` and `--skip-ipv6` that, when passed, will skip all checks for the corresponding IP family.