### PR TITLE
enabled l7Proxy & removed err.log message for WireGuard

### DIFF
--- a/install/helm.go
+++ b/install/helm.go
@@ -125,11 +125,13 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 			// TODO(gandro): Future versions of Cilium will remove the following
 			// two limitations, we will need to have set the config map values
 			// based on the installed Cilium version
-			helmMapOpts["l7Proxy"] = "false"
-			k.Log("ℹ️  L7 proxy disabled due to Wireguard encryption")
+			if versioncheck.MustCompile("<=1.13.0")(k.chartVersion) {
+				helmMapOpts["l7Proxy"] = "false"
+				k.Log("ℹ️  L7 proxy disabled due to Wireguard encryption")
 
-			if k.params.NodeEncryption {
-				k.Log("⚠️️  Wireguard does not support node encryption yet")
+				if k.params.NodeEncryption {
+					k.Log("⚠️️  Wireguard does not support node encryption yet")
+				}
 			}
 		}
 


### PR DESCRIPTION
Since https://github.com/cilium/cilium/pull/19401 (to be released in v1.14) there's no need to **_disable_** the `L7 proxy` when WireGuard is **_enabled_** on the > v1.13 Cilium (the relevant log message L7 proxy disabled due to Wireguard encryption).

> As a bonus, the unnecessary log/WARN `Wireguard does not support node encryption yet` has also been removed.

Fixes #1405 
cc: @brb 
Signed-off-by: [Pratyay Banerjee](mailto:putubanerjee23@gmail.com)