### PR TITLE
clustermesh: update etcd version to v3.5.4

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -163,7 +163,7 @@ func (k *K8sClusterMesh) apiserverImage(imagePathMode utils.ImagePathMode) strin
 }
 
 func (k *K8sClusterMesh) etcdImage() string {
-	etcdVersion := "v3.4.13"
+	etcdVersion := "v3.5.4"
 	if k.clusterArch == "amd64" {
 		return "quay.io/coreos/etcd:" + etcdVersion
 	}


### PR DESCRIPTION
With helm, etcd uses v3.5.4.
There is no reason to separate cilium-cli, so we will match them.

https://github.com/cilium/cilium/blob/e8104547227af8fa53ed197e13f5879957d8297c/install/kubernetes/cilium/values.yaml#L2288

The container image in v3.5.4 of etcd is multi-platform.
I am using EKS, which is a managed control plane, so I am running on amd64.

Therefore, when using EKS, there are many configurations where the control plane is amd64, but the node runs on arm64.
Currently, the `-arm64` suffix of etcd only refers to the architecture of the control plane, so it does not cover many usecases.
However, upgrading etcd will solve all the problems.

```
Server Version: version.Info{Major:"1", Minor:"25+", GitVersion:"v1.25.6-eks-48e63af", GitCommit:"9f22d4ae876173884749c0701f01340879ab3f95", GitTreeState:"clean", BuildDate:"2023-01-24T19:19:02Z", GoVersion:"go1.19.5", Compiler:"gc", Platform:"linux/amd64"}
```

https://quay.io/repository/coreos/etcd?tab=tags&tag=latest
