### PR TITLE
Add profiling data(cpu/heap) of cilium agent to sysdump.

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -74,6 +74,9 @@ func initSysdumpFlags(cmd *cobra.Command, options *sysdump.Options, optionPrefix
 	cmd.Flags().BoolVar(&options.Debug,
 		optionPrefix+"debug", sysdump.DefaultDebug,
 		"Whether to enable debug logging")
+	cmd.Flags().BoolVar(&options.Profiling,
+		optionPrefix+"profiling", sysdump.DefaultProfiling,
+		"Whether to enable scraping profiling data")
 	cmd.Flags().StringArrayVar(&options.ExtraLabelSelectors,
 		optionPrefix+"extra-label-selectors", nil,
 		"Optional set of labels selectors used to target additional pods for log collection.")

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -113,6 +113,10 @@ var (
 		"stack",
 		"stats",
 	}
+	gopsProfiling = []string{
+		"pprof-heap",
+		"pprof-cpu",
+	}
 )
 
 var (

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -28,6 +28,7 @@ const (
 	DefaultCiliumOperatorLabelSelector       = "io.cilium/app=operator"
 	DefaultClustermeshApiserverLabelSelector = labelPrefix + "clustermesh-apiserver"
 	DefaultDebug                             = false
+	DefaultProfiling                         = true
 	DefaultHubbleLabelSelector               = labelPrefix + "hubble"
 	DefaultHubbleFlowsCount                  = 10000
 	DefaultHubbleFlowsTimeout                = 5 * time.Second

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -148,6 +148,19 @@ func (b *SysdumpSuite) TestExtractGopsPID(c *check.C) {
 
 }
 
+func (b *SysdumpSuite) TestExtractGopsProfileData(c *check.C) {
+	gopsOutput := `
+	Profiling CPU now, will take 30 secs...
+	Profile dump saved to: /tmp/cpu_profile3302111893
+	`
+	wantFilepath := "/tmp/cpu_profile3302111893"
+
+	gotFilepath, err := extractGopsProfileData(gopsOutput)
+	c.Assert(err, check.IsNil)
+	c.Assert(gotFilepath, check.Equals, wantFilepath)
+
+}
+
 func TestKVStoreTask(t *testing.T) {
 	assert := assert.New(t)
 	client := &fakeClient{


### PR DESCRIPTION
Scrape cpu and heap profiles from the Cilium agents by default when gathering sysdump. 