### PR TITLE
Don't enable nodeinit on EKS when not needed

### DIFF
--- a/install/helm.go
+++ b/install/helm.go
@@ -169,22 +169,20 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 			}
 		}
 
+		// Set nodeinit enabled option
+		if needsNodeInit(k.flavor.Kind, k.chartVersion) {
+			helmMapOpts["nodeinit.enabled"] = "true"
+		}
+
 		// Set Helm options specific to the detected Kubernetes cluster type
 		switch k.flavor.Kind {
 		case k8s.KindKind:
 			helmMapOpts["ipam.mode"] = ipamKubernetes
 
-		case k8s.KindEKS:
-			helmMapOpts["nodeinit.enabled"] = "true"
-
 		case k8s.KindGKE:
-			helmMapOpts["nodeinit.enabled"] = "true"
 			helmMapOpts["nodeinit.removeCbrBridge"] = "true"
 			helmMapOpts["nodeinit.reconfigureKubelet"] = "true"
 			helmMapOpts["cni.binPath"] = "/home/kubernetes/bin"
-
-		case k8s.KindAKS:
-			helmMapOpts["nodeinit.enabled"] = "true"
 
 		case k8s.KindMicrok8s:
 			helmMapOpts["cni.binPath"] = Microk8sSnapPath + "/opt/cni/bin"

--- a/install/install.go
+++ b/install/install.go
@@ -917,7 +917,7 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 	})
 
 	// Create the node-init daemonset if one is required for the current kind.
-	if needsNodeInit(k.flavor.Kind) {
+	if needsNodeInit(k.flavor.Kind, k.chartVersion) {
 		k.Log("🚀 Creating %s Node Init DaemonSet...", k.flavor.Kind.String())
 		ds := k.generateNodeInitDaemonSet(k.flavor.Kind)
 		if _, err := k.client.CreateDaemonSet(ctx, k.params.Namespace, ds, metav1.CreateOptions{}); err != nil {

--- a/install/node_init.go
+++ b/install/node_init.go
@@ -4,17 +4,24 @@
 package install
 
 import (
-	"github.com/cilium/cilium/pkg/versioncheck"
+	"github.com/blang/semver/v4"
 	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/k8s"
 )
 
-func needsNodeInit(k k8s.Kind) bool {
+func needsNodeInit(k k8s.Kind, version semver.Version) bool {
 	switch k {
-	case k8s.KindAKS, k8s.KindEKS, k8s.KindGKE:
+
+	case k8s.KindAKS, k8s.KindGKE:
 		return true
+	case k8s.KindEKS:
+		if versioncheck.MustCompile("<=1.13.1")(version) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Recent changes to helm charts make nodeinit not necessary on EKS, let's enable it only on older versions.

Don't merge it until https://github.com/cilium/cilium/pull/24134 is backported and released (version check might require changes)