### PR TITLE
.github/workflows: use tag name instead of fully-formed ref in release name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          name: Release ${{ github.ref }}
+          name: Release ${{ github.ref_name }}
           draft: true
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION


Before the release would be named "Release refs/tags/v0.13.1", now it's named "Release v0.13.1".

Fixes: 34db9d12626a (".github/workflows: use softprops/action-gh-release in release workflow")