### PR TITLE
RELEASE.md: adjust release instructions after change to new release action

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,8 +62,7 @@ Then tag and push the release:
 
 When a tag is pushed, a GitHub Action job takes care of creating a new GitHub
 draft release, building artifacts and attaching them to the draft release. Once
-the draft is ready, use the "Auto-generate release notes" button to generate
-the release notes from PR titles, review them and publish the release.
+the draft is ready, review the release notes and publish the release.
 
 ### Update stable.txt
 


### PR DESCRIPTION
We no longer need to hit the button, the action generates the release notes for us :sparkle:

See https://github.com/cilium/cilium-cli/pull/1433