### PR TITLE
experiment: Don't pay attention to yaml files anymore

### DIFF
--- a/connectivity/check/delete.go
+++ b/connectivity/check/delete.go
@@ -161,21 +161,21 @@ func (ct *ConnectivityTest) generateManifestsNodeAffinity(ctx context.Context, h
 		}
 		k8sVersionStr = k8sVersion.String()
 	}
+	/*
+		manifests, err := helm.GenManifests(
+			ctx,
+			ct.params.HelmChartDirectory,
+			k8sVersionStr,
+			helmState.Version,
+			ct.params.CiliumNamespace,
+			vals,
+			[]string{},
+		)
+		if err != nil {
+			return err
+		}*/
 
-	manifests, err := helm.GenManifests(
-		ctx,
-		ct.params.HelmChartDirectory,
-		k8sVersionStr,
-		helmState.Version,
-		ct.params.CiliumNamespace,
-		vals,
-		[]string{},
-	)
-	if err != nil {
-		return err
-	}
-
-	ct.manifests = manifests
+	//ct.manifests = manifests //XXX
 	ct.helmYAMLValues = yamlValues
 	return nil
 }

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -594,12 +594,12 @@ func (k *K8sHubble) genManifests(ctx context.Context, printHelmTemplate bool, pr
 		k8sVersionStr = k8sVersion.String()
 	}
 
-	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, ciliumVer, k.params.Namespace, vals, apiVersions)
+	//	manifests, err := helm.GenManifests(ctx, k.params.HelmChartDirectory, k8sVersionStr, ciliumVer, k.params.Namespace, vals, apiVersions)
 	if err != nil {
 		return err
 	}
 
-	k.manifests = manifests
+	//k.manifests = manifests
 	k.helmYAMLValues = yamlValue
 	return nil
 }

--- a/install/azure.go
+++ b/install/azure.go
@@ -7,13 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	"github.com/cilium/cilium/pkg/versioncheck"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/internal/utils"
 )
 
 type azureVersionValidation struct{}
@@ -218,6 +211,7 @@ func (k *K8sInstaller) azExec(args ...string) ([]byte, error) {
 	return k.Exec("az", args...)
 }
 
+/*
 func (k *K8sInstaller) createAKSSecrets(ctx context.Context) error {
 	// Check if secret already exists and reuse it
 	_, err := k.client.GetSecret(ctx, k.params.Namespace, defaults.AKSSecretName, metav1.GetOptions{})
@@ -255,3 +249,4 @@ func (k *K8sInstaller) createAKSSecrets(ctx context.Context) error {
 
 	return nil
 }
+*/

--- a/install/helm.go
+++ b/install/helm.go
@@ -318,6 +318,7 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	k.Log("%+v", manifests)
 
 	k.manifests = manifests
 	k.helmYAMLValues = yamlValue

--- a/install/node_init.go
+++ b/install/node_init.go
@@ -4,10 +4,6 @@
 package install
 
 import (
-	"github.com/cilium/cilium/pkg/versioncheck"
-	appsv1 "k8s.io/api/apps/v1"
-
-	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/k8s"
 )
 
@@ -19,6 +15,7 @@ func needsNodeInit(k k8s.Kind) bool {
 	return false
 }
 
+/*
 func (k *K8sInstaller) generateNodeInitDaemonSet(_ k8s.Kind) *appsv1.DaemonSet {
 	var (
 		dsFileName string
@@ -37,3 +34,5 @@ func (k *K8sInstaller) generateNodeInitDaemonSet(_ k8s.Kind) *appsv1.DaemonSet {
 	utils.MustUnmarshalYAML([]byte(dsFile), &ds)
 	return &ds
 }
+
+*/

--- a/install/rbac.go
+++ b/install/rbac.go
@@ -3,16 +3,7 @@
 
 package install
 
-import (
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-
-	"github.com/cilium/cilium/pkg/versioncheck"
-
-	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/internal/utils"
-)
-
+/*
 func (k *K8sInstaller) NewServiceAccount(name string) *corev1.ServiceAccount {
 	var (
 		saFileName string
@@ -159,3 +150,4 @@ func (k *K8sInstaller) NewRoleBinding(crbName string) []*rbacv1.RoleBinding {
 	}
 	return out
 }
+*/


### PR DESCRIPTION
Rather than referencing individual template files, set up install such that we pass around rendered objects and reference them by name and kind.

This means we don't have to worry about template structure changing when using cilium-cli.