### PR TITLE
connectivity: allow to restrict connectivity test pods using nodeSelector

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -50,6 +50,7 @@ type Parameters struct {
 	DNSTestServerImage    string
 	Datapath              bool
 	AgentPodSelector      string
+	NodeSelector          map[string]string
 	ExternalTarget        string
 	ExternalCIDR          string
 	ExternalIP            string

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -119,6 +119,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity test in")
 	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
 	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
+	cmd.Flags().StringToStringVar(&params.NodeSelector, "node-selector", map[string]string{}, "Restrict connectivity test pods to nodes matching this label")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")


### PR DESCRIPTION
The connectivity test pods will be restricted to nodes matching labels given in the `--node-selector` flag.

Usage:

    $ kubectl get nodes
    NAME                 STATUS   ROLES           AGE   VERSION
    kind-control-plane   Ready    control-plane   15m   v1.25.3
    kind-worker          Ready    <none>          15m   v1.25.3
    kind-worker2         Ready    <none>          15m   v1.25.3
    kind-worker3         Ready    <none>          15m   v1.25.3
    kind-worker4         Ready    <none>          15m   v1.25.3
    $ kubectl label nodes kind-worker{2,3} connectivity.cilium.io/test=true
    $ cilium connectivity test --node-selector connectivity.cilium.io/test=true
    [...]
    ✅ All 32 tests (261 actions) successful, 2 tests skipped, 1 scenarios skipped.
    $ kubectl get pods -n cilium-test -o wide
    NAME                              READY   STATUS    RESTARTS   AGE     IP             NODE           NOMINATED NODE   READINESS GATES
    client-7858556799-xd52x           1/1     Running   0          5m56s   10.244.2.120   kind-worker3   <none>           <none>
    client2-646989676f-zgxxl          1/1     Running   0          5m56s   10.244.2.55    kind-worker3   <none>           <none>
    echo-other-node-79659b5c6-8dzfw   2/2     Running   0          5m55s   10.244.3.148   kind-worker2   <none>           <none>
    echo-same-node-69f7699d84-5bvxj   2/2     Running   0          5m56s   10.244.2.168   kind-worker3   <none>           <none>

Fixes #1269