### PR TITLE
bug: "allow-all-egress.yaml" Manifest Traffic Fix

### DIFF
--- a/connectivity/manifests/allow-all-egress.yaml
+++ b/connectivity/manifests/allow-all-egress.yaml
@@ -7,5 +7,5 @@ spec:
   egress:
   - toEndpoints:
     - {}
-  - toCIDR:
-    - 0.0.0.0/0
+  - toEntities:
+      - world


### PR DESCRIPTION
The "allow-all" egress policy manifest file for the connectivity tests incorrectly "allows all" traffic with the policy of allowing all IPv4 traffic. This works because of a bug in Cilium which incorrectly translates the "0.0.0.0/0" CIDR policy as being synonymous with the "world" entity. This is incorrect and is being fixed. The policy now correctly refers to all external traffic.