### PR TITLE
helm: fix incorrect log error formatting directive.

### DIFF
--- a/install/helm.go
+++ b/install/helm.go
@@ -284,7 +284,7 @@ func (k *K8sInstaller) generateManifests(ctx context.Context) error {
 	if len(apiVersions) == 0 {
 		gvs, err := k.client.ListAPIResources(ctx)
 		if err != nil {
-			k.Log("⚠️ Unable to list kubernetes api resources, try --api-versions if needed: %w", err)
+			k.Log("⚠️ Unable to list kubernetes api resources, try --api-versions if needed: %s", err)
 		}
 		for _, gv := range gvs {
 			switch gv {


### PR DESCRIPTION
Replace logf error wrap directive with string.

Fixes ugly logs like:

```
⚠️ Unable to list kubernetes api resources, try --api-versions if needed: %!w(*fmt.wrapError=&{failed to list api resources: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request 0x14000e26030})
```