### PR TITLE
refactor: Break generateManifests() into smaller functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/apiserver v0.26.2 // indirect

--- a/install/helm_test.go
+++ b/install/helm_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package install
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cilium/cilium-cli/k8s"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestK8sInstaller_getHelmValuesKind(t *testing.T) {
+	installer := K8sInstaller{
+		params:       Parameters{},
+		flavor:       k8s.Flavor{Kind: k8s.KindKind},
+		chartVersion: semver.MustParse("1.13.0"),
+	}
+	values, err := installer.getHelmValues()
+	assert.NoError(t, err)
+	actual, err := yaml.Marshal(values)
+	assert.NoError(t, err)
+	expected, err := os.ReadFile("testdata/kind.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, string(expected), string(actual))
+}

--- a/install/testdata/kind.yaml
+++ b/install/testdata/kind.yaml
@@ -1,0 +1,9 @@
+ipam:
+  mode: kubernetes
+operator:
+  replicas: 1
+serviceAccounts:
+  cilium:
+    name: cilium
+  operator:
+    name: cilium-operator


### PR DESCRIPTION
Break generateManifests() into smaller functions without changing the logic to make it easier to reuse and unit test.