### PR TITLE
clustermesh: correctly mount the etcd data dir in the init container

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -320,7 +320,7 @@ func (k *K8sClusterMesh) generateDeployment(clustermeshApiserverArgs []string) *
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "etcd-data-dir",
-									MountPath: "etcd-data-dir",
+									MountPath: "/var/run/etcd",
 								},
 							},
 						},


### PR DESCRIPTION
This PR fixes an incorrect volume mount specification for the init container of the clustermesh-apiserver deployment created through `cilium clustermesh enable`.