### PR TITLE
Add a l7 header replace test

### DIFF
--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -182,6 +182,14 @@ var (
 		ExitCode:       ExitCurlHTTPError,
 	}
 
+	// ResultCurlHTTPError expects a failed command, but no dropped flow or DNS proxy.
+	ResultCurlHTTPError = Result{
+		L7Proxy:        true,
+		Drop:           false,
+		DropReasonFunc: defaultDropReason,
+		ExitCode:       ExitCurlHTTPError,
+	}
+
 	// ResultDrop expects a dropped flow and a failed command.
 	ResultDrop = Result{
 		Drop:           true,

--- a/connectivity/manifests/client-egress-l7-http-matchheader-secret.yaml
+++ b/connectivity/manifests/client-egress-l7-http-matchheader-secret.yaml
@@ -1,0 +1,32 @@
+---
+# client2 is allowed to contact the echo Pod
+# on port 8080 via POST method. HTTP introspection is enabled for client2.
+# The request to /auth-header-required will be injected with an auth header to work
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-l7-http-matchheader-secret
+spec:
+  description: "Allow POST <echo>:8080/auth-header-required and set the header from client2"
+  endpointSelector:
+    matchLabels:
+      other: client
+  egress:
+  # Allow POST /auth-header-required requests towards echo pods with added header.
+  - toEndpoints:
+    - matchLabels:
+        kind: echo
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "POST"
+          path: "/auth-header-required$"
+          headerMatches:
+            - name: Authorization
+              mismatch: REPLACE
+              secret:
+                namespace: "{{.TestNamespace}}"
+                name: header-match

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -13,6 +13,7 @@ type labelsOption struct {
 	sourceLabels      map[string]string
 	destinationLabels map[string]string
 	method            string
+	path              string
 }
 
 func WithMethod(method string) Option {
@@ -30,6 +31,12 @@ func WithSourceLabelsOption(sourceLabels map[string]string) Option {
 func WithDestinationLabelsOption(destinationLabels map[string]string) Option {
 	return func(option *labelsOption) {
 		option.destinationLabels = destinationLabels
+	}
+}
+
+func WithPath(path string) Option {
+	return func(option *labelsOption) {
+		option.path = path
 	}
 }
 

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -76,6 +76,7 @@ func PodToPodWithEndpoints(opts ...Option) check.Scenario {
 		sourceLabels:      options.sourceLabels,
 		destinationLabels: options.destinationLabels,
 		method:            options.method,
+		path:              options.path,
 	}
 }
 
@@ -84,6 +85,7 @@ type podToPodWithEndpoints struct {
 	sourceLabels      map[string]string
 	destinationLabels map[string]string
 	method            string
+	path              string
 }
 
 func (s *podToPodWithEndpoints) Name() string {
@@ -123,7 +125,12 @@ func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test
 	}
 
 	// Manually construct an HTTP endpoint for each API endpoint.
-	for _, path := range []string{"public", "private"} {
+	paths := []string{"public", "private"}
+	if s.path != "" { // Override default paths if one is set
+		paths = []string{s.path}
+	}
+
+	for _, path := range paths {
 		epName := fmt.Sprintf("%s-%s", name, path)
 		url := fmt.Sprintf("%s/%s", baseURL, path)
 		ep := check.HTTPEndpointWithLabels(epName, url, echo.Labels())

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -69,7 +69,7 @@ const (
 
 	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.6.0@sha256:408430f548a8390089b9b83020148b0ef80b0be1beb41a98a8bfe036709c196e"
 	ConnectivityPerformanceImage     = "quay.io/cilium/network-perf:a816f935930cb2b40ba43230643da4d5751a5711@sha256:679d3a370c696f63884da4557a4466f3b5569b4719bb4f86e8aac02fbe390eea"
-	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0"
+	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.4@sha256:d5fbc5d7762530b53af27b0ba247e61a2fa5da42c8b5a58956933fe6a6ce15b8"
 	ConnectivityDNSTestServerImage   = "docker.io/coredns/coredns:1.10.0@sha256:017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955"
 
 	ConfigMapName = "cilium-config"


### PR DESCRIPTION
This adds a test for the L7 policy to add/replace a HTTP header in a request. It does this by sending a request to a new endpoint that required an auth header, which will succeed if injected from a secret.

This came up while needing a test for https://github.com/cilium/cilium/issues/24020 and it will work against the current Cilium version where it was previously not tested in Ginkgo. 
