### PR TITLE
Add connectivity tests for auth

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -59,6 +59,8 @@ const (
 
 	FeatureCNP Feature = "cilium-network-policy"
 	FeatureKNP Feature = "k8s-network-policy"
+
+	FeatureAuthMTLSSpiffe Feature = "auth-mtls-spiffe"
 )
 
 // FeatureStatus describes the status of a feature. Some features are either
@@ -197,6 +199,10 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 
 	result[FeatureEndpointRoutes] = FeatureStatus{
 		Enabled: cm.Data["enable-endpoint-routes"] == "true",
+	}
+
+	result[FeatureAuthMTLSSpiffe] = FeatureStatus{
+		Enabled: cm.Data["mesh-auth-mtls-enabled"] == "true",
 	}
 
 	return nil

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -202,6 +202,10 @@ func defaultDenyReason(flow *flowpb.Flow) bool {
 	return flow.GetDropReasonDesc() == flowpb.DropReason_POLICY_DENIED
 }
 
+func authRequiredDropReason(flow *flowpb.Flow) bool {
+	return flow.GetDropReasonDesc() == flowpb.DropReason_AUTH_REQUIRED
+}
+
 var (
 	// ResultNone expects a successful command, don't match any packets.
 	ResultNone = Result{
@@ -246,6 +250,12 @@ var (
 		Drop:           true,
 		ExitCode:       ExitAnyError,
 		DropReasonFunc: defaultDropReason,
+	}
+
+	// ResultDropAuthRequired expects a dropped flow with auth required as reason.
+	ResultDropAuthRequired = Result{
+		Drop:           true,
+		DropReasonFunc: authRequiredDropReason,
 	}
 
 	// ResultAnyReasonEgressDrop expects a dropped flow at Egress and a failed command.

--- a/connectivity/manifests/echo-ingress-auth-fail.yaml
+++ b/connectivity/manifests/echo-ingress-auth-fail.yaml
@@ -1,0 +1,21 @@
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: auth-ingress-fail
+  namespace: cilium-test
+spec:
+  description: "Allow other client to contact echo but fail on auth"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            kind: client
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+      auth:
+        type: always-fail

--- a/connectivity/manifests/echo-ingress-mtls.yaml
+++ b/connectivity/manifests/echo-ingress-mtls.yaml
@@ -1,0 +1,21 @@
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: auth-ingress
+  namespace: cilium-test
+spec:
+  description: "Allow other client to contact echo after mTLS"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            kind: client
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+      auth:
+        type: mtls-spiffe

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -135,6 +135,12 @@ var (
 
 	//go:embed manifests/echo-ingress-icmp-deny.yaml
 	echoIngressICMPDenyPolicyYAML string
+
+	//go:embed manifests/echo-ingress-auth-fail.yaml
+	echoIngressAuthFailPolicyYAML string
+
+	//go:embed manifests/echo-ingress-mtls.yaml
+	echoIngressMTLSPolicyYAML string
 )
 
 var (
@@ -823,6 +829,27 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 			}
 			return check.ResultCurlHTTPError, check.ResultNone // if the header is not set the request will get a 401
 		})
+
+	// Test mTLS auth with always-fail
+	ct.NewTest("echo-ingress-auth-always-fail").WithCiliumPolicy(echoIngressAuthFailPolicyYAML).
+		// this test is only useful when auth is supported in the Cilium version and it is enabled
+		// currently this is tested my mtls-spiffe as that is the only functional auth method
+		WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureAuthMTLSSpiffe)).
+		WithScenarios(
+			tests.PodToPod(),
+			tests.PodToPodWithEndpoints(),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			return check.ResultDropCurlTimeout, check.ResultDropAuthRequired
+		})
+
+	// Test mTLS auth with SPIFFE
+	ct.NewTest("echo-ingress-auth-mtls-spiffe").WithCiliumPolicy(echoIngressMTLSPolicyYAML).
+		WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureAuthMTLSSpiffe)).
+		WithScenarios(
+			tests.PodToPod(),
+			tests.PodToPodWithEndpoints(),
+		)
 
 	// Only allow UDP:53 to kube-dns, no DNS proxy enabled.
 	ct.NewTest("dns-only").WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML).


### PR DESCRIPTION
This adds tests to validate that the auth handling in policy is working. It uses  the always-fail type to test the fail case. If mTLS-SPIFFE is enabled in the cluster it will also perfom a successful test run with mTLS enabled.

The auth-fail tests will be able to run against `master` of cilium, the mTLS tests can be enabled in installation once https://github.com/cilium/cilium/pull/24765 is merged