### PR TITLE
connectivity: Make detected Cilium Agent version available for feature detection

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -34,11 +34,15 @@ type ConnectivityTest struct {
 	client       *k8s.Client
 	hubbleClient observer.ObserverClient
 
+	// CiliumVersion is the detected or assumed version of the Cilium agent
+	CiliumVersion semver.Version
+
 	features FeatureSet
 
 	// Parameters to the test suite, specified by the CLI user.
 	params Parameters
 
+	// version is the version string of the cilium-cli itself
 	version string
 
 	// Clients for source and destination clusters.
@@ -237,6 +241,11 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context) error {
 		return err
 	}
 	if err := ct.initCiliumPods(ctx); err != nil {
+		return err
+	}
+	// Detect Cilium version after Cilium pods have been initialized and before feature
+	// detection.
+	if err := ct.detectCiliumVersion(ctx); err != nil {
 		return err
 	}
 	if err := ct.detectFeatures(ctx); err != nil {

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -8,13 +8,11 @@ import (
 	_ "embed"
 	"fmt"
 
-	"github.com/blang/semver/v4"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/utils"
 )
 
@@ -167,25 +165,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		renderedTemplates[key] = val
 	}
 
-	var v semver.Version
-	if assumeCiliumVersion := ct.Params().AssumeCiliumVersion; assumeCiliumVersion != "" {
-		ct.Warnf("Assuming Cilium version %s for connectivity tests", assumeCiliumVersion)
-		var err error
-		v, err = utils.ParseCiliumVersion(assumeCiliumVersion)
-		if err != nil {
-			return err
-		}
-	} else if minVersion, err := ct.DetectMinimumCiliumVersion(ctx); err != nil {
-		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests: %s", defaults.Version, err)
-		v, err = utils.ParseCiliumVersion(defaults.Version)
-		if err != nil {
-			return err
-		}
-	} else {
-		v = *minVersion
-	}
-
-	ct.Infof("Cilium version: %v", v)
+	ct.Infof("Cilium version: %v", ct.CiliumVersion)
 
 	// Network Performance Test
 	if ct.Params().Perf {


### PR DESCRIPTION
Make detected Cilium Agent version available for feature detection and use it instead of trying to detect Cilium version from the agent image reference. This helps avoid failures like this when the image tag is not a semantic version (in this case image tag is "test"):
```
  connectivity test failed: unable to determine if KNP feature is enabled: failed to parse Cilium version test to semver
```
Cilium agent version was already detected, this PR moves the detection a bit earlier to make it available for feature detection.

Fixes: #1470
Fixes: #1507