### PR TITLE
misc: get rid of Go label breaks & gotos

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -871,8 +871,7 @@ func (a *Action) ValidateFlows(ctx context.Context, peer TestPeer, reqs []filter
 	}
 
 	a.Logf("📄 Validating flows for peer %s", peer.Name())
-
-	res := a.validate(ctx, reqs)
+	res := a.validateFlowsForPeer(ctx, reqs)
 
 	// Store the validation result for the given peer.
 	a.flowResults[peer] = res
@@ -886,7 +885,7 @@ func (a *Action) ValidateFlows(ctx context.Context, peer TestPeer, reqs []filter
 	a.Log()
 }
 
-func (a *Action) validate(ctx context.Context, reqs []filters.FlowSetRequirement) FlowRequirementResults {
+func (a *Action) validateFlowsForPeer(ctx context.Context, reqs []filters.FlowSetRequirement) FlowRequirementResults {
 	var res FlowRequirementResults
 
 	interval := time.NewTicker(defaults.FlowRetryInterval)

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -274,22 +275,22 @@ func (ct *ConnectivityTest) extractFeaturesFromClusterRole(ctx context.Context, 
 		return err
 	}
 
-	hasSecretAccess := false
+	result[FeatureSecretBackendK8s] = FeatureStatus{
+		Enabled: canAccessK8sResourceSecret(cr),
+	}
+	return nil
+}
 
-L:
+func canAccessK8sResourceSecret(cr *rbacv1.ClusterRole) bool {
 	for _, rule := range cr.Rules {
 		for _, resource := range rule.Resources {
 			if resource == "secrets" {
-				hasSecretAccess = true
-				break L
+				return true
 			}
 		}
 	}
 
-	result[FeatureSecretBackendK8s] = FeatureStatus{
-		Enabled: hasSecretAccess,
-	}
-	return nil
+	return false
 }
 
 func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context, ciliumPod Pod, result FeatureSet) error {


### PR DESCRIPTION
This PR removes usages of Go label breaks & goto. IMO they should only used if necessary.

Most often, they are replaced with introducing an extracted function. Beside getting rid of the statements itself - this approach also improves readability.