### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/aks-azure-ipam.yaml
+++ b/.github/workflows/aks-azure-ipam.yaml
@@ -3,7 +3,7 @@ name: AKS (Azure IPAM)
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   ### FOR TESTING PURPOSES
-  # This workflow runs in the context of `master`, and ignores changes to
+  # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
   # - Make sure the PR uses a branch from the base repository (requires write
   #   privileges). It will not work with a branch from a fork (missing secrets).
@@ -13,7 +13,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
   pull_request_target: {}

--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -3,7 +3,7 @@ name: AKS (BYOCNI)
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   ### FOR TESTING PURPOSES
-  # This workflow runs in the context of `master`, and ignores changes to
+  # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
   # - Make sure the PR uses a branch from the base repository (requires write
   #   privileges). It will not work with a branch from a fork (missing secrets).
@@ -13,7 +13,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
   pull_request_target: {}

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -3,7 +3,7 @@ name: EKS (tunnel)
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   ### FOR TESTING PURPOSES
-  # This workflow runs in the context of `master`, and ignores changes to
+  # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
   # - Make sure the PR uses a branch from the base repository (requires write
   #   privileges). It will not work with a branch from a fork (missing secrets).

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -3,7 +3,7 @@ name: EKS (ENI)
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   ### FOR TESTING PURPOSES
-  # This workflow runs in the context of `master`, and ignores changes to
+  # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
   # - Make sure the PR uses a branch from the base repository (requires write
   #   privileges). It will not work with a branch from a fork (missing secrets).

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -3,7 +3,7 @@ name: External Workloads
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   ### FOR TESTING PURPOSES
-  # This workflow runs in the context of `master`, and ignores changes to
+  # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
   # - Make sure the PR uses a branch from the base repository (requires write
   #   privileges). It will not work with a branch from a fork (missing secrets).
@@ -13,7 +13,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
   pull_request_target: {}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -3,7 +3,7 @@ name: GKE
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   ### FOR TESTING PURPOSES
-  # This workflow runs in the context of `master`, and ignores changes to
+  # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
   # - Make sure the PR uses a branch from the base repository (requires write
   #   privileges). It will not work with a branch from a fork (missing secrets).
@@ -13,7 +13,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
   pull_request_target: {}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,9 +3,9 @@ name: Go
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -9,7 +9,7 @@ on:
       - reopened
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
@@ -50,11 +50,11 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
-      # master branch pushes
+      # main branch pushes
       - name: CI Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        id: docker_build_ci_master
+        id: docker_build_ci_main
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -69,8 +69,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_master.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_master.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_main.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_main.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # PR updates
       - name: CI Build ${{ matrix.name }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -3,7 +3,7 @@ name: Multicluster
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   ### FOR TESTING PURPOSES
-  # This workflow runs in the context of `master`, and ignores changes to
+  # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
   # - Make sure the PR uses a branch from the base repository (requires write
   #   privileges). It will not work with a branch from a fork (missing secrets).
@@ -13,7 +13,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
   pull_request_target: {}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 # See https://golangci-lint.run/usage/configuration/ for available options.
-# Also https://github.com/cilium/cilium/blob/master/.golangci.yaml as a reference.
+# Also https://github.com/cilium/cilium/blob/main/.golangci.yaml as a reference.
 run:
   timeout: 5m
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 All members of the Cilium community must abide by the [Cilium Community Code of
-Conduct](https://github.com/cilium/cilium/blob/master/CODE_OF_CONDUCT.md). Only
+Conduct](https://github.com/cilium/cilium/blob/main/CODE_OF_CONDUCT.md). Only
 by respecting each other can we develop a productive, collaborative community.
 If you would like to report a violation of the code of contact, please contact
 the code of conduct team via [conduct@cilium.io](mailto:conduct@cilium.io).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ outside of GitHub.
 ## Code of conduct
 
 All members of the Cilium community must abide by the [Cilium Community Code of
-Conduct](https://github.com/cilium/cilium/blob/master/CODE_OF_CONDUCT.md). Only
+Conduct](https://github.com/cilium/cilium/blob/main/CODE_OF_CONDUCT.md). Only
 by respecting each other can we develop a productive, collaborative community.
 If you would like to report a violation of the code of contact, please contact
 any of the maintainers or our mediator, Beatriz Martinez <beatriz@cilium.io>.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ BINDIR=~/.local/bin make install
 Alternatively, to install the latest binary release:
 
 ```
-CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 Release process and checklist for `cilium-cli`.
 
-This repository currently uses release branches `v0.10` and `master`. All releases stem from
+This repository currently uses release branches `v0.10` and `main`. All releases stem from
 one of these branches. Refer to the [Release
 table](https://github.com/cilium/cilium-cli#releases) for the most recent supported versions.
 
@@ -37,22 +37,22 @@ match the new release `$RELEASE`.
     git commit -s -m "Prepare for $RELEASE release"
     git push origin HEAD
 
-Then open a pull request against `master` branch. Wait for the PR to be reviewed and merged.
+Then open a pull request against `main` branch. Wait for the PR to be reviewed and merged.
 
 ## Tag a release
 
 Update your local checkout:
 
-    git checkout master
-    git pull origin master
+    git checkout main
+    git pull origin main
 
 Set the commit you want to tag:
 
     export COMMIT_SHA=<commit-sha-to-release>
 
-Usually this is the most recent commit on `master`, i.e.
+Usually this is the most recent commit on `main`, i.e.
 
-    export COMMIT_SHA=$(git rev-parse origin/master)
+    export COMMIT_SHA=$(git rev-parse origin/main)
 
 Then tag and push the release:
 
@@ -67,7 +67,7 @@ the draft is ready, review the release notes and publish the release.
 ### Update stable.txt
 
 The CLI installation instructions in the Cilium documentation use the version
-specified in `stable.txt` in the `master` branch. Update `stable.txt` after the
+specified in `stable.txt` in the `main` branch. Update `stable.txt` after the
 release, whenever Cilium users should pick up this new release for
 installation:
 
@@ -77,4 +77,4 @@ installation:
     git commit -s -m "Update stable release to $RELEASE"
     git push origin HEAD
 
-Then open a pull request against `master` branch.
+Then open a pull request against `main` branch.

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -23,7 +23,7 @@ var (
 )
 
 func getLatestStableVersion() string {
-	resp, err := http.Get("https://raw.githubusercontent.com/cilium/cilium/master/stable.txt")
+	resp, err := http.Get("https://raw.githubusercontent.com/cilium/cilium/main/stable.txt")
 	if err != nil {
 		return "unknown"
 	}


### PR DESCRIPTION
In order to merge this PR, we will need to rename the default branch in the GitHub UI first.

Fixes #1518