### PR TITLE
cli: adapt helm chart cleanup of deprecated hubble values

### DIFF
--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -515,8 +515,16 @@ func (k *K8sHubble) generateManifestsEnable(ctx context.Context, printHelmTempla
 		}
 
 		helmMapOpts["hubble.enabled"] = "true"
-		helmMapOpts["hubble.tls.ca.cert"] = certs.EncodeCertBytes(k.certManager.CACertBytes())
-		helmMapOpts["hubble.tls.ca.key"] = certs.EncodeCertBytes(k.certManager.CAKeyBytes())
+
+		switch {
+		// hubble.tls.* properties have been deprecated in Cilium 1.12.x
+		case versioncheck.MustCompile("<1.12.0")(ciliumVer):
+			helmMapOpts["hubble.tls.ca.cert"] = certs.EncodeCertBytes(k.certManager.CACertBytes())
+			helmMapOpts["hubble.tls.ca.key"] = certs.EncodeCertBytes(k.certManager.CAKeyBytes())
+		default:
+			helmMapOpts["tls.ca.cert"] = certs.EncodeCertBytes(k.certManager.CACertBytes())
+			helmMapOpts["tls.ca.key"] = certs.EncodeCertBytes(k.certManager.CAKeyBytes())
+		}
 
 		if k.params.UI {
 			helmMapOpts["hubble.ui.enabled"] = "true"


### PR DESCRIPTION
Deprecated Cilium Helm Chart values have been removed in the PR https://github.com/cilium/cilium/pull/24214 - [this change](https://github.com/cilium/cilium/pull/24214/files#diff-48ba11928b3e5bd05ddae3774b1f2c228f54699b357603ac3bfc72ee846a93f0) specifically.

Installing Cilium (`cilium install --chart-directory install/kubernetes/cilium`) & enabling hubble (`cilium hubble enable --chart-directory install/kubernetes/cilium`) will break the connectivity from the hubble relay to the peer service (`Failed to create peer client for peers synchronization...`).

This will consequently also fail the connectivity tests with the following error: `Timeout waiting for flow listener to become ready`.

We need to set `tls.ca.cert` & `tls.ca.key` during `cilium hubble enable` to use the same CA cert.

Occurred in the CIlium Integration Tests of Cilium Proxy where latest Cilium CLI gets used in combination with latest Cilium version: https://github.com/cilium/proxy/actions/runs/4742847574/jobs/8421623603