### PR TITLE
cli: Add hooks and exported NewCiliumCommand

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/internal/cli/cmd"
+	"github.com/cilium/cilium-cli/sysdump"
+)
+
+func NewDefaultCiliumCommand() *cobra.Command {
+	return NewCiliumCommand(&NopHooks{})
+}
+
+func NewCiliumCommand(hooks Hooks) *cobra.Command {
+	return cmd.NewCiliumCommand(hooks)
+}
+
+type (
+	Hooks                 = cmd.Hooks
+	ConnectivityTestHooks = cmd.ConnectivityTestHooks
+	SysdumpHooks          = cmd.SysdumpHooks
+)
+
+type NopHooks struct{}
+
+var _ Hooks = &NopHooks{}
+
+func (*NopHooks) AddSysdumpFlags(flags *pflag.FlagSet)                  {}
+func (*NopHooks) AddSysdumpTasks(*sysdump.Collector) error              { return nil }
+func (*NopHooks) AddConnectivityTestFlags(flags *pflag.FlagSet)         {}
+func (*NopHooks) AddConnectivityTests(ct *check.ConnectivityTest) error { return nil }

--- a/cmd/cilium/main.go
+++ b/cmd/cilium/main.go
@@ -10,7 +10,7 @@ import (
 
 	gops "github.com/google/gops/agent"
 
-	"github.com/cilium/cilium-cli/internal/cli/cmd"
+	"github.com/cilium/cilium-cli/cli"
 	_ "github.com/cilium/cilium-cli/internal/logging" // necessary to disable unwanted cfssl log messages
 )
 
@@ -19,7 +19,7 @@ func main() {
 		log.Printf("Unable to start gops: %s", err)
 	}
 
-	if err := cmd.NewDefaultCiliumCommand().Execute(); err != nil {
+	if err := cli.NewDefaultCiliumCommand().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -121,7 +121,7 @@ var (
 	client2Label = map[string]string{"name": "client2"}
 )
 
-func Run(ctx context.Context, ct *check.ConnectivityTest) error {
+func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*check.ConnectivityTest) error) error {
 	if err := ct.SetupAndValidate(ctx); err != nil {
 		return err
 	}
@@ -780,6 +780,10 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 
 	// Tests with DNS redirects to the proxy (e.g., client-egress-l7, dns-only,
 	// and to-fqdns) should always be executed last. See #367 for details.
+
+	if err := addExtraTests(ct); err != nil {
+		return err
+	}
 
 	return ct.Run(ctx)
 }

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -19,7 +19,7 @@ var (
 	k8sClient *k8s.Client
 )
 
-func NewDefaultCiliumCommand() *cobra.Command {
+func NewCiliumCommand(hooks Hooks) *cobra.Command {
 	cmd := &cobra.Command{
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// return early for commands that don't require the kubernetes client
@@ -71,11 +71,11 @@ cilium connectivity test`,
 	cmd.AddCommand(
 		newCmdClusterMesh(),
 		newCmdConfig(),
-		newCmdConnectivity(),
+		newCmdConnectivity(hooks),
 		newCmdContext(),
 		newCmdHubble(),
 		newCmdStatus(),
-		newCmdSysdump(),
+		newCmdSysdump(hooks),
 		newCmdUpgrade(),
 		newCmdVersion(),
 	)

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -24,14 +24,14 @@ import (
 
 var errInternal = errors.New("encountered internal error, exiting")
 
-func newCmdConnectivity() *cobra.Command {
+func newCmdConnectivity(hooks Hooks) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connectivity",
 		Short: "Connectivity troubleshooting",
 		Long:  ``,
 	}
 
-	cmd.AddCommand(newCmdConnectivityTest())
+	cmd.AddCommand(newCmdConnectivityTest(hooks))
 
 	return cmd
 }
@@ -46,7 +46,7 @@ var params = check.Parameters{
 }
 var tests []string
 
-func newCmdConnectivityTest() *cobra.Command {
+func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Validate connectivity in cluster",
@@ -90,7 +90,7 @@ func newCmdConnectivityTest() *cobra.Command {
 			// and end the goroutine without returning.
 			go func() {
 				defer func() { done <- struct{}{} }()
-				err = connectivity.Run(ctx, cc)
+				err = connectivity.Run(ctx, cc, hooks.AddConnectivityTests)
 
 				// If Fatal() was called in the test suite, the statement below won't fire.
 				finished = true
@@ -160,7 +160,9 @@ func newCmdConnectivityTest() *cobra.Command {
 
 	cmd.Flags().BoolVar(&params.CollectSysdumpOnFailure, "collect-sysdump-on-failure", false, "Collect sysdump after a test fails")
 
-	initSysdumpFlags(cmd, &params.SysdumpOptions, "sysdump-")
+	initSysdumpFlags(cmd, &params.SysdumpOptions, "sysdump-", hooks)
+
+	hooks.AddConnectivityTestFlags(cmd.Flags())
 
 	return cmd
 }

--- a/internal/cli/cmd/hooks.go
+++ b/internal/cli/cmd/hooks.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/sysdump"
+)
+
+// Hooks to extend the default cilium-cli command with additional functionality.
+type Hooks interface {
+	ConnectivityTestHooks
+	SysdumpHooks
+}
+
+type ConnectivityTestHooks interface {
+	AddConnectivityTestFlags(flags *pflag.FlagSet)
+	AddConnectivityTests(ct *check.ConnectivityTest) error
+}
+
+type SysdumpHooks interface {
+	AddSysdumpFlags(flags *pflag.FlagSet)
+	AddSysdumpTasks(*sysdump.Collector) error
+}


### PR DESCRIPTION
This allows building a version of cilium-cli externally with extended tests and other functionality.