### PR TITLE
.github: add mirror from main -> master

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -1,0 +1,20 @@
+name: mirror
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  mirror_job:
+    runs-on: ubuntu-latest
+    environment: mirror
+    name: Mirror main branch to master branch
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'main'
+        dest: 'master'


### PR DESCRIPTION
there should be a grace period for developers relying on the 'master' branch to catch up and switch to relying on 'main'. During that grace period, this action will clone all pushes to 'main' into the 'master' branch.

For #1518