### PR TITLE
helm mode: add clustermesh enable/disable

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -26,11 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
-  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
-  clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
-  firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
   cilium_version: v1.13.2
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -40,9 +36,21 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: ["classic", "helm"]
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      # Note: These names currently approach the limit of 40 characters
+      - name: Set mode-specific names
+        run: |
+          echo "clusterNameBase=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}" >> $GITHUB_ENV
+          echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-1" >> $GITHUB_ENV
+          echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-2" >> $GITHUB_ENV
+          echo "firewallRuleName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode}}" >> $GITHUB_ENV
 
       - name: Install kubectl
         run: |
@@ -168,6 +176,7 @@ jobs:
             --set test_script_cm=cilium-cli-test-script \
             --set cluster_name_1=${{ env.clusterName1 }} \
             --set cluster_name_2=${{ env.clusterName2 }} \
+            --set cilium_cli_mode=${{ matrix.mode }}
 
       - name: Wait for test job
         env:

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1762,3 +1762,42 @@ func (k *K8sClusterMesh) ExternalWorkloadStatus(ctx context.Context, names []str
 	fmt.Println(buf.String())
 	return err
 }
+
+func EnableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameters) error {
+	helmStrValues := []string{
+		"clustermesh.useAPIServer=true",
+		fmt.Sprintf("clustermesh.apiserver.service.type=%s", params.ServiceType),
+	}
+	vals, err := helm.ParseVals(helmStrValues)
+	if err != nil {
+		return err
+	}
+	upgradeParams := helm.UpgradeParameters{
+		Namespace:   params.Namespace,
+		Name:        defaults.HelmReleaseName,
+		Values:      vals,
+		ResetValues: false,
+		ReuseValues: true,
+	}
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	return err
+}
+
+func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameters) error {
+	helmStrValues := []string{
+		"clustermesh.useAPIServer=false",
+	}
+	vals, err := helm.ParseVals(helmStrValues)
+	if err != nil {
+		return err
+	}
+	upgradeParams := helm.UpgradeParameters{
+		Namespace:   params.Namespace,
+		Name:        defaults.HelmReleaseName,
+		Values:      vals,
+		ResetValues: false,
+		ReuseValues: true,
+	}
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	return err
+}

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -366,7 +366,7 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&params.ServiceType, "service-type", "LoadBalancer", "Type of Kubernetes service to expose control plane { ClusterIP | LoadBalancer | NodePort }")
+	cmd.Flags().StringVar(&params.ServiceType, "service-type", "NodePort", "Type of Kubernetes service to expose control plane { LoadBalancer | NodePort | ClusterIP }")
 
 	return cmd
 }

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -361,6 +361,10 @@ func MergeVals(
 	return vals, nil
 }
 
+// ParseVals takes a slice of Helm values of the form
+// ["some.chart.value=val1", "some.other.value=val2"]
+// and returns a deeply nested map of Values of the form
+// expected by Helm actions.
 func ParseVals(helmStrValues []string) (map[string]interface{}, error) {
 	helmValStr := strings.Join(helmStrValues, ",")
 	helmValues := map[string]interface{}{}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -361,6 +361,16 @@ func MergeVals(
 	return vals, nil
 }
 
+func ParseVals(helmStrValues []string) (map[string]interface{}, error) {
+	helmValStr := strings.Join(helmStrValues, ",")
+	helmValues := map[string]interface{}{}
+	err := strvals.ParseInto(helmValStr, helmValues)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing helm options %q: %w", helmValStr, err)
+	}
+	return helmValues, nil
+}
+
 // PrintHelmTemplateCommand will log a message so that users can replicate
 // the same behavior as the CLI. The log message will be slightly different
 // depending on if 'helmChartDirectory' is set or not.

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -62,3 +62,74 @@ func TestResolveHelmChartVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestParseVals(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name:    "simple-val",
+			input:   []string{"simple=true"},
+			want:    map[string]interface{}{"simple": true},
+			wantErr: false,
+		},
+		{
+			name:    "two-levels",
+			input:   []string{"two.levels=true"},
+			want:    map[string]interface{}{"two": map[string]interface{}{"levels": true}},
+			wantErr: false,
+		},
+		{
+			name:    "multiple-keys",
+			input:   []string{"multiple=true", "keys=true"},
+			want:    map[string]interface{}{"multiple": true, "keys": true},
+			wantErr: false,
+		},
+		{
+			name:    "string-type",
+			input:   []string{"string=testval"},
+			want:    map[string]interface{}{"string": "testval"},
+			wantErr: false,
+		},
+		{
+			name:    "mixed-type",
+			input:   []string{"string=testval", "bool=false"},
+			want:    map[string]interface{}{"string": "testval", "bool": false},
+			wantErr: false,
+		},
+		{
+			name:  "mixed-levels",
+			input: []string{"two.levels=true", "three.levels.deep=true"},
+			want: map[string]interface{}{
+				"two":   map[string]interface{}{"levels": true},
+				"three": map[string]interface{}{"levels": map[string]interface{}{"deep": true}},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid-input",
+			input:   []string{"invalid"},
+			wantErr: true,
+		},
+		{
+			name:    "mixed-invalid",
+			input:   []string{"testkey=val", "invalid"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVals(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseVals() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseVals() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two commits for review

#### Add cilium clustermesh {enable,disable} using Helm

Implements a version of `clustermesh enable` and `clustermesh disable` using Helm actions run directly against the cluster

#### Enable Helm mode matrix for multicluster tests

Enables a workflow matrix for "classic" and "helm" mode for multicluster tests using GKE. The recently added parameter for cilium_cli_mode in the `cilium-cli-test-job-chart` is used.