### PR TITLE
fixes versioncheck for l7 proxy disabling with wireguard encryption

### DIFF
--- a/install/helm.go
+++ b/install/helm.go
@@ -159,7 +159,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 			// TODO(gandro): Future versions of Cilium will remove the following
 			// two limitations, we will need to have set the config map values
 			// based on the installed Cilium version
-			if versioncheck.MustCompile("<=1.13.0")(k.chartVersion) {
+			if versioncheck.MustCompile("<1.14.0")(k.chartVersion) {
 				helmMapOpts["l7Proxy"] = "false"
 				k.Log("ℹ️  L7 proxy disabled due to Wireguard encryption")
 


### PR DESCRIPTION
This commit fixes versioncheck so that it includes patch versions of cilium 1.13.x. Versions 1.13.x triggers en error:

level=fatal msg="Wireguard (--enable-wireguard) is not compatible with L7 proxy (--enable-l7-proxy)" subsys=daemon

Fixes: 64924bfa9663 ("enabled l7Proxy & removed err.log message for WireGuard")