### PR TITLE
connectivity: Add test cases for Ingress 

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -56,6 +56,7 @@ type ConnectivityTest struct {
 	perfServerPod     map[string]Pod
 	PerfResults       map[PerfTests]PerfResult
 	echoServices      map[string]Service
+	ingressService    map[string]Service
 	externalWorkloads map[string]ExternalWorkload
 
 	hostNetNSPodsByNode map[string]Pod
@@ -183,6 +184,7 @@ func NewConnectivityTest(client *k8s.Client, p Parameters, version string) (*Con
 		perfServerPod:       make(map[string]Pod),
 		PerfResults:         make(map[PerfTests]PerfResult),
 		echoServices:        make(map[string]Service),
+		ingressService:      make(map[string]Service),
 		externalWorkloads:   make(map[string]ExternalWorkload),
 		hostNetNSPodsByNode: make(map[string]Pod),
 		nodes:               make(map[string]*corev1.Node),
@@ -683,6 +685,10 @@ func (ct *ConnectivityTest) EchoPods() map[string]Pod {
 
 func (ct *ConnectivityTest) EchoServices() map[string]Service {
 	return ct.echoServices
+}
+
+func (ct *ConnectivityTest) IngressService() map[string]Service {
+	return ct.ingressService
 }
 
 func (ct *ConnectivityTest) ExternalWorkloads() map[string]ExternalWorkload {

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -62,6 +62,8 @@ const (
 	FeatureKNP Feature = "k8s-network-policy"
 
 	FeatureAuthMTLSSpiffe Feature = "auth-mtls-spiffe"
+
+	FeatureIngressController Feature = "ingress-controller"
 )
 
 // FeatureStatus describes the status of a feature. Some features are either
@@ -204,6 +206,10 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 
 	result[FeatureAuthMTLSSpiffe] = FeatureStatus{
 		Enabled: cm.Data["mesh-auth-mtls-enabled"] == "true",
+	}
+
+	result[FeatureIngressController] = FeatureStatus{
+		Enabled: cm.Data["enable-ingress-controller"] == "true",
 	}
 
 	return nil

--- a/connectivity/manifests/allow-ingress-identity.yaml
+++ b/connectivity/manifests/allow-ingress-identity.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-from-cilium-ingress
+spec:
+  description: Allow cilium ingress to access any pod
+  endpointSelector: {}
+  ingress:
+  - fromEntities:
+    - ingress

--- a/install/install.go
+++ b/install/install.go
@@ -262,6 +262,8 @@ type k8sInstallerImplementation interface {
 	GetPlatform(ctx context.Context) (*k8s.Platform, error)
 	GetServerVersion() (*semver.Version, error)
 	CreateIngressClass(ctx context.Context, r *networkingv1.IngressClass, opts metav1.CreateOptions) (*networkingv1.IngressClass, error)
+	GetIngress(ctx context.Context, namespace string, ingressName string, opts metav1.GetOptions) (*networkingv1.Ingress, error)
+	CreateIngress(ctx context.Context, namespace string, ingress *networkingv1.Ingress, opts metav1.CreateOptions) (*networkingv1.Ingress, error)
 	DeleteIngressClass(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
 	ListAPIResources(ctx context.Context) ([]string, error)

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -996,6 +996,14 @@ func (c *Client) CreateIngressClass(ctx context.Context, ingressClass *networkin
 	return c.Clientset.NetworkingV1().IngressClasses().Create(ctx, ingressClass, opts)
 }
 
+func (c *Client) GetIngress(ctx context.Context, namespace string, name string, opts metav1.GetOptions) (*networkingv1.Ingress, error) {
+	return c.Clientset.NetworkingV1().Ingresses(namespace).Get(ctx, name, opts)
+}
+
+func (c *Client) CreateIngress(ctx context.Context, namespace string, ingress *networkingv1.Ingress, opts metav1.CreateOptions) (*networkingv1.Ingress, error) {
+	return c.Clientset.NetworkingV1().Ingresses(namespace).Create(ctx, ingress, opts)
+}
+
 func (c *Client) DeleteIngressClass(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.Clientset.NetworkingV1().IngressClasses().Delete(ctx, name, opts)
 }


### PR DESCRIPTION
### Description

This commit is to improve the Ingress coverage with the below cases:

- no policy, requests should pass.
- default denied for all endpoints, request should fail.
- default denied for all endpoints, but allow Ingress identity, requests
  should pass.

Relates: https://github.com/cilium/cilium/pull/24826

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing was done locally

- master branch -> failed for ingress identity test
- with https://github.com/cilium/cilium/pull/24826 -> successfully ran as expected.