### PR TITLE
multicluster CI: Validate Hubble CA cert logic

### DIFF
--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -57,14 +57,16 @@ cilium --context "${CONTEXT2}" clustermesh status --wait
 
 # Copy the clustermesh secrets
 # TODO(ajs): Patch the connect command to expect the Helm secret name
-kubectl get secrets --context ${CONTEXT1} \
-  -n kube-system clustermesh-apiserver-remote-cert -oyaml \
-  | sed 's/name: .*/name: clustermesh-apiserver-client-cert/' \
-  | kubectl apply --context ${CONTEXT1} -f -
-kubectl get secrets --context ${CONTEXT2} \
-  -n kube-system clustermesh-apiserver-remote-cert -oyaml \
-  | sed 's/name: .*/name: clustermesh-apiserver-client-cert/' \
-  | kubectl apply --context ${CONTEXT2} -f -
+if [ "$CILIUM_CLI_MODE" = "helm" ]; then
+  kubectl get secrets --context ${CONTEXT1} \
+    -n kube-system clustermesh-apiserver-remote-cert -oyaml \
+    | sed 's/name: .*/name: clustermesh-apiserver-client-cert/' \
+    | kubectl apply --context ${CONTEXT1} -f -
+  kubectl get secrets --context ${CONTEXT2} \
+    -n kube-system clustermesh-apiserver-remote-cert -oyaml \
+    | sed 's/name: .*/name: clustermesh-apiserver-client-cert/' \
+    | kubectl apply --context ${CONTEXT2} -f -
+fi
 
 # Connect clusters
 cilium --context "${CONTEXT1}" clustermesh connect --destination-context "${CONTEXT2}"

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -57,7 +57,8 @@ cilium --context "${CONTEXT2}" clustermesh status --wait
 
 # Copy the clustermesh secrets
 # TODO(ajs): Patch the connect command to expect the Helm secret name
-if [ "$CILIUM_CLI_MODE" = "helm" ]; then
+echo "(asauber): CILIUM_CLI_MODE: $CILIUM_CLI_MODE"
+if [ "$CILIUM_CLI_MODE" == "helm" ]; then
   kubectl get secrets --context ${CONTEXT1} \
     -n kube-system clustermesh-apiserver-remote-cert -oyaml \
     | sed 's/name: .*/name: clustermesh-apiserver-client-cert/' \

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -51,13 +51,9 @@ cilium --context "${CONTEXT2}" status --wait
 cilium --context "${CONTEXT1}" clustermesh enable
 cilium --context "${CONTEXT2}" clustermesh enable
 
-# Wait for cluster mesh status to be ready
-cilium --context "${CONTEXT1}" clustermesh status --wait
-cilium --context "${CONTEXT2}" clustermesh status --wait
-
 # Copy the clustermesh secrets
 # TODO(ajs): Patch the connect command to expect the Helm secret name
-echo "(asauber): CILIUM_CLI_MODE: $CILIUM_CLI_MODE"
+echo "CILIUM_CLI_MODE: $CILIUM_CLI_MODE"
 if [ "$CILIUM_CLI_MODE" == "helm" ]; then
   kubectl get secrets --context ${CONTEXT1} \
     -n kube-system clustermesh-apiserver-remote-cert -oyaml \
@@ -68,6 +64,10 @@ if [ "$CILIUM_CLI_MODE" == "helm" ]; then
     | sed 's/name: .*/name: clustermesh-apiserver-client-cert/' \
     | kubectl apply --context ${CONTEXT2} -f -
 fi
+
+# Wait for cluster mesh status to be ready
+cilium --context "${CONTEXT1}" clustermesh status --wait
+cilium --context "${CONTEXT2}" clustermesh status --wait
 
 # Connect clusters
 cilium --context "${CONTEXT1}" clustermesh connect --destination-context "${CONTEXT2}"

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -26,8 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
-  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
@@ -40,9 +38,17 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    strategy:
+      matrix:
+        mode: ["classic", "helm"]
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Set cluster names
+        run: |
+          echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-mesh-1" >> $GITHUB_ENV
+          echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-mesh-2" >> $GITHUB_ENV
 
       - name: Install kubectl
         run: |
@@ -168,6 +174,7 @@ jobs:
             --set test_script_cm=cilium-cli-test-script \
             --set cluster_name_1=${{ env.clusterName1 }} \
             --set cluster_name_2=${{ env.clusterName2 }} \
+            --set cilium_cli_mode=${{ matrix.mode }}
 
       - name: Wait for test job
         env:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -45,10 +45,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
+      # Note: These names currently approach the GKE limit of 40 characters
       - name: Set cluster names
         run: |
-          echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-mesh-1" >> $GITHUB_ENV
-          echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-mesh-2" >> $GITHUB_ENV
+          echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-1" >> $GITHUB_ENV
+          echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-2" >> $GITHUB_ENV
 
       - name: Install kubectl
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -26,9 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
-  firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
   cilium_version: v1.13.2
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -45,11 +43,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
-      # Note: These names currently approach the GKE limit of 40 characters
-      - name: Set cluster names
+      # Note: These names currently approach the limit of 40 characters
+      - name: Set mode-specific names
         run: |
+          echo "clusterNameBase=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}" >> $GITHUB_ENV
           echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-1" >> $GITHUB_ENV
           echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-2" >> $GITHUB_ENV
+          echo "firewallRuleName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode}}" >> $GITHUB_ENV
 
       - name: Install kubectl
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
         mode: ["classic", "helm"]
     steps:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -14,7 +14,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
   pull_request_target: {}
   # Run every 6 hours

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1762,3 +1762,42 @@ func (k *K8sClusterMesh) ExternalWorkloadStatus(ctx context.Context, names []str
 	fmt.Println(buf.String())
 	return err
 }
+
+func EnableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameters) error {
+	helmStrValues := []string{
+		"clustermesh.useAPIServer=true",
+		fmt.Sprintf("clustermesh.apiserver.service.type=%s", params.ServiceType),
+	}
+	vals, err := helm.ParseVals(helmStrValues)
+	if err != nil {
+		return err
+	}
+	upgradeParams := helm.UpgradeParameters{
+		Namespace:   params.Namespace,
+		Name:        defaults.HelmReleaseName,
+		Values:      vals,
+		ResetValues: false,
+		ReuseValues: true,
+	}
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	return err
+}
+
+func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameters) error {
+	helmStrValues := []string{
+		"clustermesh.useAPIServer=false",
+	}
+	vals, err := helm.ParseVals(helmStrValues)
+	if err != nil {
+		return err
+	}
+	upgradeParams := helm.UpgradeParameters{
+		Namespace:   params.Namespace,
+		Name:        defaults.HelmReleaseName,
+		Values:      vals,
+		ResetValues: false,
+		ReuseValues: true,
+	}
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	return err
+}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -361,6 +361,16 @@ func MergeVals(
 	return vals, nil
 }
 
+func ParseVals(helmStrValues []string) (map[string]interface{}, error) {
+	helmValStr := strings.Join(helmStrValues, ",")
+	helmValues := map[string]interface{}{}
+	err := strvals.ParseInto(helmValStr, helmValues)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing helm options %q: %w", helmValStr, err)
+	}
+	return helmValues, nil
+}
+
 // PrintHelmTemplateCommand will log a message so that users can replicate
 // the same behavior as the CLI. The log message will be slightly different
 // depending on if 'helmChartDirectory' is set or not.


### PR DESCRIPTION
Copy the CA cert from cluster1 to cluster2 before installing Cilium on Cluster 2


This should seed all CAs in cluster2 due to logic in the helm chart found here, e.g. for Hubble https://github.com/cilium/cilium/blob/8b6aa6eda91927275ae722ac020deeb5a9ce479d/install/kubernetes/cilium/templates/hubble/tls-helm/_helpers.tpl#L24-L33
