### PR TITLE
Remove "Release Date" column from the release table

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ binary releases.
 
 ## Releases
 
-| Release                                                              | Release Date | Maintained | Supported Cilium Versions |
-|----------------------------------------------------------------------|--------------|------------|---------------------------|
-| [v0.14.0](https://github.com/cilium/cilium-cli/releases/tag/v0.14.0) | 2023-04-22   | Yes        | Cilium 1.11 and newer     |
-| [v0.10.7](https://github.com/cilium/cilium-cli/releases/tag/v0.10.7) | 2022-05-31   | No         | Cilium 1.10               |
+| Release                                                              | Maintained | Supported Cilium Versions |
+|----------------------------------------------------------------------|------------|---------------------------|
+| [v0.14.0](https://github.com/cilium/cilium-cli/releases/tag/v0.14.0) | Yes        | Cilium 1.11 and newer     |
+| [v0.10.7](https://github.com/cilium/cilium-cli/releases/tag/v0.10.7) | No         | Cilium 1.10               |
 
 Please see [Experimental `helm` installation mode](#experimental-helm-installation-mode)
 section regarding our plan to migrate to the new `helm` installation mode and deprecate


### PR DESCRIPTION
There is no guarantee that the release date is accurate, since the release might not get tagged the same day the release pull request gets created.

Let's just remove the column. We link to release pages that contain the actual timestamps of when they got tagged.