### PR TITLE
connectivity: add retry to external targets

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -64,6 +64,9 @@ type Parameters struct {
 
 	DeleteCiliumOnNodes []string
 
+	Retry      uint
+	RetryDelay time.Duration
+
 	ConnectTimeout time.Duration
 	RequestTimeout time.Duration
 

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -216,10 +216,10 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		tests.ClientToClient(),
 		tests.PodToService(),
 		tests.PodToHostPort(),
-		tests.PodToWorld(),
+		tests.PodToWorld(tests.WithRetryAll()),
 		tests.PodToHost(),
 		tests.PodToExternalWorkload(),
-		tests.PodToCIDR(),
+		tests.PodToCIDR(tests.WithRetryAll()),
 	}
 	if s, ok := ct.Feature(check.FeatureNodeWithoutCilium); ok && s.Enabled {
 		noPoliciesScenarios = append(noPoliciesScenarios, tests.FromCIDRToPod())
@@ -286,7 +286,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	// 2. Egress to world works because there is no egress policy (so egress traffic originating from a pod is allowed),
 	//    then when replies come back, they are considered as "replies" to the outbound connection.
 	//    so they are not subject to ingress policy.
-	allIngressDenyScenarios := []check.Scenario{tests.PodToPod(), tests.PodToCIDR()}
+	allIngressDenyScenarios := []check.Scenario{tests.PodToPod(), tests.PodToCIDR(tests.WithRetryAll())}
 	if s, ok := ct.Feature(check.FeatureNodeWithoutCilium); ok && s.Enabled {
 		allIngressDenyScenarios = append(allIngressDenyScenarios, tests.FromCIDRToPod())
 	}
@@ -309,7 +309,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 			// Egress to world works because there is no egress policy (so egress traffic originating from a pod is allowed),
 			// then when replies come back, they are considered as "replies" to the outbound connection.
 			// so they are not subject to ingress policy.
-			tests.PodToCIDR(),
+			tests.PodToCIDR(tests.WithRetryAll()),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
@@ -455,7 +455,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	// This policy allows UDP to kube-dns and port 80 TCP to all 'world' endpoints.
 	ct.NewTest("to-entities-world").WithCiliumPolicy(clientEgressToEntitiesWorldPolicyYAML).
 		WithScenarios(
-			tests.PodToWorld(),
+			tests.PodToWorld(tests.WithRetryDestPort(80)),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 80 {
@@ -470,7 +470,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	ct.NewTest("to-cidr-external").
 		WithCiliumPolicy(renderedTemplates["clientEgressToCIDRExternalPolicyYAML"]).
 		WithScenarios(
-			tests.PodToCIDR(),
+			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(check.IPFamilyV4) == ct.Params().ExternalOtherIP {
@@ -485,7 +485,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	ct.NewTest("to-cidr-external-knp").
 		WithK8SPolicy(renderedTemplates["clientEgressToCIDRExternalPolicyKNPYAML"]).
 		WithScenarios(
-			tests.PodToCIDR(),
+			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(check.IPFamilyV4) == ct.Params().ExternalOtherIP {
@@ -616,7 +616,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		WithCiliumPolicy(allowAllEgressPolicyYAML). // Allow all egress traffic
 		WithCiliumPolicy(renderedTemplates["clientEgressToCIDRExternalDenyPolicyYAML"]).
 		WithScenarios(
-			tests.PodToCIDR(), // Denies all traffic to ExternalOtherIP, but allow ExternalIP
+			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)), // Denies all traffic to ExternalOtherIP, but allow ExternalIP
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
@@ -733,7 +733,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		WithCiliumPolicy(renderedTemplates["clientEgressL7HTTPPolicyYAML"]). // L7 allow policy with HTTP introspection
 		WithScenarios(
 			tests.PodToPod(),
-			tests.PodToWorld(),
+			tests.PodToWorld(tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.
@@ -761,7 +761,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 		WithCiliumPolicy(renderedTemplates["clientEgressL7HTTPNamedPortPolicyYAML"]). // L7 allow policy with HTTP introspection (named port)
 		WithScenarios(
 			tests.PodToPod(),
-			tests.PodToWorld(),
+			tests.PodToWorld(tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.
@@ -897,7 +897,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	ct.NewTest("to-fqdns").WithCiliumPolicy(renderedTemplates["clientEgressToFQDNsCiliumIOPolicyYAML"]).
 		WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureL7Proxy)).
 		WithScenarios(
-			tests.PodToWorld(),
+			tests.PodToWorld(tests.WithRetryDestPort(80)),
 			tests.PodToWorld2(), // resolves cilium.io
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -85,6 +85,9 @@ const (
 
 	PolicyWaitTimeout = 15 * time.Second
 
+	ConnectRetry      = 3
+	ConnectRetryDelay = 3 * time.Second
+
 	ConnectTimeout = 2 * time.Second
 	RequestTimeout = 10 * time.Second
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -156,6 +156,9 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
 
+	cmd.Flags().UintVar(&params.Retry, "retry", defaults.ConnectRetry, "Number of retries on connection failure to external targets")
+	cmd.Flags().DurationVar(&params.RetryDelay, "retry-delay", defaults.ConnectRetryDelay, "Delay between retries for external targets")
+
 	cmd.Flags().DurationVar(&params.ConnectTimeout, "connect-timeout", defaults.ConnectTimeout, "Maximum time to allow initiation of the connection to take")
 	cmd.Flags().DurationVar(&params.RequestTimeout, "request-timeout", defaults.RequestTimeout, "Maximum time to allow a request to take")
 


### PR DESCRIPTION
Adds --retry and --retry-delay flags to the connectivity test.
They are used in external `pod-to-world` and `po-to-cidr` tests to try to reconnect
on failures thus making flaky tests less likely.