### PR TITLE
build: update golangci-lint to version 1.52.2

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Run static checks
       uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
       with:
-        version: v1.51.1
+        version: v1.52.2
         args: --config=.golangci.yml --verbose
         skip-cache: true
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TEST_TIMEOUT ?= 5s
 RELEASE_UID ?= $(shell id -u)
 RELEASE_GID ?= $(shell id -g)
 
-GOLANGCILINT_WANT_VERSION = 1.51.1
+GOLANGCILINT_WANT_VERSION = 1.52.2
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 $(TARGET):

--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -190,7 +190,7 @@ func (k *K8sClusterMesh) installCertificates(ctx context.Context) error {
 	}
 
 	if caSecret != nil {
-		err = k.certManager.LoadCAFromK8s(ctx, caSecret)
+		err = k.certManager.LoadCAFromK8s(caSecret)
 		if err != nil {
 			k.Log("❌ Unable to load Cilium CA: %s", err)
 			return err

--- a/cmd/internal/add-image-digests/main.go
+++ b/cmd/internal/add-image-digests/main.go
@@ -109,11 +109,7 @@ func run() error {
 		return err
 	}
 	//nolint:gosec
-	if err := os.WriteFile(filename, imageDigestsJSON, 0o644); err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(filename, imageDigestsJSON, 0o644)
 }
 
 func main() {

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -356,7 +356,7 @@ func (a *Action) printFlows(peer TestPeer) {
 	a.Log()
 }
 
-func (a *Action) matchFlowRequirements(ctx context.Context, flows flowsSet, req *filters.FlowSetRequirement) FlowRequirementResults {
+func (a *Action) matchFlowRequirements(flows flowsSet, req *filters.FlowSetRequirement) FlowRequirementResults {
 	var offset int
 	r := FlowRequirementResults{Failures: -1} // -1 to get the loop started
 
@@ -815,7 +815,7 @@ func (a *Action) followFlows(ctx context.Context, ready chan bool) error {
 // matchAllFlowRequirements takes a list of flow requirements and matches each
 // of them against the flows logged against the Action up to this point.
 // Returns the merged verdict of all matcher operations using all requirements.
-func (a *Action) matchAllFlowRequirements(ctx context.Context, reqs []filters.FlowSetRequirement) FlowRequirementResults {
+func (a *Action) matchAllFlowRequirements(reqs []filters.FlowSetRequirement) FlowRequirementResults {
 	//TODO(timo): Reduce complexity of matcher output to make the surrounding logic
 	// easier to comprehend and modify. Different properties of the verdict should
 	// be exposed as methods, otherwise subtle bugs slip into the surrounding code
@@ -840,7 +840,7 @@ func (a *Action) matchAllFlowRequirements(ctx context.Context, reqs []filters.Fl
 	defer a.flowsMu.Unlock()
 
 	for i := range reqs {
-		res := a.matchFlowRequirements(ctx, a.flows, &reqs[i])
+		res := a.matchFlowRequirements(a.flows, &reqs[i])
 		//TODO(timo): The matcher should probably take in all requirements
 		// and return its verdict in a single struct.
 		out.Merge(&res)
@@ -906,7 +906,7 @@ func (a *Action) validateFlowsForPeer(ctx context.Context, reqs []filters.FlowSe
 			}
 			a.Debugf("Validating %d flows against %d requirements", len(a.flows), len(reqs))
 
-			res = a.matchAllFlowRequirements(ctx, reqs)
+			res = a.matchAllFlowRequirements(reqs)
 			if !res.NeedMoreFlows && res.FirstMatch != -1 {
 				// TODO(timo): This success condition should be a method on FlowRequirementResults.
 				return res

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -286,7 +286,7 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context) error {
 		}
 	}
 	if ct.features.MatchRequirements(RequireFeatureEnabled(FeatureNodeWithoutCilium)) {
-		if err := ct.validateExternalFromCIDRsWithNodesWithoutCilium(ctx); err != nil {
+		if err := ct.validateExternalFromCIDRsWithNodesWithoutCilium(); err != nil {
 			return fmt.Errorf("invalid configuration for nodes without Cilium: %w", err)
 		}
 	}
@@ -446,7 +446,7 @@ func (ct *ConnectivityTest) enableHubbleClient(ctx context.Context) error {
 	return nil
 }
 
-func (ct *ConnectivityTest) validateExternalFromCIDRsWithNodesWithoutCilium(ctx context.Context) error {
+func (ct *ConnectivityTest) validateExternalFromCIDRsWithNodesWithoutCilium() error {
 	if len(ct.params.ExternalFromCIDRs) == 0 {
 		ct.Fatalf("--%s must not be empty if Cilium was install with --%s set", "external-from-cidrs", "nodes-without-cilium")
 	}

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -402,10 +402,10 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			if _, ok := zones[l.GetLabels()["topology.kubernetes.io/zone"]]; ok {
 				zone = l.GetLabels()["topology.kubernetes.io/zone"]
 				break
-			} else {
-				zones[l.GetLabels()["topology.kubernetes.io/zone"]] = 1
-				lz = l.GetLabels()["topology.kubernetes.io/zone"]
 			}
+
+			zones[l.GetLabels()["topology.kubernetes.io/zone"]] = 1
+			lz = l.GetLabels()["topology.kubernetes.io/zone"]
 		}
 		// No zone had > 1, use the last zone.
 		if zone == "" {

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -246,7 +246,7 @@ func (ct *ConnectivityTest) extractFeaturesFromRuntimeConfig(ctx context.Context
 		Enabled: cfg.EncryptNode,
 	}
 
-	isFeatureKNPEnabled, err := ct.isFeatureKNPEnabled(namespace, cfg.EnableK8sNetworkPolicy)
+	isFeatureKNPEnabled, err := ct.isFeatureKNPEnabled(cfg.EnableK8sNetworkPolicy)
 	if err != nil {
 		return fmt.Errorf("unable to determine if KNP feature is enabled: %w", err)
 	}
@@ -520,7 +520,7 @@ func (ct *ConnectivityTest) ForceDisableFeature(feature Feature) {
 
 // isFeatureKNPEnabled checks if the Kubernetes Network Policy feature is enabled from the configuration.
 // Note that the flag appears in Cilium version 1.14, before that it was unable even thought KNPs were present.
-func (ct *ConnectivityTest) isFeatureKNPEnabled(namespace string, enableK8SNetworkPolicy bool) (bool, error) {
+func (ct *ConnectivityTest) isFeatureKNPEnabled(enableK8SNetworkPolicy bool) (bool, error) {
 	switch {
 	case enableK8SNetworkPolicy:
 		// Flag is enabled, means the flag exists.

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -251,7 +251,7 @@ func (ie icmpEndpoint) Port() uint32 {
 }
 
 // HasLabel checks if given label exists and value matches.
-func (ie icmpEndpoint) HasLabel(name, value string) bool {
+func (ie icmpEndpoint) HasLabel(_, _ string) bool {
 	return false
 }
 

--- a/connectivity/filters/filters.go
+++ b/connectivity/filters/filters.go
@@ -118,7 +118,7 @@ type dropFilter struct {
 	dropReasonFunc   func(flow *flowpb.Flow) bool
 }
 
-func (d *dropFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+func (d *dropFilter) Match(flow *flowpb.Flow, _ *FlowContext) bool {
 	if d.trafficDirection != nil && d.dropReasonFunc != nil {
 		return flow.GetTrafficDirection() == *d.trafficDirection && d.dropReasonFunc(flow)
 	}
@@ -128,7 +128,7 @@ func (d *dropFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return flow.GetDropReasonDesc() != flowpb.DropReason_DROP_REASON_UNKNOWN
 }
 
-func (d *dropFilter) String(fc *FlowContext) string {
+func (d *dropFilter) String(_ *FlowContext) string {
 	return "drop"
 }
 
@@ -172,7 +172,7 @@ func Drop(opts ...Option) FlowFilterImplementation {
 
 type l7DropFilter struct{}
 
-func (d *l7DropFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+func (d *l7DropFilter) Match(flow *flowpb.Flow, _ *FlowContext) bool {
 	l7 := flow.GetL7()
 	if l7 == nil {
 		return false
@@ -180,7 +180,7 @@ func (d *l7DropFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return flow.GetVerdict() == flowpb.Verdict_DROPPED
 }
 
-func (d *l7DropFilter) String(fc *FlowContext) string {
+func (d *l7DropFilter) String(_ *FlowContext) string {
 	return "l7 drop"
 }
 
@@ -193,7 +193,7 @@ type icmpFilter struct {
 	typ uint32
 }
 
-func (i *icmpFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+func (i *icmpFilter) Match(flow *flowpb.Flow, _ *FlowContext) bool {
 	l4 := flow.GetL4()
 	if l4 == nil {
 		return false
@@ -211,7 +211,7 @@ func (i *icmpFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return true
 }
 
-func (i *icmpFilter) String(fc *FlowContext) string {
+func (i *icmpFilter) String(_ *FlowContext) string {
 	return fmt.Sprintf("icmp(%d)", i.typ)
 }
 
@@ -224,7 +224,7 @@ type icmpv6Filter struct {
 	typ uint32
 }
 
-func (i *icmpv6Filter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+func (i *icmpv6Filter) Match(flow *flowpb.Flow, _ *FlowContext) bool {
 	l4 := flow.GetL4()
 	if l4 == nil {
 		return false
@@ -242,7 +242,7 @@ func (i *icmpv6Filter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return true
 }
 
-func (i *icmpv6Filter) String(fc *FlowContext) string {
+func (i *icmpv6Filter) String(_ *FlowContext) string {
 	return fmt.Sprintf("icmpv6(%d)", i.typ)
 }
 
@@ -314,7 +314,7 @@ type tcpFlagsFilter struct {
 	syn, ack, fin, rst bool
 }
 
-func (t *tcpFlagsFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+func (t *tcpFlagsFilter) Match(flow *flowpb.Flow, _ *FlowContext) bool {
 	l4 := flow.GetL4()
 	if l4 == nil {
 		return false
@@ -332,7 +332,7 @@ func (t *tcpFlagsFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return true
 }
 
-func (t *tcpFlagsFilter) String(fc *FlowContext) string {
+func (t *tcpFlagsFilter) String(_ *FlowContext) string {
 	var s []string
 	if t.syn {
 		s = append(s, "syn")
@@ -403,7 +403,7 @@ func (i *ipFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return true
 }
 
-func (i *ipFilter) String(fc *FlowContext) string {
+func (i *ipFilter) String(_ *FlowContext) string {
 	var s []string
 	if i.srcIP != "" {
 		s = append(s, "src="+i.srcIP)
@@ -466,7 +466,7 @@ func (t *tcpFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return true
 }
 
-func (t *tcpFilter) String(fc *FlowContext) string {
+func (t *tcpFilter) String(_ *FlowContext) string {
 	var s []string
 	if t.srcPort != 0 {
 		s = append(s, fmt.Sprintf("srcPort=%d", t.srcPort))
@@ -487,7 +487,7 @@ type dnsFilter struct {
 	rcode uint32
 }
 
-func (d *dnsFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+func (d *dnsFilter) Match(flow *flowpb.Flow, _ *FlowContext) bool {
 	l7 := flow.GetL7()
 	if l7 == nil {
 		return false
@@ -509,7 +509,7 @@ func (d *dnsFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return true
 }
 
-func (d *dnsFilter) String(fc *FlowContext) string {
+func (d *dnsFilter) String(_ *FlowContext) string {
 	var s []string
 	if d.query != "" {
 		s = append(s, fmt.Sprintf("query=%s", d.query))
@@ -533,7 +533,7 @@ type httpFilter struct {
 	headers  map[string]string
 }
 
-func (h *httpFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
+func (h *httpFilter) Match(flow *flowpb.Flow, _ *FlowContext) bool {
 	l7 := flow.GetL7()
 	if l7 == nil {
 		return false
@@ -574,7 +574,7 @@ func (h *httpFilter) Match(flow *flowpb.Flow, fc *FlowContext) bool {
 	return true
 }
 
-func (h *httpFilter) String(fc *FlowContext) string {
+func (h *httpFilter) String(_ *FlowContext) string {
 	var s []string
 	if h.code != math.MaxUint32 {
 		s = append(s, fmt.Sprintf("code=%d", h.code))

--- a/connectivity/tests/dummy.go
+++ b/connectivity/tests/dummy.go
@@ -26,7 +26,7 @@ func (s *dummy) Name() string {
 	return fmt.Sprintf("%s:%s", tn, s.name)
 }
 
-func (s *dummy) Run(ctx context.Context, t *check.Test) {
+func (s *dummy) Run(_ context.Context, t *check.Test) {
 	t.NewAction(s, "action-1", nil, nil, check.IPFamilyAny).Run(func(a *check.Action) {
 		a.Log("logging")
 		a.Debug("debugging")

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -625,7 +625,7 @@ func (k *K8sHubble) Enable(ctx context.Context) error {
 	}
 
 	if caSecret != nil {
-		err = k.certManager.LoadCAFromK8s(ctx, caSecret)
+		err = k.certManager.LoadCAFromK8s(caSecret)
 		if err != nil {
 			k.Log("❌ Unable to load Cilium CA: %s", err)
 			return err

--- a/hubble/ui.go
+++ b/hubble/ui.go
@@ -115,10 +115,10 @@ func (k *K8sHubble) disableUI(ctx context.Context) error {
 	}
 	k.client.DeleteConfigMap(ctx, hubbleUICM.GetNamespace(), hubbleUICM.GetName(), metav1.DeleteOptions{})
 
-	return k.deleteUICertificates(ctx)
+	return k.deleteUICertificates()
 }
 
-func (k *K8sHubble) deleteUICertificates(ctx context.Context) error {
+func (k *K8sHubble) deleteUICertificates() error {
 	// TODO we won't generate hubble-ui certificates because we don't want
 	//  to give a bad UX for hubble-cli (which connects to hubble-relay)
 	// k.Log("🔥 Deleting Hubble UI certificates...")
@@ -231,7 +231,7 @@ func (k *K8sHubble) enableUI(ctx context.Context) (string, error) {
 // 	return secret, nil
 // }
 
-func (p *Parameters) UIPortForwardCommand(ctx context.Context) error {
+func (p *Parameters) UIPortForwardCommand() error {
 	args := []string{
 		"port-forward",
 		"-n", p.Namespace,

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -53,7 +53,7 @@ func (k *K8sUninstaller) autodetect(ctx context.Context) {
 	}
 }
 
-func (k *K8sInstaller) detectDatapathMode(ctx context.Context, withKPR bool) error {
+func (k *K8sInstaller) detectDatapathMode(withKPR bool) error {
 	if k.params.DatapathMode != "" {
 		k.Log("ℹ️  Custom datapath mode: %s", k.params.DatapathMode)
 		return nil
@@ -76,7 +76,7 @@ func (k *K8sInstaller) detectDatapathMode(ctx context.Context, withKPR bool) err
 	case k8s.KindAKS:
 		// When on AKS, we need to determine if the cluster is in BYOCNI mode before
 		// determining which DatapathMode to use.
-		if err := k.azureAutodetect(ctx); err != nil {
+		if err := k.azureAutodetect(); err != nil {
 			return err
 		}
 
@@ -139,7 +139,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context) error {
 		}
 	}
 
-	if err := k.detectDatapathMode(ctx, true); err != nil {
+	if err := k.detectDatapathMode(true); err != nil {
 		return err
 	}
 

--- a/install/certs.go
+++ b/install/certs.go
@@ -101,7 +101,7 @@ func (k *K8sInstaller) installCerts(ctx context.Context) error {
 	}
 
 	if caSecret != nil {
-		err = k.certManager.LoadCAFromK8s(ctx, caSecret)
+		err = k.certManager.LoadCAFromK8s(caSecret)
 		if err != nil {
 			k.pushRollbackStep(func(ctx context.Context) {
 				if err := k.client.DeleteSecret(ctx, k.params.Namespace, caSecret.Name, metav1.DeleteOptions{}); err != nil {

--- a/install/gke.go
+++ b/install/gke.go
@@ -4,12 +4,11 @@
 package install
 
 import (
-	"context"
 	"fmt"
 	"strings"
 )
 
-func (k *K8sInstaller) gkeNativeRoutingCIDR(ctx context.Context, contextName string) (string, error) {
+func (k *K8sInstaller) gkeNativeRoutingCIDR(contextName string) (string, error) {
 	// Example: gke_cilium-dev_us-west2-a_tgraf-cluster1
 	parts := strings.Split(contextName, "_")
 	if len(parts) < 4 {

--- a/install/install.go
+++ b/install/install.go
@@ -639,7 +639,7 @@ func (k *K8sInstaller) preinstall(ctx context.Context) error {
 			return err
 		}
 		if k.params.IPv4NativeRoutingCIDR == "" && helmValues["ipv4NativeRoutingCIDR"] == nil {
-			cidr, err := k.gkeNativeRoutingCIDR(ctx, k.client.ContextName())
+			cidr, err := k.gkeNativeRoutingCIDR(k.client.ContextName())
 			if err != nil {
 				k.Log("❌ Unable to auto-detect GKE native routing CIDR. Is \"gcloud\" installed?")
 				k.Log("ℹ️  You can set the native routing CIDR manually with --helm-set ipv4NativeRoutingCIDR=x.x.x.x/x")
@@ -651,7 +651,7 @@ func (k *K8sInstaller) preinstall(ctx context.Context) error {
 	case k8s.KindAKS:
 		if k.params.DatapathMode == DatapathAzure {
 			// The Azure Service Principal is only needed when using Azure IPAM
-			if err := k.azureSetupServicePrincipal(ctx); err != nil {
+			if err := k.azureSetupServicePrincipal(); err != nil {
 				return err
 			}
 		}

--- a/install/kind.go
+++ b/install/kind.go
@@ -21,7 +21,7 @@ func (m *kindVersionValidation) Name() string {
 	return "minimum-version"
 }
 
-func (m *kindVersionValidation) Check(ctx context.Context, k *K8sInstaller) error {
+func (m *kindVersionValidation) Check(_ context.Context, k *K8sInstaller) error {
 	bytes, err := k.Exec("kind", "version")
 	if err != nil {
 		return err

--- a/install/minikube.go
+++ b/install/minikube.go
@@ -21,7 +21,7 @@ func (m *minikubeVersionValidation) Name() string {
 	return "minimum-version"
 }
 
-func (m *minikubeVersionValidation) Check(ctx context.Context, k *K8sInstaller) error {
+func (m *minikubeVersionValidation) Check(_ context.Context, k *K8sInstaller) error {
 	bytes, err := k.Exec("minikube", "version")
 	if err != nil {
 		return err

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -28,7 +28,7 @@ func (k *K8sInstaller) Upgrade(ctx context.Context) error {
 
 	// no need to determine KPR setting on upgrade, keep the setting configured with the old
 	// version.
-	if err := k.detectDatapathMode(ctx, false); err != nil {
+	if err := k.detectDatapathMode(false); err != nil {
 		return err
 	}
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -70,7 +70,7 @@ func (c *CertManager) GetOrCreateCASecret(ctx context.Context, caSecretName stri
 	return s, true, nil
 }
 
-func (c *CertManager) LoadCAFromK8s(ctx context.Context, secret *corev1.Secret) error {
+func (c *CertManager) LoadCAFromK8s(secret *corev1.Secret) error {
 	if key, ok := secret.Data[defaults.CASecretKeyName]; ok {
 		c.caKey = make([]byte, len(key))
 		copy(c.caKey, key)

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -174,7 +174,7 @@ func newCmdUI() *cobra.Command {
 			params.Context = contextName
 			params.Namespace = namespace
 
-			if err := params.UIPortForwardCommand(context.Background()); err != nil {
+			if err := params.UIPortForwardCommand(); err != nil {
 				fatalf("Unable to port forward: %s", err)
 			}
 			return nil

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -15,19 +15,19 @@ func init() {
 type noopLogger struct{}
 
 // Debug implements cfsslLog.SyslogWriter.
-func (s *noopLogger) Debug(msg string) {}
+func (s *noopLogger) Debug(_ string) {}
 
 // Info implements cfsslLog.SyslogWriter.
-func (s *noopLogger) Info(msg string) {}
+func (s *noopLogger) Info(_ string) {}
 
 // Warning implements cfsslLog.SyslogWriter.
-func (s *noopLogger) Warning(msg string) {}
+func (s *noopLogger) Warning(_ string) {}
 
 // Error implements cfsslLog.SyslogWriter.
-func (s *noopLogger) Err(msg string) {}
+func (s *noopLogger) Err(_ string) {}
 
 // Crit implements cfsslLog.SyslogWriter.
-func (s *noopLogger) Crit(msg string) {}
+func (s *noopLogger) Crit(_ string) {}
 
 // Emerg implements cfsslLog.SyslogWriter.
-func (s *noopLogger) Emerg(msg string) {}
+func (s *noopLogger) Emerg(_ string) {}

--- a/internal/utils/exec_test.go
+++ b/internal/utils/exec_test.go
@@ -21,7 +21,7 @@ type failIfCalled struct {
 	c *check.C
 }
 
-func (f *failIfCalled) Log(fmt string, args ...interface{}) {
+func (f *failIfCalled) Log(_ string, _ ...interface{}) {
 	f.c.Error("log method should not be called")
 }
 
@@ -29,7 +29,7 @@ type countIfCalled struct {
 	count int
 }
 
-func (c *countIfCalled) Log(fmt string, args ...interface{}) {
+func (c *countIfCalled) Log(_ string, _ ...interface{}) {
 	c.count++
 }
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -407,23 +407,6 @@ func (c *Client) ListServices(ctx context.Context, namespace string, options met
 	return c.Clientset.CoreV1().Services(namespace).List(ctx, options)
 }
 
-func (c *Client) WriteFileToPod(ctx context.Context, namespace, pod, container, path string, content []byte, mode int32) error {
-	result, err := c.execInPod(ctx, ExecParameters{
-		Namespace: namespace,
-		Pod:       pod,
-		Container: container,
-	})
-	if err != nil {
-		return fmt.Errorf("error executing cat in pod: %s", err)
-	}
-
-	if errString := result.Stderr.String(); errString != "" {
-		return fmt.Errorf("error writing file to pod: %s", errString)
-	}
-
-	return nil
-}
-
 func (c *Client) ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error) {
 	result, err := c.execInPod(ctx, ExecParameters{
 		Namespace: namespace,
@@ -774,7 +757,7 @@ func (c *Client) ListNamespaces(ctx context.Context, o metav1.ListOptions) (*cor
 	return c.Clientset.CoreV1().Namespaces().List(ctx, o)
 }
 
-func (c *Client) GetPodsTable(ctx context.Context) (*metav1.Table, error) {
+func (c *Client) GetPodsTable(_ context.Context) (*metav1.Table, error) {
 	r := resource.NewBuilder(c.RESTClientGetter).
 		Unstructured().
 		AllNamespaces(true).
@@ -952,7 +935,7 @@ func (c *Client) ListCiliumLocalRedirectPolicies(ctx context.Context, namespace 
 	return c.CiliumClientset.CiliumV2().CiliumLocalRedirectPolicies(namespace).List(ctx, opts)
 }
 
-func (c *Client) GetPlatform(ctx context.Context) (*Platform, error) {
+func (c *Client) GetPlatform(_ context.Context) (*Platform, error) {
 	v, err := c.Clientset.Discovery().ServerVersion()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Kubernetes version: %w", err)
@@ -1041,7 +1024,7 @@ func (c *Client) GetHelmState(ctx context.Context, namespace string, secretName 
 	}, nil
 }
 
-func (c *Client) ListAPIResources(ctx context.Context) ([]string, error) {
+func (c *Client) ListAPIResources(_ context.Context) ([]string, error) {
 	lists, err := c.Clientset.Discovery().ServerPreferredResources()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list api resources: %w", err)

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -128,27 +128,27 @@ func (c *k8sStatusMockClient) setDaemonSet(namespace, name, filter string, desir
 	}
 }
 
-func (c *k8sStatusMockClient) GetDaemonSet(ctx context.Context, namespace, name string, options metav1.GetOptions) (*appsv1.DaemonSet, error) {
+func (c *k8sStatusMockClient) GetDaemonSet(_ context.Context, namespace, name string, _ metav1.GetOptions) (*appsv1.DaemonSet, error) {
 	return c.daemonSet[namespace+"/"+name], nil
 }
 
-func (c *k8sStatusMockClient) GetDeployment(ctx context.Context, namespace, name string, options metav1.GetOptions) (*appsv1.Deployment, error) {
+func (c *k8sStatusMockClient) GetDeployment(_ context.Context, namespace, name string, _ metav1.GetOptions) (*appsv1.Deployment, error) {
 	return c.deployment[namespace+"/"+name], nil
 }
 
-func (c *k8sStatusMockClient) ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error) {
+func (c *k8sStatusMockClient) ListPods(_ context.Context, _ string, options metav1.ListOptions) (*corev1.PodList, error) {
 	return c.podList[options.LabelSelector], nil
 }
 
-func (c *k8sStatusMockClient) ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error) {
+func (c *k8sStatusMockClient) ListCiliumEndpoints(_ context.Context, _ string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error) {
 	return c.ciliumEndpointList[options.LabelSelector], nil
 }
 
-func (c *k8sStatusMockClient) CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error) {
+func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _ string, _ time.Time, _ *regexp.Regexp) (string, error) {
 	return "[error] a sample cilium-agent error message", nil
 }
 
-func (c *k8sStatusMockClient) CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error) {
+func (c *k8sStatusMockClient) CiliumStatus(_ context.Context, _, pod string) (*models.StatusResponse, error) {
 	s, ok := c.status[pod]
 	if !ok {
 		return nil, fmt.Errorf("pod %s not found", pod)

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -790,7 +790,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to list Cilium pods: %w", err)
 				}
-				if err := c.SubmitCniConflistSubtask(ctx, FilterPods(p, c.NodeList), ciliumAgentContainerName); err != nil {
+				if err := c.SubmitCniConflistSubtask(FilterPods(p, c.NodeList), ciliumAgentContainerName); err != nil {
 					return fmt.Errorf("failed to collect CNI configuration files: %w", err)
 				}
 				return nil
@@ -825,7 +825,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get Cilium pods: %w", err)
 				}
-				if err := c.SubmitGopsSubtasks(ctx, FilterPods(p, c.NodeList), ciliumAgentContainerName); err != nil {
+				if err := c.SubmitGopsSubtasks(FilterPods(p, c.NodeList), ciliumAgentContainerName); err != nil {
 					return fmt.Errorf("failed to collect Cilium gops: %w", err)
 				}
 				return nil
@@ -842,7 +842,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get Hubble pods: %w", err)
 				}
-				if err := c.SubmitGopsSubtasks(ctx, FilterPods(p, c.NodeList), hubbleContainerName); err != nil {
+				if err := c.SubmitGopsSubtasks(FilterPods(p, c.NodeList), hubbleContainerName); err != nil {
 					return fmt.Errorf("failed to collect Hubble gops: %w", err)
 				}
 				return nil
@@ -859,7 +859,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get Hubble Relay pods: %w", err)
 				}
-				if err := c.SubmitGopsSubtasks(ctx, FilterPods(p, c.NodeList), hubbleRelayContainerName); err != nil {
+				if err := c.SubmitGopsSubtasks(FilterPods(p, c.NodeList), hubbleRelayContainerName); err != nil {
 					return fmt.Errorf("failed to collect Hubble Relay gops: %w", err)
 				}
 				return nil
@@ -876,7 +876,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get Cilium pods: %w", err)
 				}
-				if err := c.submitCiliumBugtoolTasks(ctx, FilterPods(p, c.NodeList)); err != nil {
+				if err := c.submitCiliumBugtoolTasks(FilterPods(p, c.NodeList)); err != nil {
 					return fmt.Errorf("failed to collect 'cilium-bugtool': %w", err)
 				}
 				return nil
@@ -896,7 +896,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get profiling from Cilium pods: %w", err)
 				}
-				if err := c.SubmitProfilingGopsSubtasks(ctx, FilterPods(p, c.NodeList), ciliumAgentContainerName); err != nil {
+				if err := c.SubmitProfilingGopsSubtasks(FilterPods(p, c.NodeList), ciliumAgentContainerName); err != nil {
 					return fmt.Errorf("failed to collect profiling data from Cilium pods: %w", err)
 				}
 				return nil
@@ -913,7 +913,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get logs from Cilium pods")
 				}
-				if err := c.SubmitLogsTasks(ctx, FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from Cilium pods")
 				}
 				return nil
@@ -930,7 +930,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get logs from Cilium operator pods")
 				}
-				if err := c.SubmitLogsTasks(ctx, FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from Cilium operator pods")
 				}
 				return nil
@@ -947,7 +947,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get logs from 'clustermesh-apiserver' pods")
 				}
-				if err := c.SubmitLogsTasks(ctx, FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from 'clustermesh-apiserver' pods")
 				}
 				return nil
@@ -964,7 +964,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get logs from Hubble pods")
 				}
-				if err := c.SubmitLogsTasks(ctx, FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from Hubble pods")
 				}
 				return nil
@@ -981,7 +981,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get logs from Hubble Relay pods")
 				}
-				if err := c.SubmitLogsTasks(ctx, FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from Hubble Relay pods")
 				}
 				return nil
@@ -998,7 +998,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get logs from Hubble UI pods")
 				}
-				if err := c.SubmitLogsTasks(ctx, FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from Hubble UI pods")
 				}
 				return nil
@@ -1015,7 +1015,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get Tetragon pods: %w", err)
 				}
-				if err := c.submitTetragonBugtoolTasks(ctx, FilterPods(p, c.NodeList)); err != nil {
+				if err := c.submitTetragonBugtoolTasks(FilterPods(p, c.NodeList)); err != nil {
 					return fmt.Errorf("failed to collect 'tetragon-bugtool': %w", err)
 				}
 				return nil
@@ -1028,7 +1028,7 @@ func (c *Collector) Run() error {
 			Task: func(ctx context.Context) error {
 				f := c.Client.AutodetectFlavor(ctx)
 				c.logDebug("Detected flavor %q", f.Kind)
-				if err := c.submitFlavorSpecificTasks(ctx, f); err != nil {
+				if err := c.submitFlavorSpecificTasks(f); err != nil {
 					return fmt.Errorf("failed to collect platform-specific data: %w", err)
 				}
 				return nil
@@ -1108,7 +1108,7 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get logs from pods matching selector %q", selector)
 				}
-				if err := c.SubmitLogsTasks(ctx, FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(FilterPods(p, c.NodeList), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from pods matching selector %q", selector)
 				}
 				return nil
@@ -1245,7 +1245,7 @@ func (c *Collector) shouldSkipTask(t Task) bool {
 	return c.Options.Quick && !t.Quick
 }
 
-func (c *Collector) submitTetragonBugtoolTasks(ctx context.Context, pods []*corev1.Pod) error {
+func (c *Collector) submitTetragonBugtoolTasks(pods []*corev1.Pod) error {
 	for _, p := range pods {
 		p := p
 		workerID := fmt.Sprintf("%s-%s", tetragonBugtoolPrefix, p.Name)
@@ -1304,7 +1304,7 @@ func (c *Collector) submitTetragonBugtoolTasks(ctx context.Context, pods []*core
 	return nil
 }
 
-func (c *Collector) submitCiliumBugtoolTasks(ctx context.Context, pods []*corev1.Pod) error {
+func (c *Collector) submitCiliumBugtoolTasks(pods []*corev1.Pod) error {
 	for _, p := range pods {
 		p := p
 		if err := c.Pool.Submit(fmt.Sprintf("cilium-bugtool-"+p.Name), func(ctx context.Context) error {
@@ -1443,7 +1443,7 @@ func extractGopsProfileData(output string) (string, error) {
 
 }
 
-func (c *Collector) SubmitCniConflistSubtask(ctx context.Context, pods []*corev1.Pod, containerName string) error {
+func (c *Collector) SubmitCniConflistSubtask(pods []*corev1.Pod, containerName string) error {
 	for _, p := range pods {
 		p := p
 		if err := c.Pool.Submit(fmt.Sprintf("cniconflist-%s", p.GetName()), func(ctx context.Context) error {
@@ -1497,7 +1497,7 @@ func (c *Collector) getGopsPID(ctx context.Context, pod *corev1.Pod, containerNa
 }
 
 // SubmitGopsSubtasks submits tasks to collect gops statistics from pods.
-func (c *Collector) SubmitGopsSubtasks(ctx context.Context, pods []*corev1.Pod, containerName string) error {
+func (c *Collector) SubmitGopsSubtasks(pods []*corev1.Pod, containerName string) error {
 	for _, p := range pods {
 		p := p
 		for _, g := range gopsStats {
@@ -1529,7 +1529,7 @@ func (c *Collector) SubmitGopsSubtasks(ctx context.Context, pods []*corev1.Pod, 
 }
 
 // SubmitProfilingGopsSubtasks submits tasks to collect profiling data from pods.
-func (c *Collector) SubmitProfilingGopsSubtasks(ctx context.Context, pods []*corev1.Pod, containerName string) error {
+func (c *Collector) SubmitProfilingGopsSubtasks(pods []*corev1.Pod, containerName string) error {
 	for _, p := range pods {
 		p := p
 		for _, g := range gopsProfiling {
@@ -1570,7 +1570,7 @@ func (c *Collector) SubmitProfilingGopsSubtasks(ctx context.Context, pods []*cor
 }
 
 // SubmitLogsTasks submits tasks to collect kubernetes logs from pods.
-func (c *Collector) SubmitLogsTasks(ctx context.Context, pods []*corev1.Pod, since time.Duration, limitBytes int64) error {
+func (c *Collector) SubmitLogsTasks(pods []*corev1.Pod, since time.Duration, limitBytes int64) error {
 	t := time.Now().Add(-since)
 	for _, p := range pods {
 		p := p
@@ -1612,7 +1612,7 @@ func (c *Collector) SubmitLogsTasks(ctx context.Context, pods []*corev1.Pod, sin
 	return nil
 }
 
-func (c *Collector) submitFlavorSpecificTasks(ctx context.Context, f k8s.Flavor) error {
+func (c *Collector) submitFlavorSpecificTasks(f k8s.Flavor) error {
 	switch f.Kind {
 	case k8s.KindEKS:
 		if err := c.Pool.Submit(awsNodeDaemonSetName, func(ctx context.Context) error {

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -243,47 +243,47 @@ type fakeClient struct {
 	execs    map[execRequest]execResult
 }
 
-func (c *fakeClient) ListCiliumBGPPeeringPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumBGPPeeringPolicyList, error) {
+func (c *fakeClient) ListCiliumBGPPeeringPolicies(_ context.Context, _ metav1.ListOptions) (*ciliumv2alpha1.CiliumBGPPeeringPolicyList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumLoadBalancerIPPools(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumLoadBalancerIPPoolList, error) {
+func (c *fakeClient) ListCiliumLoadBalancerIPPools(_ context.Context, _ metav1.ListOptions) (*ciliumv2alpha1.CiliumLoadBalancerIPPoolList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumNodeConfigs(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumNodeConfigList, error) {
+func (c *fakeClient) ListCiliumNodeConfigs(_ context.Context, _ string, _ metav1.ListOptions) (*ciliumv2alpha1.CiliumNodeConfigList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumClusterwideEnvoyConfigs(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumClusterwideEnvoyConfigList, error) {
+func (c *fakeClient) ListCiliumClusterwideEnvoyConfigs(_ context.Context, _ metav1.ListOptions) (*ciliumv2.CiliumClusterwideEnvoyConfigList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumEnvoyConfigs(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEnvoyConfigList, error) {
+func (c *fakeClient) ListCiliumEnvoyConfigs(_ context.Context, _ string, _ metav1.ListOptions) (*ciliumv2.CiliumEnvoyConfigList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListIngresses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressList, error) {
+func (c *fakeClient) ListIngresses(_ context.Context, _ metav1.ListOptions) (*networkingv1.IngressList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) CopyFromPod(ctx context.Context, namespace, pod, container, fromFile, destFile string, retryLimit int) error {
+func (c *fakeClient) CopyFromPod(_ context.Context, _, _, _, _, _ string, _ int) error {
 	panic("implement me")
 }
 
-func (c *fakeClient) AutodetectFlavor(ctx context.Context) k8s.Flavor {
+func (c *fakeClient) AutodetectFlavor(_ context.Context) k8s.Flavor {
 	panic("implement me")
 }
 
-func (c *fakeClient) GetPod(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Pod, error) {
+func (c *fakeClient) GetPod(_ context.Context, _, _ string, _ metav1.GetOptions) (*corev1.Pod, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) CreatePod(ctx context.Context, namespace string, pod *corev1.Pod, opts metav1.CreateOptions) (*corev1.Pod, error) {
+func (c *fakeClient) CreatePod(_ context.Context, _ string, _ *corev1.Pod, _ metav1.CreateOptions) (*corev1.Pod, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) DeletePod(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+func (c *fakeClient) DeletePod(_ context.Context, _, _ string, _ metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
@@ -301,7 +301,7 @@ func (c *fakeClient) ExecInPod(ctx context.Context, namespace, pod, container st
 	return stdout, err
 }
 
-func (c *fakeClient) ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error) {
+func (c *fakeClient) ExecInPodWithStderr(_ context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error) {
 	r := execRequest{namespace, pod, container, strings.Join(command, " ")}
 	out, ok := c.execs[r]
 	if !ok {
@@ -310,55 +310,55 @@ func (c *fakeClient) ExecInPodWithStderr(ctx context.Context, namespace, pod, co
 	return *bytes.NewBuffer(out.stdout), *bytes.NewBuffer(out.stderr), out.err
 }
 
-func (c *fakeClient) GetCiliumVersion(ctx context.Context, p *corev1.Pod) (*semver.Version, error) {
+func (c *fakeClient) GetCiliumVersion(_ context.Context, _ *corev1.Pod) (*semver.Version, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error) {
+func (c *fakeClient) GetConfigMap(_ context.Context, _, _ string, _ metav1.GetOptions) (*corev1.ConfigMap, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error) {
+func (c *fakeClient) GetDaemonSet(_ context.Context, _, _ string, _ metav1.GetOptions) (*appsv1.DaemonSet, error) {
 	return nil, nil
 }
 
-func (c *fakeClient) GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error) {
+func (c *fakeClient) GetDeployment(_ context.Context, _, _ string, _ metav1.GetOptions) (*appsv1.Deployment, error) {
 	return nil, nil
 }
 
-func (c *fakeClient) GetLogs(ctx context.Context, namespace, name, container string, sinceTime time.Time, limitBytes int64, previous bool) (string, error) {
+func (c *fakeClient) GetLogs(_ context.Context, _, _, _ string, _ time.Time, _ int64, _ bool) (string, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) GetPodsTable(ctx context.Context) (*metav1.Table, error) {
+func (c *fakeClient) GetPodsTable(_ context.Context) (*metav1.Table, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) GetSecret(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
+func (c *fakeClient) GetSecret(_ context.Context, _, _ string, _ metav1.GetOptions) (*corev1.Secret, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) GetVersion(ctx context.Context) (string, error) {
+func (c *fakeClient) GetVersion(_ context.Context) (string, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumClusterwideNetworkPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumClusterwideNetworkPolicyList, error) {
+func (c *fakeClient) ListCiliumClusterwideNetworkPolicies(_ context.Context, _ metav1.ListOptions) (*ciliumv2.CiliumClusterwideNetworkPolicyList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumIdentities(ctx context.Context) (*ciliumv2.CiliumIdentityList, error) {
+func (c *fakeClient) ListCiliumIdentities(_ context.Context) (*ciliumv2.CiliumIdentityList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumEgressGatewayPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumEgressGatewayPolicyList, error) {
+func (c *fakeClient) ListCiliumEgressGatewayPolicies(_ context.Context, _ metav1.ListOptions) (*ciliumv2.CiliumEgressGatewayPolicyList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error) {
+func (c *fakeClient) ListCiliumEndpoints(_ context.Context, _ string, _ metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumEndpointSlices(ctx context.Context, options metav1.ListOptions) (*ciliumv2alpha1.CiliumEndpointSliceList, error) {
+func (c *fakeClient) ListCiliumEndpointSlices(_ context.Context, _ metav1.ListOptions) (*ciliumv2alpha1.CiliumEndpointSliceList, error) {
 	ciliumEndpointSliceList := ciliumv2alpha1.CiliumEndpointSliceList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
@@ -395,7 +395,7 @@ func (c *fakeClient) ListCiliumEndpointSlices(ctx context.Context, options metav
 	return &ciliumEndpointSliceList, nil
 }
 
-func (c *fakeClient) ListCiliumExternalWorkloads(ctx context.Context, options metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error) {
+func (c *fakeClient) ListCiliumExternalWorkloads(_ context.Context, _ metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error) {
 	ciliumExternalWorkloadList := ciliumv2.CiliumExternalWorkloadList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
@@ -420,55 +420,55 @@ func (c *fakeClient) ListCiliumExternalWorkloads(ctx context.Context, options me
 	return &ciliumExternalWorkloadList, nil
 }
 
-func (c *fakeClient) ListCiliumLocalRedirectPolicies(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumLocalRedirectPolicyList, error) {
+func (c *fakeClient) ListCiliumLocalRedirectPolicies(_ context.Context, _ string, _ metav1.ListOptions) (*ciliumv2.CiliumLocalRedirectPolicyList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error) {
+func (c *fakeClient) ListCiliumNetworkPolicies(_ context.Context, _ string, _ metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeList, error) {
+func (c *fakeClient) ListCiliumNodes(_ context.Context) (*ciliumv2.CiliumNodeList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error) {
+func (c *fakeClient) ListDaemonSet(_ context.Context, _ string, _ metav1.ListOptions) (*appsv1.DaemonSetList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error) {
+func (c *fakeClient) ListEvents(_ context.Context, _ metav1.ListOptions) (*corev1.EventList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListNamespaces(ctx context.Context, o metav1.ListOptions) (*corev1.NamespaceList, error) {
+func (c *fakeClient) ListNamespaces(_ context.Context, _ metav1.ListOptions) (*corev1.NamespaceList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error) {
+func (c *fakeClient) ListEndpoints(_ context.Context, _ metav1.ListOptions) (*corev1.EndpointsList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error) {
+func (c *fakeClient) ListNetworkPolicies(_ context.Context, _ metav1.ListOptions) (*networkingv1.NetworkPolicyList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListNodes(ctx context.Context, options metav1.ListOptions) (*corev1.NodeList, error) {
+func (c *fakeClient) ListNodes(_ context.Context, _ metav1.ListOptions) (*corev1.NodeList, error) {
 	return c.nodeList, nil
 }
 
-func (c *fakeClient) ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error) {
+func (c *fakeClient) ListPods(_ context.Context, _ string, _ metav1.ListOptions) (*corev1.PodList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListServices(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.ServiceList, error) {
+func (c *fakeClient) ListServices(_ context.Context, _ string, _ metav1.ListOptions) (*corev1.ServiceList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListUnstructured(ctx context.Context, gvr schema.GroupVersionResource, namespace *string, o metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (c *fakeClient) ListUnstructured(_ context.Context, _ schema.GroupVersionResource, _ *string, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	panic("implement me")
 }
 
-func (c *fakeClient) ListTetragonTracingPolicies(ctx context.Context, options metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyList, error) {
+func (c *fakeClient) ListTetragonTracingPolicies(_ context.Context, _ metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyList, error) {
 	tetragonTracingPolicy := tetragonv1alpha1.TracingPolicyList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
@@ -495,7 +495,7 @@ func (c *fakeClient) ListTetragonTracingPolicies(ctx context.Context, options me
 	return &tetragonTracingPolicy, nil
 }
 
-func (c *fakeClient) CreateEphemeralContainer(ctx context.Context, pod *corev1.Pod, container *corev1.EphemeralContainer) (*corev1.Pod, error) {
+func (c *fakeClient) CreateEphemeralContainer(_ context.Context, _ *corev1.Pod, _ *corev1.EphemeralContainer) (*corev1.Pod, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
This PR updates golangci-lint to version 1.52.2

In addition, newly detected issues (mostly unused parameters) have been fixed.