### PR TITLE
Support for dedicated Cilium Envoy DaemonSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,18 +102,22 @@ To install Cilium while automatically detected:
 
     cilium status
         /¯¯\
-     /¯¯\__/¯¯\    Cilium:      OK
-     \__/¯¯\__/    Operator:    OK
-     /¯¯\__/¯¯\    Hubble:      OK
-     \__/¯¯\__/
-        \__/
+     /¯¯\__/¯¯\    Cilium:             OK
+     \__/¯¯\__/    Operator:           OK
+     /¯¯\__/¯¯\    Envoy DaemonSet:    OK
+     \__/¯¯\__/    Hubble Relay:       OK
+        \__/       ClusterMesh:        disabled
+
     DaemonSet         cilium             Desired: 1, Ready: 1/1, Available: 1/1
+    DaemonSet         cilium-envoy       Desired: 1, Ready: 1/1, Available: 1/1
     Deployment        cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
     Deployment        hubble-relay       Desired: 1, Ready: 1/1, Available: 1/1
     Containers:       cilium             Running: 1
+                      cilium-envoy       Running: 1
                       cilium-operator    Running: 1
                       hubble-relay       Running: 1
     Image versions    cilium             quay.io/cilium/cilium:v1.9.1: 1
+                      cilium-envoy       quay.io/cilium/cilium-envoy:v1.25.5-37a98693f069413c82bef1724dd75dcf1b564fd9@sha256:d10841c9cc5b0822eeca4e3654929418b6424c978fd818868b429023f6cc215d: 1
                       cilium-operator    quay.io/cilium/operator-generic:v1.9.1: 1
                       hubble-relay       quay.io/cilium/hubble-relay:v1.9.1: 1
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -16,6 +16,8 @@ const (
 	AgentResourceQuota      = "cilium-resource-quota"
 	AgentImage              = "quay.io/cilium/cilium"
 
+	EnvoyDaemonSetName = "cilium-envoy"
+
 	CASecretName     = "cilium-ca"
 	CASecretKeyName  = "ca.key"
 	CASecretCertName = "ca.crt"

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -17,6 +17,7 @@ const (
 	AgentImage              = "quay.io/cilium/cilium"
 
 	EnvoyDaemonSetName = "cilium-envoy"
+	EnvoyConfigMapName = "cilium-envoy-config"
 
 	CASecretName     = "cilium-ca"
 	CASecretKeyName  = "ca.key"

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -68,6 +68,9 @@ func initSysdumpFlags(cmd *cobra.Command, options *sysdump.Options, optionPrefix
 	cmd.Flags().StringVar(&options.CiliumDaemonSetSelector,
 		optionPrefix+"cilium-daemon-set-label-selector", sysdump.DefaultCiliumLabelSelector,
 		"The labels used to target Cilium daemon set")
+	cmd.Flags().StringVar(&options.CiliumEnvoyLabelSelector,
+		optionPrefix+"cilium-envoy-label-selector", sysdump.DefaultCiliumEnvoyLabelSelector,
+		"The labels used to target Cilium Envoy pods")
 	cmd.Flags().StringVar(&options.CiliumOperatorLabelSelector,
 		optionPrefix+"cilium-operator-label-selector", sysdump.DefaultCiliumOperatorLabelSelector,
 		"The labels used to target Cilium operator pods")

--- a/status/status.go
+++ b/status/status.go
@@ -325,7 +325,7 @@ func (s *Status) Format() string {
 	fmt.Fprintf(w, Yellow+"    /¯¯\\\n")
 	fmt.Fprintf(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\tCilium:\t"+s.statusSummary(defaults.AgentDaemonSetName)+"\n")
 	fmt.Fprintf(w, Cyan+" \\__"+Red+"/¯¯\\"+Green+"__/"+Reset+"\tOperator:\t"+s.statusSummary(defaults.OperatorDeploymentName)+"\n")
-	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tEnvoy DaemonSet:\t"+s.statusSummary(defaults.EnvoyDaemonSetName)+"\n")
+	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tEnvoy DaemonSet:\t"+envoyStatusSummary(s.statusSummary(defaults.EnvoyDaemonSetName))+"\n")
 	fmt.Fprintf(w, Green+" \\__"+Blue+"/¯¯\\"+Magenta+"__/"+Reset+"\tHubble Relay:\t"+s.statusSummary(defaults.RelayDeploymentName)+"\n")
 	fmt.Fprintf(w, Blue+Blue+Blue+"    \\__/"+Reset+"\tClusterMesh:\t"+s.statusSummary(defaults.ClusterMeshDeploymentName)+"\n")
 	fmt.Fprintf(w, "\n")
@@ -379,4 +379,14 @@ func (s *Status) Format() string {
 	w.Flush()
 
 	return buf.String()
+}
+
+// envoyStatusSummary adds some more context to the default `disabled` - mainly to prevent confusion.
+// This might get removed once the DaemonSet mode becomes the only available option.
+func envoyStatusSummary(statusSummary string) string {
+	if strings.Contains(statusSummary, "disabled") {
+		return strings.Replace(statusSummary, "disabled", "disabled (using embedded mode)", 1)
+	}
+
+	return statusSummary
 }

--- a/status/status.go
+++ b/status/status.go
@@ -325,9 +325,9 @@ func (s *Status) Format() string {
 	fmt.Fprintf(w, Yellow+"    /¯¯\\\n")
 	fmt.Fprintf(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\tCilium:\t"+s.statusSummary(defaults.AgentDaemonSetName)+"\n")
 	fmt.Fprintf(w, Cyan+" \\__"+Red+"/¯¯\\"+Green+"__/"+Reset+"\tOperator:\t"+s.statusSummary(defaults.OperatorDeploymentName)+"\n")
-	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tHubble Relay:\t"+s.statusSummary(defaults.RelayDeploymentName)+"\n")
-	fmt.Fprintf(w, Green+" \\__"+Blue+"/¯¯\\"+Magenta+"__/"+Reset+"\tClusterMesh:\t"+s.statusSummary(defaults.ClusterMeshDeploymentName)+"\n")
-	fmt.Fprintf(w, Blue+"    \\__/\n"+Reset)
+	fmt.Fprintf(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tEnvoy DaemonSet:\t"+s.statusSummary(defaults.EnvoyDaemonSetName)+"\n")
+	fmt.Fprintf(w, Green+" \\__"+Blue+"/¯¯\\"+Magenta+"__/"+Reset+"\tHubble Relay:\t"+s.statusSummary(defaults.RelayDeploymentName)+"\n")
+	fmt.Fprintf(w, Blue+Blue+Blue+"    \\__/"+Reset+"\tClusterMesh:\t"+s.statusSummary(defaults.ClusterMeshDeploymentName)+"\n")
 	fmt.Fprintf(w, "\n")
 
 	if len(s.PodState) > 0 {

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -22,6 +22,8 @@ const (
 	clustermeshApiserverDeploymentName = defaults.ClusterMeshDeploymentName
 	hubbleContainerName                = "hubble"
 	hubbleDaemonSetName                = "hubble"
+	ciliumEnvoyDaemonSetName           = "cilium-envoy"
+	ciliumEnvoyConfigMapName           = defaults.EnvoyConfigMapName
 	hubbleRelayConfigMapName           = defaults.RelayConfigMapName
 	hubbleRelayContainerName           = defaults.RelayContainerName
 	hubbleRelayDeploymentName          = defaults.RelayDeploymentName
@@ -37,6 +39,8 @@ const (
 	ciliumClusterwideEnvoyConfigsFileName    = "ciliumclusterwideenvoyconfigs-<ts>.yaml"
 	ciliumConfigMapFileName                  = "cilium-configmap-<ts>.yaml"
 	ciliumDaemonSetFileName                  = "cilium-daemonset-<ts>.yaml"
+	ciliumEnvoyDaemonsetFileName             = "cilium-envoy-daemonset-<ts>.yaml"
+	ciliumEnvoyConfigMapFileName             = "cilium-envoy-configmap-<ts>.yaml"
 	ciliumIngressesFileName                  = "ciliumingresses-<ts>.yaml"
 	ciliumEgressNATPoliciesFileName          = "ciliumegressnatpolicies-<ts>.yaml"
 	ciliumEgressGatewayPoliciesFileName      = "ciliumegressgatewaypolicies-<ts>.yaml"

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -25,6 +25,7 @@ const (
 
 const (
 	DefaultCiliumLabelSelector               = labelPrefix + "cilium"
+	DefaultCiliumEnvoyLabelSelector          = labelPrefix + "cilium-envoy"
 	DefaultCiliumOperatorLabelSelector       = "io.cilium/app=operator"
 	DefaultClustermeshApiserverLabelSelector = labelPrefix + "clustermesh-apiserver"
 	DefaultDebug                             = false

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -690,6 +690,38 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting the Cilium Envoy configuration",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetConfigMap(ctx, c.Options.CiliumNamespace, ciliumEnvoyConfigMapName, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect the Cilium Envoy configuration: %w", err)
+				}
+				if err := c.WriteYAML(ciliumEnvoyConfigMapFileName, v); err != nil {
+					return fmt.Errorf("failed to collect the Cilium Envoy configuration: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting the Cilium Envoy daemonset",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetDaemonSet(ctx, c.Options.CiliumNamespace, ciliumEnvoyDaemonSetName, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						c.logWarn("Daemonset %q not found in namespace %q - this is expected if Envoy DaemonSet is not enabled", ciliumEnvoyDaemonSetName, c.Options.CiliumNamespace)
+						return nil
+					}
+					return fmt.Errorf("failed to collect the Cilium Envoy daemonset: %w", err)
+				}
+				if err := c.WriteYAML(ciliumEnvoyDaemonsetFileName, v); err != nil {
+					return fmt.Errorf("failed to collect the Cilium Envoy daemonset: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting the Hubble daemonset",
 			Quick:       true,
 			Task: func(ctx context.Context) error {


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/25081 adds support for deploying Cilium's L7 Proxy (Envoy) to be deployed in its own DaemonSet instead of running it in the same container as the Cilium Agent. Currently, it needs to be explicitly enabled via helm value `envoy.enabled=true`

This PR adds support for the new Envoy DaemonSet in the Cilium CLI.
* Status
* SysDump Log collection
* SysDump DaemonSet & ConfigMap collection

Installation works out of the box with the newly introduced helm CLI mode :tada: 

Classic mode isn't supported for the time being and needs to be discussed.