### PR TITLE
connectivity: test accessing NodePort from outside with L7 policy

### DIFF
--- a/connectivity/manifests/echo-ingress-l7-http-from-anywhere.yaml
+++ b/connectivity/manifests/echo-ingress-l7-http-from-anywhere.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "echo-ingress-l7-http-from-anywhere"
+spec:
+  description: "Allow all to GET / on echo"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+          - method: "GET"
+            path: "/$"

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -125,6 +125,9 @@ var (
 	//go:embed manifests/echo-ingress-l7-http.yaml
 	echoIngressL7HTTPPolicyYAML string
 
+	//go:embed manifests/echo-ingress-l7-http-from-anywhere.yaml
+	echoIngressL7HTTPFromAnywherePolicyYAML string
+
 	//go:embed manifests/echo-ingress-l7-http-named-port.yaml
 	echoIngressL7HTTPNamedPortPolicyYAML string
 
@@ -189,6 +192,12 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	if ct.Params().Datapath {
 		ct.NewTest("north-south-loadbalancing").
 			WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureNodeWithoutCilium)).
+			WithScenarios(
+				tests.OutsideToNodePort(),
+			)
+		ct.NewTest("north-south-loadbalancing-with-l7-policy").
+			WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureNodeWithoutCilium)).
+			WithCiliumPolicy(echoIngressL7HTTPFromAnywherePolicyYAML).
 			WithScenarios(
 				tests.OutsideToNodePort(),
 			)


### PR DESCRIPTION
This test case covers https://github.com/cilium/cilium/issues/21954. 

A new policy `echo-ingress-l7-policy-from-anywhere` is added to allow HTTP GET / on echo pods from outside.

Use `cilium connectivity test --test north-south-loadbalancing --datapath` to run this test.

Signed-off-by: Zhichuan Liang <gray.isovalent.com>