### PR TITLE
Allow the Helm timeout to be set on uninstall

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -88,6 +88,8 @@ const (
 	ConnectTimeout = 2 * time.Second
 	RequestTimeout = 10 * time.Second
 
+	UninstallTimeout = 5 * time.Minute
+
 	IngressClassName        = "cilium"
 	IngressService          = "cilium-ingress"
 	IngressControllerName   = "cilium.io/ingress-controller"

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -30,6 +30,7 @@ type UninstallParameters struct {
 	RedactHelmCertKeys   bool
 	HelmChartDirectory   string
 	WorkerCount          int
+	Timeout              time.Duration
 }
 
 type K8sUninstaller struct {
@@ -60,6 +61,7 @@ func (k *K8sUninstaller) UninstallWithHelm(k8sClient genericclioptions.RESTClien
 	}
 	helmClient := action.NewUninstall(&actionConfig)
 	helmClient.Wait = k.params.Wait
+	helmClient.Timeout = k.params.Timeout
 	_, err := helmClient.Run(defaults.HelmReleaseName)
 	return err
 }

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -325,6 +325,8 @@ func newCmdUninstallWithHelm() *cobra.Command {
 	}
 
 	addCommonUninstallFlags(cmd, &params)
+
+	cmd.Flags().DurationVar(&params.Timeout, "timeout", defaults.UninstallTimeout, "Maximum time to wait resources to be deleted")
 	return cmd
 }
 


### PR DESCRIPTION
When running Helm in the CI setup i came against the limit that a cleanup of the tests namespace took longer than the Helm default of 5 minutes. However the timeout option was not exposed in out options thus could not be changed.

This PR exposes the `--timeout` helm option on uninstall when running in Helm mode.