### PR TITLE
helm mode: add additional deprecated secret logic, and fix `clustermesh connect` for helm mode

### DIFF
--- a/clustermesh/certs.go
+++ b/clustermesh/certs.go
@@ -110,16 +110,16 @@ func (k *K8sClusterMesh) createClusterMeshClientCertificate(ctx context.Context)
 	signConf := &config.Signing{
 		Default: &config.SigningProfile{Expiry: 5 * 365 * 24 * time.Hour},
 		Profiles: map[string]*config.SigningProfile{
-			defaults.ClusterMeshClientSecretName: {
+			defaults.ClusterMeshRemoteSecretName: {
 				Expiry: 5 * 365 * 24 * time.Hour,
 				Usage:  []string{"signing", "key encipherment", "server auth", "client auth"},
 			},
 		},
 	}
 
-	cert, key, err := k.certManager.GenerateCertificate(defaults.ClusterMeshClientSecretName, certReq, signConf)
+	cert, key, err := k.certManager.GenerateCertificate(defaults.ClusterMeshRemoteSecretName, certReq, signConf)
 	if err != nil {
-		return fmt.Errorf("unable to generate certificate %s: %w", defaults.ClusterMeshClientSecretName, err)
+		return fmt.Errorf("unable to generate certificate %s: %w", defaults.ClusterMeshRemoteSecretName, err)
 	}
 
 	data := map[string][]byte{
@@ -128,9 +128,9 @@ func (k *K8sClusterMesh) createClusterMeshClientCertificate(ctx context.Context)
 		defaults.CASecretCertName: k.certManager.CACertBytes(),
 	}
 
-	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshClientSecretName, k.params.Namespace, data), metav1.CreateOptions{})
+	_, err = k.client.CreateSecret(ctx, k.params.Namespace, k8s.NewTLSSecret(defaults.ClusterMeshRemoteSecretName, k.params.Namespace, data), metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.ClusterMeshClientSecretName, err)
+		return fmt.Errorf("unable to create secret %s/%s: %w", k.params.Namespace, defaults.ClusterMeshRemoteSecretName, err)
 	}
 
 	return nil
@@ -177,8 +177,9 @@ func (k *K8sClusterMesh) deleteCertificates(ctx context.Context) error {
 	k.Log("🔥 Deleting ClusterMesh certificates...")
 	k.client.DeleteSecret(ctx, k.params.Namespace, defaults.ClusterMeshServerSecretName, metav1.DeleteOptions{})
 	k.client.DeleteSecret(ctx, k.params.Namespace, defaults.ClusterMeshAdminSecretName, metav1.DeleteOptions{})
-	k.client.DeleteSecret(ctx, k.params.Namespace, defaults.ClusterMeshClientSecretName, metav1.DeleteOptions{})
+	k.client.DeleteSecret(ctx, k.params.Namespace, defaults.ClusterMeshRemoteSecretName, metav1.DeleteOptions{})
 	k.client.DeleteSecret(ctx, k.params.Namespace, defaults.ClusterMeshExternalWorkloadSecretName, metav1.DeleteOptions{})
+	k.client.DeleteSecret(ctx, k.params.Namespace, defaults.ClusterMeshClientSecretName, metav1.DeleteOptions{})
 	return nil
 }
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -63,6 +63,7 @@ const (
 	ClusterMeshServerSecretName           = "clustermesh-apiserver-server-cert"
 	ClusterMeshAdminSecretName            = "clustermesh-apiserver-admin-cert"
 	ClusterMeshClientSecretName           = "clustermesh-apiserver-client-cert"
+	ClusterMeshRemoteSecretName           = "clustermesh-apiserver-remote-cert"
 	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-cert"
 
 	ConnectivityCheckNamespace = "cilium-test"


### PR DESCRIPTION
## Motivation

Previously, we had logic to look for deprecated names like `clustermesh-apiserver-client-certs` when `clustermesh-apiserver-client-cert` was expected. With helm-based installations, we now need to look for `clustermesh-apiserver-client-cert` when `clustermesh-apiserver-remote-cert` is expected.

## Implementation

This implements that concpet recursively, looking for the "even more deprecated" name for secrets if applicable.

## Example Runs

Two example runs that exercise the logic:

Using one level of deprecated names to find the secret
```
✅ ClusterMesh enabled!
Trying to get secret clustermesh-apiserver-remote-cert by deprecated name clustermesh-apiserver-client-cert
⚠️ Deprecated secret name "clustermesh-apiserver-client-cert", should be changed to "clustermesh-apiserver-remote-cert"
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
✅ Cluster access information is available:
  - 172.18.0.4:30212
```

Using two levels of deprecated names to find the secret
```
✅ ClusterMesh enabled!
Trying to get secret clustermesh-apiserver-remote-cert by deprecated name clustermesh-apiserver-client-cert
Trying to get secret clustermesh-apiserver-client-cert by deprecated name clustermesh-apiserver-client-certs
⚠️ Deprecated secret name "clustermesh-apiserver-client-certs", should be changed to "clustermesh-apiserver-remote-cert"
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
✅ Cluster access information is available:
  - 172.18.0.4:30652
```