### PR TITLE
sysdump: Fix writing to absolute path

### DIFF
--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -1205,11 +1205,7 @@ func (c *Collector) Run() error {
 
 	// Create the zip file in the current directory.
 	c.log("🗳 Compiling sysdump")
-	p, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current directory: %w", err)
-	}
-	f := filepath.Join(p, c.replaceTimestamp(c.Options.OutputFileName)+".zip")
+	f := c.replaceTimestamp(c.Options.OutputFileName) + ".zip"
 	if err := archiver.Archive([]string{c.sysdumpDir}, f); err != nil {
 		return fmt.Errorf("failed to create zip file: %w", err)
 	}


### PR DESCRIPTION
Writing the sysdump to an absolute path doesn't work because we always append the current directory to the output filename:

    $ ./cilium sysdump --output-filename /tmp/cilium-sysdump
    [...]
    ✅ The sysdump has been saved to /home/paul/cilium-cli/tmp/cilium-sysdump.zip

Let's remove the code that does that.

Fixes: 77a1f2389 ("sysdump: initial sysdump implementation")