### PR TITLE
connectivity: add basic egress gateway test

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Connectivity test
         run: |
-          cilium connectivity test --debug --force-deploy --all-flows --test-namespace another-test-namespace \
+          cilium connectivity test --debug --force-deploy --all-flows --test-namespace test-namespace \
             --external-from-cidrs="${EXTERNAL_NODE_IPS_PARAM}" \
             --collect-sysdump-on-failure
 

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -51,6 +51,7 @@ type ConnectivityTest struct {
 
 	ciliumPods        map[string]Pod
 	echoPods          map[string]Pod
+	echoExternalPods  map[string]Pod
 	clientPods        map[string]Pod
 	perfClientPods    map[string]Pod
 	perfServerPod     map[string]Pod
@@ -179,6 +180,7 @@ func NewConnectivityTest(client *k8s.Client, p Parameters, version string) (*Con
 		version:             version,
 		ciliumPods:          make(map[string]Pod),
 		echoPods:            make(map[string]Pod),
+		echoExternalPods:    make(map[string]Pod),
 		clientPods:          make(map[string]Pod),
 		perfClientPods:      make(map[string]Pod),
 		perfServerPod:       make(map[string]Pod),
@@ -685,6 +687,10 @@ func (ct *ConnectivityTest) EchoPods() map[string]Pod {
 
 func (ct *ConnectivityTest) EchoServices() map[string]Service {
 	return ct.echoServices
+}
+
+func (ct *ConnectivityTest) ExternalEchoPods() map[string]Pod {
+	return ct.echoExternalPods
 }
 
 func (ct *ConnectivityTest) IngressService() map[string]Service {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -218,6 +218,7 @@ func (ct *ConnectivityTest) NewTest(name string) *Test {
 		scenarios: make(map[Scenario][]*Action),
 		cnps:      make(map[string]*ciliumv2.CiliumNetworkPolicy),
 		knps:      make(map[string]*networkingv1.NetworkPolicy),
+		cegps:     make(map[string]*ciliumv2.CiliumEgressGatewayPolicy),
 		verbose:   ct.verbose(),
 		logBuf:    &bytes.Buffer{}, // maintain internal buffer by default
 		warnBuf:   &bytes.Buffer{},

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -629,6 +629,24 @@ func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam IPFamily, opts ...s
 	return cmd
 }
 
+func (ct *ConnectivityTest) CurlClientIPCommand(peer TestPeer, ipFam IPFamily, opts ...string) []string {
+	cmd := []string{"curl", "--silent", "--fail", "--show-error"}
+
+	if connectTimeout := ct.params.ConnectTimeout.Seconds(); connectTimeout > 0.0 {
+		cmd = append(cmd, "--connect-timeout", strconv.FormatFloat(connectTimeout, 'f', -1, 64))
+	}
+	if requestTimeout := ct.params.RequestTimeout.Seconds(); requestTimeout > 0.0 {
+		cmd = append(cmd, "--max-time", strconv.FormatFloat(requestTimeout, 'f', -1, 64))
+	}
+
+	cmd = append(cmd, opts...)
+	cmd = append(cmd, fmt.Sprintf("%s://%s%s/client-ip",
+		peer.Scheme(),
+		net.JoinHostPort(peer.Address(ipFam), fmt.Sprint(peer.Port())),
+		peer.Path()))
+	return cmd
+}
+
 func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam IPFamily) []string {
 	cmd := []string{"ping", "-c", "1"}
 

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -35,13 +35,15 @@ const (
 
 	DNSTestServerContainerName = "dns-test-server"
 
-	echoSameNodeDeploymentName  = "echo-same-node"
-	echoOtherNodeDeploymentName = "echo-other-node"
-	corednsConfigMapName        = "coredns-configmap"
-	corednsConfigVolumeName     = "coredns-config-volume"
-	kindEchoName                = "echo"
-	kindClientName              = "client"
-	kindPerfName                = "perf"
+	echoSameNodeDeploymentName     = "echo-same-node"
+	echoOtherNodeDeploymentName    = "echo-other-node"
+	echoExternalNodeDeploymentName = "echo-external-node"
+	corednsConfigMapName           = "coredns-configmap"
+	corednsConfigVolumeName        = "coredns-config-volume"
+	kindEchoName                   = "echo"
+	kindEchoExternalNodeName       = "echo-external-node"
+	kindClientName                 = "client"
+	kindPerfName                   = "perf"
 
 	hostNetNSDeploymentName = "host-netns"
 	kindHostNetNS           = "host-netns"
@@ -102,6 +104,7 @@ type deploymentParameters struct {
 	ReadinessProbe *corev1.Probe
 	Labels         map[string]string
 	HostNetwork    bool
+	Tolerations    []corev1.Toleration
 }
 
 func newDeployment(p deploymentParameters) *appsv1.Deployment {
@@ -154,6 +157,7 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 					Affinity:           p.Affinity,
 					NodeSelector:       p.NodeSelector,
 					HostNetwork:        p.HostNetwork,
+					Tolerations:        p.Tolerations,
 					ServiceAccountName: p.Name,
 				},
 			},
@@ -817,6 +821,35 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					return fmt.Errorf("unable to create daemonset %s: %w", hostNetNSDeploymentName, err)
 				}
 			}
+
+			_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, echoExternalNodeDeploymentName, metav1.GetOptions{})
+			if err != nil {
+				ct.Logf("✨ [%s] Deploying echo-external-node deployment...", ct.clients.src.ClusterName())
+				containerPort := 8080
+				echoExternalDeployment := newDeployment(deploymentParameters{
+					Name:           echoExternalNodeDeploymentName,
+					Kind:           kindEchoExternalNodeName,
+					Port:           containerPort,
+					NamedPort:      "http-8080",
+					HostPort:       8080,
+					Image:          ct.params.JSONMockImage,
+					Labels:         map[string]string{"external": "echo"},
+					NodeSelector:   map[string]string{"cilium.io/no-schedule": "true"},
+					ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
+					HostNetwork:    true,
+					Tolerations: []corev1.Toleration{
+						{Operator: corev1.TolerationOpExists},
+					},
+				})
+				_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(echoExternalNodeDeploymentName), metav1.CreateOptions{})
+				if err != nil {
+					return fmt.Errorf("unable to create service account %s: %s", echoExternalNodeDeploymentName, err)
+				}
+				_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoExternalDeployment, metav1.CreateOptions{})
+				if err != nil {
+					return fmt.Errorf("unable to create deployment %s: %s", echoExternalNodeDeploymentName, err)
+				}
+			}
 		}
 	}
 
@@ -871,6 +904,10 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 
 	if (ct.params.MultiCluster != "" || !ct.params.SingleNode) && !ct.params.Perf {
 		dstList = append(dstList, echoOtherNodeDeploymentName)
+	}
+
+	if ct.features[FeatureNodeWithoutCilium].Enabled {
+		dstList = append(dstList, echoExternalNodeDeploymentName)
 	}
 
 	return srcList, dstList
@@ -1015,6 +1052,22 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			err := ct.waitForPodDNS(otherNodeDNSCtx, cp, otherNodePod)
 			if err != nil {
 				return err
+			}
+		}
+	}
+
+	if ct.features[FeatureNodeWithoutCilium].Enabled {
+		echoExternalNodePods, err := ct.clients.dst.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + echoExternalNodeDeploymentName})
+		if err != nil {
+			return fmt.Errorf("unable to list other node pods: %w", err)
+		}
+
+		for _, pod := range echoExternalNodePods.Items {
+			ct.echoExternalPods[pod.Name] = Pod{
+				K8sClient: ct.client,
+				Pod:       pod.DeepCopy(),
+				scheme:    "http",
+				port:      8080, // listen port of the echo server inside the container
 			}
 		}
 	}

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -64,6 +64,8 @@ const (
 	FeatureAuthMTLSSpiffe Feature = "auth-mtls-spiffe"
 
 	FeatureIngressController Feature = "ingress-controller"
+
+	FeatureEgressGateway Feature = "enable-ipv4-egress-gateway"
 )
 
 // FeatureStatus describes the status of a feature. Some features are either
@@ -210,6 +212,10 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 
 	result[FeatureIngressController] = FeatureStatus{
 		Enabled: cm.Data["enable-ingress-controller"] == "true",
+	}
+
+	result[FeatureEgressGateway] = FeatureStatus{
+		Enabled: cm.Data["enable-ipv4-egress-gateway"] == "true",
 	}
 
 	return nil

--- a/connectivity/manifests/egress-gateway-policy.yaml
+++ b/connectivity/manifests/egress-gateway-policy.yaml
@@ -13,4 +13,4 @@ spec:
   egressGateway:
     nodeSelector:
       matchLabels:
-        kubernetes.io/hostname: kind-worker2
+        kubernetes.io/hostname: NODE_NAME_PLACEHOLDER

--- a/connectivity/manifests/egress-gateway-policy.yaml
+++ b/connectivity/manifests/egress-gateway-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  name: cegp-sample
+spec:
+  selectors:
+  - podSelector:
+      matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: client
+  destinationCIDRs:
+  - 0.0.0.0/0
+  egressGateway:
+    nodeSelector:
+      matchLabels:
+        kubernetes.io/hostname: kind-worker2

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -145,6 +145,9 @@ var (
 
 	//go:embed manifests/echo-ingress-mtls.yaml
 	echoIngressMTLSPolicyYAML string
+
+	//go:embed manifests/egress-gateway-policy.yaml
+	egressGatewayPolicyYAML string
 )
 
 var (
@@ -205,6 +208,14 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 				check.RequireFeatureEnabled(check.FeatureEncryptionNode)).
 			WithScenarios(
 				tests.NodeToNodeEncryption(),
+			)
+
+		ct.NewTest("egress-gateway").
+			WithCiliumEgressGatewayPolicy(egressGatewayPolicyYAML).
+			WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureEgressGateway),
+				check.RequireFeatureEnabled(check.FeatureNodeWithoutCilium)).
+			WithScenarios(
+				tests.EgressGateway(),
 			)
 
 		return ct.Run(ctx)

--- a/connectivity/tests/egressgateway.go
+++ b/connectivity/tests/egressgateway.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/internal/utils"
+)
+
+const (
+	gatewayNodeName = "kind-worker2"
+)
+
+// EgressGateway is a test case which, given the cegp-sample
+// CiliumEgressGatewayPolicy targeting:
+// - a couple of client pods (kind=client) as source
+// - the 0.0.0.0/0 destination CIDR
+// - kind-worker2 as gateway node
+//
+// ensures that traffic from both clients reaches the echo-external service with
+// the egress IP of the gateway node.
+func EgressGateway() check.Scenario {
+	return &egressGateway{}
+}
+
+type egressGateway struct{}
+
+func (s *egressGateway) Name() string {
+	return "egress-gateway"
+}
+
+func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	egressIP := getGatewayNodeInternalIP(ct)
+
+	waitForBpfPolicyEntries(ctx, t)
+
+	i := 0
+	for _, client := range ct.ClientPods() {
+		client := client
+
+		for _, externalEcho := range ct.ExternalEchoPods() {
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, externalEcho, check.IPFamilyV4).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlClientIPCommand(externalEcho, check.IPFamilyV4))
+				clientIP := extractClientIPFromResponse(a.CmdOutput())
+
+				if !clientIP.Equal(egressIP) {
+					t.Fatal("Request reached external echo service with wrong source IP")
+				}
+			})
+			i++
+		}
+	}
+}
+
+// getGatewayNodeInternalIP returns the k8s internal IP of the node acting as
+// gateway for this test
+func getGatewayNodeInternalIP(ct *check.ConnectivityTest) net.IP {
+	gatewayNode, ok := ct.Nodes()[gatewayNodeName]
+	if !ok {
+		return nil
+	}
+
+	for _, addr := range gatewayNode.Status.Addresses {
+		if addr.Type != "InternalIP" {
+			continue
+		}
+
+		ip := net.ParseIP(addr.Address)
+		if ip == nil || ip.To4() == nil {
+			continue
+		}
+
+		return ip
+	}
+
+	return nil
+}
+
+// bpfEgressGatewayPolicyEntry represents an entry in the BPF egress gateway
+// policy map
+type bpfEgressGatewayPolicyEntry struct {
+	SourceIP  string
+	DestCIDR  string
+	EgressIP  string
+	GatewayIP string
+}
+
+// matches is an helper used to compare the receiver bpfEgressGatewayPolicyEntry
+// with another entry
+func (e *bpfEgressGatewayPolicyEntry) matches(t bpfEgressGatewayPolicyEntry) bool {
+	return t.SourceIP == e.SourceIP &&
+		t.DestCIDR == e.DestCIDR &&
+		t.EgressIP == e.EgressIP &&
+		t.GatewayIP == e.GatewayIP
+}
+
+// waitForBpfPolicyEntries waits for the egress gateway policy maps on each node
+// to be populated with the entries for the cegp-sample CiliumEgressGatewayPolicy
+func waitForBpfPolicyEntries(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+
+	w := utils.NewWaitObserver(ctx, utils.WaitParameters{Timeout: 10 * time.Second})
+	defer w.Cancel()
+
+	ensureBpfPolicyEntries := func() error {
+		gatewayNodeInternalIP := getGatewayNodeInternalIP(ct)
+		if gatewayNodeInternalIP == nil {
+			t.Fatalf("Cannot retrieve internal IP of gateway node")
+		}
+
+		for _, ciliumPod := range ct.CiliumPods() {
+			egressIP := "0.0.0.0"
+			if ciliumPod.Pod.Spec.NodeName == gatewayNodeName {
+				egressIP = gatewayNodeInternalIP.String()
+			}
+
+			targetEntries := []bpfEgressGatewayPolicyEntry{}
+			for _, client := range ct.ClientPods() {
+				targetEntries = append(targetEntries,
+					bpfEgressGatewayPolicyEntry{
+						SourceIP:  client.Pod.Status.PodIP,
+						DestCIDR:  "0.0.0.0/0",
+						EgressIP:  egressIP,
+						GatewayIP: gatewayNodeInternalIP.String(),
+					})
+			}
+
+			cmd := strings.Split("cilium bpf egress list -o json", " ")
+			stdout, err := ciliumPod.K8sClient.ExecInPod(ctx, ciliumPod.Pod.Namespace, ciliumPod.Pod.Name, defaults.AgentContainerName, cmd)
+			if err != nil {
+				t.Fatal("failed to run cilium bpf egress list command: %w", err)
+			}
+
+			entries := []bpfEgressGatewayPolicyEntry{}
+			json.Unmarshal(stdout.Bytes(), &entries)
+
+		nextTargetEntry:
+			for _, targetEntry := range targetEntries {
+				for _, entry := range entries {
+					if targetEntry.matches(entry) {
+						continue nextTargetEntry
+					}
+				}
+
+				return fmt.Errorf("Could not find egress gateway policy entry matching %+v", targetEntry)
+			}
+		}
+
+		return nil
+	}
+
+	for {
+		if err := ensureBpfPolicyEntries(); err != nil {
+			if err := w.Retry(err); err != nil {
+				t.Fatal("Failed to ensure egress gateway policy map is properly populated:", err)
+			}
+
+			continue
+		}
+
+		return
+	}
+}
+
+// extractClientIPFromResponse extracts the client IP from the response of the
+// echo-external service
+func extractClientIPFromResponse(res string) net.IP {
+	var clientIP struct {
+		ClientIP string `json:"client-ip"`
+	}
+
+	json.Unmarshal([]byte(res), &clientIP)
+
+	return net.ParseIP(clientIP.ClientIP).To4()
+}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -713,6 +713,26 @@ func (c *Client) DeleteCiliumNetworkPolicy(ctx context.Context, namespace, name 
 	return c.CiliumClientset.CiliumV2().CiliumNetworkPolicies(namespace).Delete(ctx, name, opts)
 }
 
+func (c *Client) ListCiliumEgressGatewayPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumEgressGatewayPolicyList, error) {
+	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().List(ctx, opts)
+}
+
+func (c *Client) GetCiliumEgressGatewayPolicy(ctx context.Context, name string, opts metav1.GetOptions) (*ciliumv2.CiliumEgressGatewayPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().Get(ctx, name, opts)
+}
+
+func (c *Client) CreateCiliumEgressGatewayPolicy(ctx context.Context, cegp *ciliumv2.CiliumEgressGatewayPolicy, opts metav1.CreateOptions) (*ciliumv2.CiliumEgressGatewayPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().Create(ctx, cegp, opts)
+}
+
+func (c *Client) UpdateCiliumEgressGatewayPolicy(ctx context.Context, cegp *ciliumv2.CiliumEgressGatewayPolicy, opts metav1.UpdateOptions) (*ciliumv2.CiliumEgressGatewayPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().Update(ctx, cegp, opts)
+}
+
+func (c *Client) DeleteCiliumEgressGatewayPolicy(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().Delete(ctx, name, opts)
+}
+
 func (c *Client) ListCiliumBGPPeeringPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumBGPPeeringPolicyList, error) {
 	return c.CiliumClientset.CiliumV2alpha1().CiliumBGPPeeringPolicies().List(ctx, opts)
 }
@@ -921,10 +941,6 @@ func (c *Client) GetRunningCiliumVersion(ctx context.Context, namespace string) 
 		return "", errors.New("unable to obtain cilium version: no cilium container found")
 	}
 	return "", errors.New("unable to obtain cilium version: no cilium pods found")
-}
-
-func (c *Client) ListCiliumEgressGatewayPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumEgressGatewayPolicyList, error) {
-	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().List(ctx, opts)
 }
 
 func (c *Client) ListCiliumLoadBalancerIPPools(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumLoadBalancerIPPoolList, error) {


### PR DESCRIPTION
This PR adds a first basic egress gateway test.
Given the cegp-sample CiliumEgressGatewayPolicy targeting:
  - a couple of client pods (kind=client) as source
  - the 0.0.0.0/0 destination CIDR
  - kind-worker2 as gateway node

the test simply ensures that traffic from both clients reaches the echo-external service with the egress IP of the gateway node