### PR TITLE
gha: Bump k8s version using in kind

### DIFF
--- a/.github/kind-config-1.yaml
+++ b/.github/kind-config-1.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.27.1
 networking:
   disableDefaultCNI: true
   podSubnet: "10.201.0.0/16"

--- a/.github/kind-config-2.yaml
+++ b/.github/kind-config-2.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.27.1
 networking:
   disableDefaultCNI: true
   podSubnet: "10.202.0.0/16"

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.27.1
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,9 +12,9 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.27.1
   - role: worker
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.27.1
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  KIND_VERSION: v0.14.0
+  KIND_VERSION: v0.18.0
   KIND_CONFIG: .github/kind-config.yaml
   TIMEOUT: 2m
   LOG_TIME: 30m


### PR DESCRIPTION
k8s 1.19 was declared as EOL a while ago, there is no point running test with this version. Also, kind version is bumped while we are here.