### PR TITLE
helm mode: Make Helm chart repository configurable

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -102,6 +102,9 @@ const (
 	HelmChartVersionSecretKeyName = "io.cilium.chart-version"
 
 	CiliumNoScheduleLabel = "cilium.io/no-schedule"
+
+	// HelmRepository specifies Helm repository to download Cilium charts from.
+	HelmRepository = "https://helm.cilium.io"
 )
 
 var (

--- a/install/install.go
+++ b/install/install.go
@@ -400,6 +400,9 @@ type Parameters struct {
 	// DryRunHelmValues writes non-default Helm values to stdout without performing the actual installation.
 	// For Helm installation mode only.
 	DryRunHelmValues bool
+
+	// HelmRepository specifies the Helm repository to download Cilium Helm charts from.
+	HelmRepository string
 }
 
 type rollbackStep func(context.Context)
@@ -453,7 +456,7 @@ func NewK8sInstaller(client k8sInstallerImplementation, p Parameters) (*K8sInsta
 	}
 
 	cm := certs.NewCertManager(client, certs.Parameters{Namespace: p.Namespace})
-	chartVersion, helmChart, err := helm.ResolveHelmChartVersion(p.Version, p.HelmChartDirectory)
+	chartVersion, helmChart, err := helm.ResolveHelmChartVersion(p.Version, p.HelmChartDirectory, p.HelmRepository)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -291,6 +291,7 @@ cilium install --context kind-cluster1 --helm-set cluster.id=1 --helm-set cluste
 	addCommonHelmFlags(cmd, &params)
 	cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "Write resources to be installed to stdout without actually installing them")
 	cmd.Flags().BoolVar(&params.DryRunHelmValues, "dry-run-helm-values", false, "Write non-default Helm values to stdout without performing the actual installation")
+	cmd.Flags().StringVar(&params.HelmRepository, "repository", defaults.HelmRepository, "Helm chart repository to download Cilium charts from")
 	return cmd
 }
 
@@ -374,5 +375,6 @@ cilium upgrade --helm-set cluster.id=1 --helm-set cluster.name=cluster1
 		"Write resources to be installed to stdout without actually installing them")
 	cmd.Flags().BoolVar(&params.DryRunHelmValues, "dry-run-helm-values", false,
 		"Write non-default Helm values to stdout; without performing the actual upgrade")
+	cmd.Flags().StringVar(&params.HelmRepository, "repository", defaults.HelmRepository, "Helm chart repository to download Cilium charts from")
 	return cmd
 }

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cilium/cilium-cli/defaults"
+
 	"github.com/blang/semver/v4"
 )
 
@@ -51,7 +53,7 @@ func TestResolveHelmChartVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := ResolveHelmChartVersion(tt.args.versionFlag, tt.args.chartDirectoryFlag)
+			got, _, err := ResolveHelmChartVersion(tt.args.versionFlag, tt.args.chartDirectoryFlag, defaults.HelmRepository)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ResolveHelmChartVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Add --repository flag in helm mode install / upgrade commands to override
the default https://helm.cilium.io repository.

I intentionally avoided adding this flag to the classic mode since it's
being deprecated in the next minor release (v0.15). The behavior of the
classic mode is unchanged in this pull request.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>