### PR TITLE
Replace versioncheck.Version with semver.ParseTolerant

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/defaults"
 )
@@ -26,8 +25,7 @@ func CheckVersion(version string) error {
 }
 
 func ParseCiliumVersion(version string) (semver.Version, error) {
-	ersion := strings.TrimPrefix(version, "v")
-	return versioncheck.Version(ersion)
+	return semver.ParseTolerant(version)
 }
 
 type ImagePathMode int

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -76,6 +76,19 @@ func TestParseCiliumVersion(t *testing.T) {
 			version: "v1.9.99",
 			want:    semver.Version{Major: 1, Minor: 9, Patch: 99},
 		},
+		{
+			name:    "valid-pre-release-version",
+			version: "1.13.90-dev.1234-main-5678abcd",
+			want: semver.Version{
+				Major: 1,
+				Minor: 13,
+				Patch: 90,
+				Pre: []semver.PRVersion{
+					{VersionStr: "dev", IsNum: false},
+					{VersionStr: "1234-main-5678abcd", IsNum: false},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
ParseCiliumVersion uses versioncheck.Version from Cilium's versioncheck
package ([1]), which ignores certain pre-release identifiers. Silently
ignoring certain pre-release identifiers can be confusing since you
might end up installing a different version of Cilium than what you
specified.

This commit replaces versioncheck.Version with semver.ParseTolerant ([2])
in ParseCiliumVersion function so that cilium-cli interprets the version
provided via the --version flag as is.

[1]: https://pkg.go.dev/github.com/cilium/cilium/pkg/versioncheck#Version
[2]: https://pkg.go.dev/github.com/blang/semver#ParseTolerant

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>