### PR TITLE
connectivity: enable IPv6 test for per-endpoint routing

### DIFF
--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -725,16 +725,6 @@ func (t *Test) collectSysdump() {
 
 func (t *Test) ForEachIPFamily(do func(IPFamily)) {
 	ipFams := []IPFamily{IPFamilyV4, IPFamilyV6}
-
-	// TODO(brb):
-	// The per-endpoint routes feature is broken with IPv6 when there are any
-	// netpols installed (tracked in https://github.com/cilium/cilium/issues/23852
-	// and https://github.com/cilium/cilium/issues/23910). Once both issues
-	// are resolved, we can start testing IPv6 with netpols.
-	if f, ok := t.Context().Feature(FeatureEndpointRoutes); ok && f.Enabled && (len(t.cnps) > 0 || len(t.knps) > 0) {
-		ipFams = []IPFamily{IPFamilyV4}
-	}
-
 	for _, ipFam := range ipFams {
 		switch ipFam {
 		case IPFamilyV4:


### PR DESCRIPTION
As https://github.com/cilium/cilium/issues/23852 and https://github.com/cilium/cilium/issues/23910 has been resolved, we can enable IPv6 test for per-endpoint routing.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>