### PR TITLE
Add GatewayAPI resources to sysdump

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -798,6 +798,10 @@ func (c *Client) ListEndpoints(ctx context.Context, o metav1.ListOptions) (*core
 	return c.Clientset.CoreV1().Endpoints(corev1.NamespaceAll).List(ctx, o)
 }
 
+func (c *Client) ListIngressClasses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressClassList, error) {
+	return c.Clientset.NetworkingV1().IngressClasses().List(ctx, o)
+}
+
 func (c *Client) ListIngresses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressList, error) {
 	return c.Clientset.NetworkingV1().Ingresses(corev1.NamespaceAll).List(ctx, o)
 }

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -58,6 +58,7 @@ type KubernetesClient interface {
 	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
 	ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error)
 	ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error)
+	ListIngressClasses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressClassList, error)
 	ListIngresses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressList, error)
 	ListNamespaces(ctx context.Context, o metav1.ListOptions) (*corev1.NamespaceList, error)
 	ListNetworkPolicies(ctx context.Context, o metav1.ListOptions) (*networkingv1.NetworkPolicyList, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -78,6 +78,15 @@ const (
 	kubernetesVersionInfoFileName            = "k8s-version-<ts>.txt"
 	securityGroupPoliciesFileName            = "aws-securitygrouppolicies-<ts>.yaml"
 	timestampPlaceholderFileName             = "<ts>"
+	gatewayClassesFileName                   = "gatewayapi-gatewayclasses-<ts>.yaml"
+	gatewaysFileName                         = "gatewayapi-gateways-<ts>.yaml"
+	httpRoutesFileName                       = "gatewayapi-httproutes-<ts>.yaml"
+	tlsRoutesFileName                        = "gatewayapi-tlsroutes-<ts>.yaml"
+	grpcRoutesFileName                       = "gatewayapi-grpcroutes-<ts>.yaml"
+	tcpRoutesFileName                        = "gatewayapi-tcroutes-<ts>.yaml"
+	udpRoutesFileName                        = "gatewayapi-udproutes-<ts>.yaml"
+	referenceGrantsFileName                  = "gatewayapi-referencegrants-<ts>.yaml"
+	ingressClassesFileName                   = "ingressclasses-<ts>.yaml"
 )
 
 const (
@@ -118,6 +127,55 @@ var (
 	gopsProfiling = []string{
 		"pprof-heap",
 		"pprof-cpu",
+	}
+
+	// Gateway API resource group versions used for sysdumping these
+	gatewayClass = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "gatewayclasses",
+		Version:  "v1beta1",
+	}
+
+	gateway = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "gateways",
+		Version:  "v1beta1",
+	}
+
+	referenceGrant = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "referencegrants",
+		Version:  "v1alpha2",
+	}
+
+	httpRoute = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "httproutes",
+		Version:  "v1beta1",
+	}
+
+	tlsRoute = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "tlsroutes",
+		Version:  "v1alpha2",
+	}
+
+	tcpRoute = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "tcproutes",
+		Version:  "v1alpha2",
+	}
+
+	udpRoute = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "udproutes",
+		Version:  "v1alpha2",
+	}
+
+	grpcRoute = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "grpcroutes",
+		Version:  "v1alpha2",
 	}
 )
 

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -569,6 +569,20 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting IngressClasses",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.ListIngressClasses(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect IngressClasses: %w", err)
+				}
+				if err := c.WriteYAML(ingressClassesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect IngressClasses: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting CiliumClusterwideEnvoyConfigs",
 			Quick:       true,
 			Task: func(ctx context.Context) error {
@@ -1091,6 +1105,126 @@ func (c *Collector) Run() error {
 				}
 				if err := c.WriteYAML(ciliumExternalWorkloadFileName, v); err != nil {
 					return fmt.Errorf("failed to collect Cilium external workloads: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting GatewayClass entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, gatewayClass, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect GatewayClass entries: %w", err)
+				}
+				if err := c.WriteYAML(gatewayClassesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect GatewayClass entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting Gateway entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, gateway, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect Gateway entries: %w", err)
+				}
+				if err := c.WriteYAML(gatewaysFileName, v); err != nil {
+					return fmt.Errorf("failed to collect Gateway entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting ReferenceGrant entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, referenceGrant, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect ReferenceGrant entries: %w", err)
+				}
+				if err := c.WriteYAML(referenceGrantsFileName, v); err != nil {
+					return fmt.Errorf("failed to collect ReferenceGrant entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting HTTPRoute entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, httpRoute, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect HTTPRoute entries: %w", err)
+				}
+				if err := c.WriteYAML(httpRoutesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect HTTPRoute entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting TLSRoute entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, tlsRoute, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect TLSRoute entries: %w", err)
+				}
+				if err := c.WriteYAML(tlsRoutesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect TLSRoute entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting GRPCRoute entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, grpcRoute, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect GRPCRoute entries: %w", err)
+				}
+				if err := c.WriteYAML(grpcRoutesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect GRPCRoute entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting TCPRoute entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, tcpRoute, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect TCPRoute entries: %w", err)
+				}
+				if err := c.WriteYAML(tcpRoutesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect TCPRoute entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting UDPRoute entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, udpRoute, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect UDPRoute entries: %w", err)
+				}
+				if err := c.WriteYAML(udpRoutesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect UDPRoute entries: %w", err)
 				}
 				return nil
 			},

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -468,6 +468,10 @@ func (c *fakeClient) ListUnstructured(_ context.Context, _ schema.GroupVersionRe
 	panic("implement me")
 }
 
+func (c *fakeClient) ListIngressClasses(_ context.Context, _ metav1.ListOptions) (*networkingv1.IngressClassList, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) ListTetragonTracingPolicies(_ context.Context, _ metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyList, error) {
 	tetragonTracingPolicy := tetragonv1alpha1.TracingPolicyList{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
This adds all GatewayAPI objects to the sysdump as well as the IngressClass object. This will be helpful for troubleshooting GatewayAPI related issues.
The objects are dumped into YAML if available prefixed with gatewayapi- for ease of use.

Fixes https://github.com/cilium/cilium-cli/issues/1567