### PR TITLE
connectivity: report peer name in "no flows recorded" log message

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -334,7 +334,7 @@ func (a *Action) expectedExitCode() ExitCode {
 
 func (a *Action) printFlows(peer TestPeer) {
 	if len(a.flows) == 0 {
-		a.Logf("📄 No flows recorded during action %s", a.name)
+		a.Logf("📄 No flows recorded for peer %s during action %s", peer.Name(), a.name)
 		return
 	}
 


### PR DESCRIPTION
Before:

      📄 No flows recorded during action external-1111-0
      📄 No flows recorded during action external-1111-0

After:

      📄 No flows recorded for peer cilium-test/client-7b78db77d5-6x9vj during action external-1111-0
      📄 No flows recorded for peer external-1111 during action external-1111-0