### PR TITLE
Add Prometheus metrics validation

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -126,7 +126,7 @@ jobs:
           fi
           echo "EXTERNAL_NODE_IPS_PARAM=${EXTERNAL_NODE_IPS_PARAM}" >> $GITHUB_ENV
 
-      # Install Cilium with HostPort support for extended connectivity test.
+      # Install Cilium with HostPort support and enables Prometheus for extended connectivity test.
       - name: Install Cilium
         run: |
           cilium install \
@@ -136,7 +136,8 @@ jobs:
             --helm-set bpf.monitorAggregation=none \
             --helm-set cni.chainingMode=portmap \
             --helm-set loadBalancer.l7.backend=envoy \
-            --helm-set tls.secretsBackend=k8s
+            --helm-set tls.secretsBackend=k8s \
+            --helm-set prometheus.enabled=true
 
       - name: Enable Relay
         run: |

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -361,3 +361,21 @@ func (a *Action) Fatalf(format string, s ...interface{}) {
 func timestamp() string {
 	return fmt.Sprintf("[%s] ", time.Now().Format(time.RFC3339))
 }
+
+type debugWriter struct {
+	ct *ConnectivityTest
+}
+
+func (d *debugWriter) Write(b []byte) (int, error) {
+	d.ct.Debug(string(b))
+	return len(b), nil
+}
+
+type warnWriter struct {
+	ct *ConnectivityTest
+}
+
+func (w *warnWriter) Write(b []byte) (int, error) {
+	w.ct.Warn(string(b))
+	return len(b), nil
+}

--- a/connectivity/check/metrics.go
+++ b/connectivity/check/metrics.go
@@ -47,6 +47,21 @@ func (a *Action) collectPrometheusMetrics(source MetricsSource) (promMetricsPerN
 	return m, nil
 }
 
+// collectPrometheusMetricsForNode retrieves all the metrics for a source on a particular node.
+func (a *Action) collectPrometheusMetricsForNode(source MetricsSource, node string) (promMetricsFamily, error) {
+	for _, pod := range source.Pods {
+		if pod.NodeName() == node {
+			metrics, err := a.collectMetricsForPod(pod, source.Port)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve prometheus metrics for pod %s on node %s: %w", pod.Name(), pod.NodeName(), err)
+			}
+			return metrics, nil
+		}
+	}
+
+	return promMetricsFamily{}, nil
+}
+
 // collectMetricsForPod retrieves the metrics for one pod.
 func (a *Action) collectMetricsForPod(pod Pod, port string) (promMetricsFamily, error) {
 	// The context is in charge if closing the port-forward when it is cancelled.

--- a/connectivity/check/metrics.go
+++ b/connectivity/check/metrics.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+
+	"github.com/cilium/cilium-cli/k8s"
+)
+
+// metricsURLFormat is the path format to retrieve the metrics on the
+const metricsURLFormat = "http://localhost:%d/metrics"
+
+// promMetricsPerSource holds all the metrics per source name per node.
+// sources e.g.: cilium agent, cilium operator, hubble
+type promMetricsPerSource map[string]promMetricsPerNode
+
+// promMetricsPerNode stores for each node Prometheus Metrics.
+type promMetricsPerNode map[string]promMetricsFamily
+
+// promMetricsFamily holds Prometheus metrics per metric name.
+type promMetricsFamily map[string]*dto.MetricFamily
+
+// collectPrometheusMetrics retrieves the Prometheus metrics by
+// port-forwarding the Prometheus port of each source pod and calling /metrics endpoint.
+func (a *Action) collectPrometheusMetrics(source MetricsSource) (promMetricsPerNode, error) {
+	m := make(promMetricsPerNode)
+
+	// Retrieve metrics for all Cilium pods.
+	for _, pod := range source.Pods {
+		metrics, err := a.collectMetricsForPod(pod, source.Port)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve prometheus metrics for pod %s: %w", pod.Name(), err)
+		}
+
+		// Store metrics per node for the ease of use when validating.
+		m[pod.NodeName()] = metrics
+	}
+
+	return m, nil
+}
+
+// collectMetricsForPod retrieves the metrics for one pod.
+func (a *Action) collectMetricsForPod(pod Pod, port string) (promMetricsFamily, error) {
+	// The context is in charge if closing the port-forward when it is cancelled.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := k8s.PortForwardParameters{
+		Namespace:  pod.Namespace(),
+		Pod:        pod.NameWithoutNamespace(),
+		Ports:      []string{fmt.Sprintf(":%s", port)},
+		Addresses:  nil, // default is localhost
+		OutWriters: k8s.OutWriters{Out: &debugWriter{ct: a.test.ctx}, ErrOut: &warnWriter{ct: a.test.ctx}},
+	}
+
+	// Call the k8s dialer to port forward,
+	// a random port will be generated to avoid conflict.
+	res, err := pod.K8sClient.PortForward(ctx, p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to port forward: %w", err)
+	}
+
+	// Call the metrics path on the retrieved local port.
+	url := fmt.Sprintf(metricsURLFormat, res.ForwardedPorts[0].Local)
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve metrics: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Convert the text output into handy format metrics.
+	metrics, err := parseMetrics(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse metrics: %w", err)
+	}
+
+	return metrics, nil
+}
+
+// parseMetrics transforms the response from the call to prometheus metric endpoint
+// into a dto model MetricFamily.
+func parseMetrics(reader io.Reader) (promMetricsFamily, error) {
+	var parser expfmt.TextParser
+	mf, err := parser.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, err
+	}
+	return mf, nil
+}

--- a/connectivity/check/metrics.go
+++ b/connectivity/check/metrics.go
@@ -110,3 +110,30 @@ func parseMetrics(reader io.Reader) (promMetricsFamily, error) {
 	}
 	return mf, nil
 }
+
+// metricsIncrease verifies for all the metrics that the values increased.
+func metricsIncrease(mf1, mf2 dto.MetricFamily) error {
+	metrics1 := mf1.GetMetric()
+	metrics2 := mf2.GetMetric()
+
+	if len(metrics1) != len(metrics2) {
+		return fmt.Errorf("metric %s has different length metrics 1: %d and metrics 2: %d", mf1.GetName(), len(metrics1), len(metrics2))
+	}
+
+	for i := range metrics1 {
+		if metrics1[i].GetCounter() == nil {
+			return fmt.Errorf("metric %s is not a Counter: %v", mf1.GetName(), metrics1[i])
+		}
+		if metrics2[i].GetCounter() == nil {
+			return fmt.Errorf("metric %s is not a Counter: %v", mf1.GetName(), metrics2[i])
+		}
+
+		value1 := metrics1[i].GetCounter().GetValue() // Here we assume that metrics are of Counter type.
+		value2 := metrics2[i].GetCounter().GetValue()
+		if value1 >= value2 {
+			return fmt.Errorf("metric %s did not increase as expected, value 1: %f and value 2: %f", mf1.GetName(), value1, value2)
+		}
+	}
+
+	return nil
+}

--- a/connectivity/check/metrics_test.go
+++ b/connectivity/check/metrics_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"strings"
+	"testing"
+
+	prommodel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePromMetrics(t *testing.T) {
+	input := `
+# HELP cilium_forward_count_total Total forwarded packets, tagged by ingress/egress direction
+# TYPE cilium_forward_count_total counter
+cilium_forward_count_total{direction="EGRESS"} 444088
+cilium_forward_count_total{direction="INGRESS"} 812973
+`
+
+	metricName := "cilium_forward_count_total"
+	metricHelp := "Total forwarded packets, tagged by ingress/egress direction"
+	metricTypeCounter := prommodel.MetricType_COUNTER
+	labelName := "direction"
+	labelEgress := "EGRESS"
+	labelIngress := "INGRESS"
+	valueEgress := float64(444088)
+	valueIngress := float64(812973)
+
+	want := promMetricsFamily{
+		metricName: {
+			Name: &metricName,
+			Help: &metricHelp,
+			Type: &metricTypeCounter,
+			Metric: []*prommodel.Metric{
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelEgress}},
+					Counter: &prommodel.Counter{Value: &valueEgress},
+				},
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelIngress}},
+					Counter: &prommodel.Counter{Value: &valueIngress},
+				},
+			},
+		},
+	}
+
+	reader := strings.NewReader(input)
+	got, err := parseMetrics(reader)
+	assert.NoError(t, err)
+	assert.Exactly(t, want, got)
+}

--- a/connectivity/check/metrics_test.go
+++ b/connectivity/check/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	dto "github.com/prometheus/client_model/go"
 	prommodel "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 )
@@ -50,4 +51,83 @@ cilium_forward_count_total{direction="INGRESS"} 812973
 	got, err := parseMetrics(reader)
 	assert.NoError(t, err)
 	assert.Exactly(t, want, got)
+}
+
+func TestMetricsIncrease(t *testing.T) {
+	metricName := "cilium_forward_count_total"
+	metricHelp := "Total forwarded packets, tagged by ingress/egress direction"
+	metricTypeCounter := prommodel.MetricType_COUNTER
+	labelName := "direction"
+	labelEgress := "EGRESS"
+	labelIngress := "INGRESS"
+	valueEgress := 444088.
+	valueIngress := 812973.
+
+	valueEgressAfter := 1599128.
+	valueIngressAfter := 3789798.
+
+	ciliumForwardCountTotalBefore := dto.MetricFamily{
+		Name: &metricName,
+		Help: &metricHelp,
+		Type: &metricTypeCounter,
+		Metric: []*prommodel.Metric{
+			{
+				Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelEgress}},
+				Counter: &prommodel.Counter{Value: &valueEgress},
+			},
+			{
+				Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelIngress}},
+				Counter: &prommodel.Counter{Value: &valueIngress},
+			},
+		},
+	}
+
+	ciliumForwardCountTotalAfter := dto.MetricFamily{
+		Name: &metricName,
+		Help: &metricHelp,
+		Type: &metricTypeCounter,
+		Metric: []*prommodel.Metric{
+			{
+				Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelEgress}},
+				Counter: &prommodel.Counter{Value: &valueEgressAfter},
+			},
+			{
+				Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelIngress}},
+				Counter: &prommodel.Counter{Value: &valueIngressAfter},
+			},
+		},
+	}
+
+	tt := map[string]struct {
+		before dto.MetricFamily
+		after  dto.MetricFamily
+		err    bool
+	}{
+		"metric increases": {
+			before: ciliumForwardCountTotalBefore,
+			after:  ciliumForwardCountTotalAfter,
+			err:    false,
+		},
+		"metrics are equals": {
+			before: ciliumForwardCountTotalBefore,
+			after:  ciliumForwardCountTotalBefore,
+			err:    true,
+		},
+		"metric decreases": {
+			before: ciliumForwardCountTotalAfter,
+			after:  ciliumForwardCountTotalBefore,
+			err:    true,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			err := metricsIncrease(tc.before, tc.after)
+			if tc.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/connectivity/check/metricssource.go
+++ b/connectivity/check/metricssource.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/components"
+)
+
+const prometheusContainerPortName = "prometheus"
+
+// MetricsSource defines the info for a source to be used in metrics collection.
+type MetricsSource struct {
+	Name string // the name of the source, e.g.: cilium-agent
+	Pods []Pod  // the list of pods for the given source
+	Port string // the container port value for prometheus
+}
+
+// IsEmpty returns if the metrics source name is empty,
+// assuming it MetricsSource is set to its zero value.
+func (m MetricsSource) IsEmpty() bool {
+	return m.Name == ""
+}
+
+// CiliumAgentMetrics returns the MetricsSource for the cilium-agent component.
+func (ct *ConnectivityTest) CiliumAgentMetrics() MetricsSource {
+	ciliumPods := ct.CiliumPods()
+	if len(ciliumPods) == 0 {
+		return MetricsSource{}
+	}
+
+	source := MetricsSource{
+		Name: components.CiliumAgentName,
+	}
+
+	// Retrieve the container port value for Prometheus.
+	for _, p := range ciliumPods {
+		source.Pods = append(source.Pods, p)
+		// parse all the containers
+		for _, c := range p.Pod.Spec.Containers {
+			if c.Name == components.CiliumAgentName {
+				// parse all the container ports
+				for _, port := range c.Ports {
+					if port.Name == prometheusContainerPortName {
+						source.Port = fmt.Sprintf("%d", port.ContainerPort)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Prometheus port was not find, let's return an empty MetricsSource.
+	if source.Port == "" {
+		return MetricsSource{}
+	}
+
+	return source
+}

--- a/connectivity/check/metricssource_test.go
+++ b/connectivity/check/metricssource_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/components"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConnectivityTestCiliumAgentMetrics(t *testing.T) {
+	ciliumPod := Pod{
+		Pod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: components.CiliumAgentName,
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          prometheusContainerPortName,
+								HostPort:      9962,
+								ContainerPort: 9962,
+								Protocol:      corev1.ProtocolTCP,
+							}},
+					},
+				},
+			},
+		},
+	}
+
+	podWithPrometheusMissing := Pod{
+		Pod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: components.CiliumAgentName,
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "peer-service",
+								HostPort:      4244,
+								ContainerPort: 4244,
+								Protocol:      corev1.ProtocolTCP,
+							}},
+					},
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		ct   ConnectivityTest
+		want MetricsSource
+	}{
+		"nominal case": {
+			ct: ConnectivityTest{ciliumPods: map[string]Pod{
+				components.CiliumAgentName: ciliumPod,
+			}},
+			want: MetricsSource{
+				Name: components.CiliumAgentName,
+				Pods: []Pod{ciliumPod},
+				Port: "9962",
+			},
+		},
+		"no cilium pods": {
+			ct:   ConnectivityTest{ciliumPods: map[string]Pod{}},
+			want: MetricsSource{},
+		},
+		"no prometheus container port": {
+			ct:   ConnectivityTest{ciliumPods: map[string]Pod{components.CiliumAgentName: podWithPrometheusMissing}},
+			want: MetricsSource{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tc.ct.CiliumAgentMetrics()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -71,6 +71,21 @@ func (p Pod) Name() string {
 	return p.Pod.Namespace + "/" + p.Pod.Name
 }
 
+// NameWithoutNamespace returns only the name of the Pod.
+func (p Pod) NameWithoutNamespace() string {
+	return p.Pod.Name
+}
+
+// NodeName returns the node name a pod belongs to.
+func (p Pod) NodeName() string {
+	return p.Pod.Spec.NodeName
+}
+
+// Namespace returns the namespace the pod belongs to.
+func (p Pod) Namespace() string {
+	return p.Pod.Namespace
+}
+
 func (p Pod) Scheme() string {
 	return p.scheme
 }

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -24,43 +24,12 @@ import (
 	"github.com/cilium/cilium-cli/k8s"
 )
 
-type ExitCode int16
-
-const (
-	ExitAnyError    ExitCode = -1
-	ExitInvalidCode ExitCode = -2
-
-	ExitCurlHTTPError ExitCode = 22
-	ExitCurlTimeout   ExitCode = 28
-
-	/* How many times we should retry getting the policy revisions before
-	 * giving up. We want to reduce the likelihood that a connectivity blip
-	 * will prevent us from removing policies (dependent on revisions today)
-	 * because that may then cause subsequent tests to fail.
-	 */
-	getPolicyRevisionRetries = 3
-)
-
-func (e ExitCode) String() string {
-	switch e {
-	case ExitAnyError:
-		return "any"
-	case ExitInvalidCode:
-		return "invalid"
-	default:
-		return strconv.Itoa(int(e))
-	}
-}
-
-func (e ExitCode) Check(code uint8) bool {
-	switch e {
-	case ExitAnyError:
-		return code != 0
-	case ExitCode(code):
-		return true
-	}
-	return false
-}
+/* How many times we should retry getting the policy revisions before
+ * giving up. We want to reduce the likelihood that a connectivity blip
+ * will prevent us from removing policies (dependent on revisions today)
+ * because that may then cause subsequent tests to fail.
+ */
+const getPolicyRevisionRetries = 3
 
 // getCiliumPolicyRevisions returns the current policy revisions of all Cilium pods
 func (ct *ConnectivityTest) getCiliumPolicyRevisions(ctx context.Context) (map[Pod]int, error) {
@@ -368,76 +337,6 @@ var (
 		ExitCode: ExitCurlHTTPError,
 	}
 )
-
-type HTTP struct {
-	Status string
-	Method string
-	URL    string
-}
-
-type Result struct {
-	// Request is dropped
-	Drop bool
-
-	// Request is dropped at Egress
-	EgressDrop bool
-
-	// Request is dropped at Ingress
-	IngressDrop bool
-
-	// DropReasonFunc
-	DropReasonFunc func(flow *flowpb.Flow) bool
-
-	// No flows are to be expected. Used for ingress when egress drops
-	None bool
-
-	// DNSProxy is true when DNS Proxy is to be expected, only valid for egress
-	DNSProxy bool
-
-	// L7Proxy is true when L7 proxy (e.g., Envoy) is to be expected
-	L7Proxy bool
-
-	// HTTPStatus is non-zero when a HTTP status code in response is to be expected
-	HTTP HTTP
-
-	// ExitCode is the expected shell exit code
-	ExitCode ExitCode
-}
-
-func (r Result) String() string {
-	if r.None {
-		return "None"
-	}
-	ret := "Allow"
-	if r.Drop {
-		ret = "Drop"
-	}
-	if r.DNSProxy {
-		ret += "-DNS"
-	}
-	if r.L7Proxy {
-		ret += "-L7"
-	}
-	if r.HTTP.Status != "" || r.HTTP.Method != "" || r.HTTP.URL != "" {
-		ret += "-HTTP"
-	}
-	if r.HTTP.Method != "" {
-		ret += "-"
-		ret += r.HTTP.Method
-	}
-	if r.HTTP.URL != "" {
-		ret += "-"
-		ret += r.HTTP.URL
-	}
-	if r.HTTP.Status != "" {
-		ret += "-"
-		ret += r.HTTP.Status
-	}
-	if r.ExitCode >= 0 && r.ExitCode <= 255 {
-		ret += fmt.Sprintf("-exit(%d)", r.ExitCode)
-	}
-	return ret
-}
 
 type ExpectationsFunc func(a *Action) (egress, ingress Result)
 

--- a/connectivity/check/result.go
+++ b/connectivity/check/result.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"fmt"
+	"strconv"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+)
+
+type Result struct {
+	// Request is dropped
+	Drop bool
+
+	// Request is dropped at Egress
+	EgressDrop bool
+
+	// Request is dropped at Ingress
+	IngressDrop bool
+
+	// DropReasonFunc
+	DropReasonFunc func(flow *flowpb.Flow) bool
+
+	// No flows are to be expected. Used for ingress when egress drops
+	None bool
+
+	// DNSProxy is true when DNS Proxy is to be expected, only valid for egress
+	DNSProxy bool
+
+	// L7Proxy is true when L7 proxy (e.g., Envoy) is to be expected
+	L7Proxy bool
+
+	// HTTPStatus is non-zero when a HTTP status code in response is to be expected
+	HTTP HTTP
+
+	// ExitCode is the expected shell exit code
+	ExitCode ExitCode
+}
+
+type HTTP struct {
+	Status string
+	Method string
+	URL    string
+}
+
+type ExitCode int16
+
+const (
+	ExitAnyError    ExitCode = -1
+	ExitInvalidCode ExitCode = -2
+
+	ExitCurlHTTPError ExitCode = 22
+	ExitCurlTimeout   ExitCode = 28
+)
+
+func (e ExitCode) String() string {
+	switch e {
+	case ExitAnyError:
+		return "any"
+	case ExitInvalidCode:
+		return "invalid"
+	default:
+		return strconv.Itoa(int(e))
+	}
+}
+
+func (e ExitCode) Check(code uint8) bool {
+	switch e {
+	case ExitAnyError:
+		return code != 0
+	case ExitCode(code):
+		return true
+	}
+	return false
+}
+
+func (r Result) String() string {
+	if r.None {
+		return "None"
+	}
+	ret := "Allow"
+	if r.Drop {
+		ret = "Drop"
+	}
+	if r.DNSProxy {
+		ret += "-DNS"
+	}
+	if r.L7Proxy {
+		ret += "-L7"
+	}
+	if r.HTTP.Status != "" || r.HTTP.Method != "" || r.HTTP.URL != "" {
+		ret += "-HTTP"
+	}
+	if r.HTTP.Method != "" {
+		ret += "-"
+		ret += r.HTTP.Method
+	}
+	if r.HTTP.URL != "" {
+		ret += "-"
+		ret += r.HTTP.URL
+	}
+	if r.HTTP.Status != "" {
+		ret += "-"
+		ret += r.HTTP.Status
+	}
+	if r.ExitCode >= 0 && r.ExitCode <= 255 {
+		ret += fmt.Sprintf("-exit(%d)", r.ExitCode)
+	}
+	return ret
+}

--- a/connectivity/check/result_test.go
+++ b/connectivity/check/result_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/components"
+
+	prommodel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestExpectMetricsToIncrease(t *testing.T) {
+	ciliumPod := Pod{
+		Pod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: components.CiliumAgentName,
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "prometheus",
+								HostPort:      9962,
+								ContainerPort: 9962,
+								Protocol:      corev1.ProtocolTCP,
+							}},
+					},
+				},
+			},
+		},
+	}
+
+	metricName := "cilium_forward_count_total"
+	metricHelp := "Total forwarded packets, tagged by ingress/egress direction"
+	metricTypeCounter := prommodel.MetricType_COUNTER
+	labelName := "direction"
+	labelEgress := "EGRESS"
+	labelIngress := "INGRESS"
+	valueBefore := 1432571.
+	valueAfter := 1432625.
+
+	metricsBefore := promMetricsFamily{
+		metricName: {
+			Name: &metricName,
+			Help: &metricHelp,
+			Type: &metricTypeCounter,
+			Metric: []*prommodel.Metric{
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelEgress}},
+					Counter: &prommodel.Counter{Value: &valueBefore},
+				},
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelIngress}},
+					Counter: &prommodel.Counter{Value: &valueBefore},
+				},
+			},
+		},
+	}
+
+	metricsAfter := promMetricsFamily{
+		metricName: {
+			Name: &metricName,
+			Help: &metricHelp,
+			Type: &metricTypeCounter,
+			Metric: []*prommodel.Metric{
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelEgress}},
+					Counter: &prommodel.Counter{Value: &valueAfter},
+				},
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelIngress}},
+					Counter: &prommodel.Counter{Value: &valueAfter},
+				},
+			},
+		},
+	}
+
+	otherMetric := promMetricsFamily{
+		"other_metrics": {
+			Name: &metricName,
+			Help: &metricHelp,
+			Type: &metricTypeCounter,
+			Metric: []*prommodel.Metric{
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelEgress}},
+					Counter: &prommodel.Counter{Value: &valueAfter},
+				},
+				{
+					Label:   []*prommodel.LabelPair{{Name: &labelName, Value: &labelIngress}},
+					Counter: &prommodel.Counter{Value: &valueAfter},
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		source        MetricsSource
+		metrics       string
+		metricsBefore promMetricsFamily
+		metricsAfter  promMetricsFamily
+		wantErr       bool
+	}{
+		"nominal case: metrics increase": {
+			metrics:       "cilium_forward_count_total",
+			metricsBefore: metricsBefore,
+			metricsAfter:  metricsAfter,
+			wantErr:       false,
+		},
+		"metrics decrease": {
+			metrics:       "cilium_forward_count_total",
+			metricsBefore: metricsAfter,
+			metricsAfter:  metricsBefore,
+			wantErr:       true,
+		},
+		"metric name not present in the metrics before": {
+			metrics: "cilium_forward_count_total",
+			source: MetricsSource{
+				Name: components.CiliumAgentName,
+				Pods: []Pod{ciliumPod},
+				Port: "9962",
+			},
+			metricsBefore: otherMetric,
+			metricsAfter:  metricsAfter,
+			wantErr:       true,
+		},
+		"metric name not present in the metrics after": {
+			metrics:       "cilium_forward_count_total",
+			metricsBefore: metricsBefore,
+			metricsAfter:  otherMetric,
+			wantErr:       true,
+		},
+		"metric name not present in the metrics before and after": {
+			metrics:       "unknown_metric",
+			metricsBefore: metricsBefore,
+			metricsAfter:  metricsAfter,
+			wantErr:       true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := Result{}
+			got := r.ExpectMetricsIncrease(tc.source, tc.metrics)
+
+			for _, m := range got.Metrics {
+				// check the source
+				assert.Equal(t, tc.source, m.Source)
+
+				// check the assert method
+				err := m.Assert(tc.metricsBefore, tc.metricsAfter)
+				if tc.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -305,6 +305,16 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			return check.ResultOK, check.ResultDefaultDenyIngressDrop
 		})
 
+	// This policy allows traffic pod to pod and checks if the metric cilium_forward_count_total increases on cilium agent.
+	ct.NewTest("allow-all-with-metrics-check").
+		WithScenarios(
+			tests.PodToPod(),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK.ExpectMetricsIncrease(ct.CiliumAgentMetrics(), "cilium_forward_count_total"),
+				check.ResultOK.ExpectMetricsIncrease(ct.CiliumAgentMetrics(), "cilium_forward_count_total")
+		})
+
 	// This policy denies all ingresses by default.
 	//
 	// 1. Pod to Pod fails because there is no egress policy (so egress traffic originating from a pod is allowed),

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -50,6 +50,9 @@ func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 					a.ValidateFlows(ctx, dst, a.GetIngressRequirements(check.FlowParameters{
 						Protocol: check.ICMP,
 					}))
+
+					a.ValidateMetrics(ctx, src, a.GetEgressMetricsRequirements())
+					a.ValidateMetrics(ctx, dst, a.GetIngressMetricsRequirements())
 				})
 			})
 

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -50,6 +50,8 @@ func (s *podToHost) Run(ctx context.Context, t *check.Test) {
 						a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 							Protocol: check.ICMP,
 						}))
+
+						a.ValidateMetrics(ctx, pod, a.GetEgressMetricsRequirements())
 					})
 
 					i++

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -59,6 +59,9 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 
 					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
 					a.ValidateFlows(ctx, echo, a.GetIngressRequirements(check.FlowParameters{}))
+
+					a.ValidateMetrics(ctx, echo, a.GetIngressMetricsRequirements())
+					a.ValidateMetrics(ctx, echo, a.GetEgressMetricsRequirements())
 				})
 			})
 

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -58,6 +58,8 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 					DNSRequired: true,
 					AltDstPort:  svc.Port(),
 				}))
+
+				a.ValidateMetrics(ctx, pod, a.GetEgressMetricsRequirements())
 			})
 
 			i++

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -102,6 +102,7 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https, check.IPFamilyAny).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyAny))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
+			a.ValidateMetrics(ctx, client, a.GetEgressMetricsRequirements())
 		})
 
 		i++

--- a/go.mod
+++ b/go.mod
@@ -153,8 +153,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/prometheus/client_golang v1.15.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.42.0 // indirect
+	github.com/prometheus/client_model v0.3.0
+	github.com/prometheus/common v0.42.0
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect

--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// ForwardedPort holds the remote and local mapped port.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+// PortForwardParameters are the needed parameters to call PortForward.
+// Ports value follow the kubectl syntax: <local-port>:<remote-port>
+// 5000 means 5000:5000 listening on 5000 port locally, forwarding to 5000 in the pod
+// 8888:5000 means listening on 8888 port locally, forwarding to 5000 in the pod
+// 0:5000 means listening on a random port locally, forwarding to 5000 in the pod
+// :5000 means listening on a random port locally, forwarding to 5000 in the pod
+type PortForwardParameters struct {
+	Namespace  string
+	Pod        string
+	Ports      []string
+	Addresses  []string
+	OutWriters OutWriters
+}
+
+// OutWriters holds the two io.Writer needed for the port forward
+// one for the output and for the errors.
+type OutWriters struct {
+	Out    io.Writer
+	ErrOut io.Writer
+}
+
+// PortForwardResult are the ports that have been forwarded.
+type PortForwardResult struct {
+	ForwardedPorts []ForwardedPort
+}
+
+// PortForward executes in a goroutine a port forward command.
+// To stop the port-forwarding, use the context by cancelling it
+func (c *Client) PortForward(ctx context.Context, p PortForwardParameters) (*PortForwardResult, error) {
+	req := c.Clientset.CoreV1().RESTClient().Post().Namespace(p.Namespace).
+		Resource("pods").Name(p.Pod).SubResource(strings.ToLower("PortForward"))
+
+	roundTripper, upgrader, err := spdy.RoundTripperFor(c.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, req.URL())
+	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
+	if len(p.Addresses) == 0 {
+		p.Addresses = []string{"localhost"}
+	}
+
+	pw, err := portforward.NewOnAddresses(dialer, p.Addresses, p.Ports, stopChan, readyChan, p.OutWriters.Out, p.OutWriters.ErrOut)
+	if err != nil {
+		return nil, err
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		if err := pw.ForwardPorts(); err != nil {
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		close(stopChan)
+	}()
+
+	select {
+	case <-pw.Ready:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errChan:
+		return nil, err
+	}
+
+	ports, err := pw.GetPorts()
+	if err != nil {
+		return nil, err
+	}
+
+	forwardedPorts := make([]ForwardedPort, 0, len(ports))
+	for _, port := range ports {
+		forwardedPorts = append(forwardedPorts, ForwardedPort{port.Local, port.Remote})
+	}
+
+	return &PortForwardResult{
+		ForwardedPorts: forwardedPorts,
+	}, nil
+}

--- a/vendor/k8s.io/client-go/tools/portforward/doc.go
+++ b/vendor/k8s.io/client-go/tools/portforward/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package portforward adds support for SSH-like port forwarding from the client's
+// local host to remote containers.
+package portforward // import "k8s.io/client-go/tools/portforward"

--- a/vendor/k8s.io/client-go/tools/portforward/portforward.go
+++ b/vendor/k8s.io/client-go/tools/portforward/portforward.go
@@ -1,0 +1,439 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	netutils "k8s.io/utils/net"
+)
+
+// PortForwardProtocolV1Name is the subprotocol used for port forwarding.
+// TODO move to API machinery and re-unify with kubelet/server/portfoward
+const PortForwardProtocolV1Name = "portforward.k8s.io"
+
+var ErrLostConnectionToPod = errors.New("lost connection to pod")
+
+// PortForwarder knows how to listen for local connections and forward them to
+// a remote pod via an upgraded HTTP request.
+type PortForwarder struct {
+	addresses []listenAddress
+	ports     []ForwardedPort
+	stopChan  <-chan struct{}
+
+	dialer        httpstream.Dialer
+	streamConn    httpstream.Connection
+	listeners     []io.Closer
+	Ready         chan struct{}
+	requestIDLock sync.Mutex
+	requestID     int
+	out           io.Writer
+	errOut        io.Writer
+}
+
+// ForwardedPort contains a Local:Remote port pairing.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+/*
+valid port specifications:
+
+5000
+- forwards from localhost:5000 to pod:5000
+
+8888:5000
+- forwards from localhost:8888 to pod:5000
+
+0:5000
+:5000
+  - selects a random available local port,
+    forwards from localhost:<random port> to pod:5000
+*/
+func parsePorts(ports []string) ([]ForwardedPort, error) {
+	var forwards []ForwardedPort
+	for _, portString := range ports {
+		parts := strings.Split(portString, ":")
+		var localString, remoteString string
+		if len(parts) == 1 {
+			localString = parts[0]
+			remoteString = parts[0]
+		} else if len(parts) == 2 {
+			localString = parts[0]
+			if localString == "" {
+				// support :5000
+				localString = "0"
+			}
+			remoteString = parts[1]
+		} else {
+			return nil, fmt.Errorf("invalid port format '%s'", portString)
+		}
+
+		localPort, err := strconv.ParseUint(localString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing local port '%s': %s", localString, err)
+		}
+
+		remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing remote port '%s': %s", remoteString, err)
+		}
+		if remotePort == 0 {
+			return nil, fmt.Errorf("remote port must be > 0")
+		}
+
+		forwards = append(forwards, ForwardedPort{uint16(localPort), uint16(remotePort)})
+	}
+
+	return forwards, nil
+}
+
+type listenAddress struct {
+	address     string
+	protocol    string
+	failureMode string
+}
+
+func parseAddresses(addressesToParse []string) ([]listenAddress, error) {
+	var addresses []listenAddress
+	parsed := make(map[string]listenAddress)
+	for _, address := range addressesToParse {
+		if address == "localhost" {
+			if _, exists := parsed["127.0.0.1"]; !exists {
+				ip := listenAddress{address: "127.0.0.1", protocol: "tcp4", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+			if _, exists := parsed["::1"]; !exists {
+				ip := listenAddress{address: "::1", protocol: "tcp6", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+		} else if netutils.ParseIPSloppy(address).To4() != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp4", failureMode: "any"}
+		} else if netutils.ParseIPSloppy(address) != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp6", failureMode: "any"}
+		} else {
+			return nil, fmt.Errorf("%s is not a valid IP", address)
+		}
+	}
+	addresses = make([]listenAddress, len(parsed))
+	id := 0
+	for _, v := range parsed {
+		addresses[id] = v
+		id++
+	}
+	// Sort addresses before returning to get a stable order
+	sort.Slice(addresses, func(i, j int) bool { return addresses[i].address < addresses[j].address })
+
+	return addresses, nil
+}
+
+// New creates a new PortForwarder with localhost listen addresses.
+func New(dialer httpstream.Dialer, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	return NewOnAddresses(dialer, []string{"localhost"}, ports, stopChan, readyChan, out, errOut)
+}
+
+// NewOnAddresses creates a new PortForwarder with custom listen addresses.
+func NewOnAddresses(dialer httpstream.Dialer, addresses []string, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	if len(addresses) == 0 {
+		return nil, errors.New("you must specify at least 1 address")
+	}
+	parsedAddresses, err := parseAddresses(addresses)
+	if err != nil {
+		return nil, err
+	}
+	if len(ports) == 0 {
+		return nil, errors.New("you must specify at least 1 port")
+	}
+	parsedPorts, err := parsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+	return &PortForwarder{
+		dialer:    dialer,
+		addresses: parsedAddresses,
+		ports:     parsedPorts,
+		stopChan:  stopChan,
+		Ready:     readyChan,
+		out:       out,
+		errOut:    errOut,
+	}, nil
+}
+
+// ForwardPorts formats and executes a port forwarding request. The connection will remain
+// open until stopChan is closed.
+func (pf *PortForwarder) ForwardPorts() error {
+	defer pf.Close()
+
+	var err error
+	pf.streamConn, _, err = pf.dialer.Dial(PortForwardProtocolV1Name)
+	if err != nil {
+		return fmt.Errorf("error upgrading connection: %s", err)
+	}
+	defer pf.streamConn.Close()
+
+	return pf.forward()
+}
+
+// forward dials the remote host specific in req, upgrades the request, starts
+// listeners for each port specified in ports, and forwards local connections
+// to the remote host via streams.
+func (pf *PortForwarder) forward() error {
+	var err error
+
+	listenSuccess := false
+	for i := range pf.ports {
+		port := &pf.ports[i]
+		err = pf.listenOnPort(port)
+		switch {
+		case err == nil:
+			listenSuccess = true
+		default:
+			if pf.errOut != nil {
+				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", port.Local, err)
+			}
+		}
+	}
+
+	if !listenSuccess {
+		return fmt.Errorf("unable to listen on any of the requested ports: %v", pf.ports)
+	}
+
+	if pf.Ready != nil {
+		close(pf.Ready)
+	}
+
+	// wait for interrupt or conn closure
+	select {
+	case <-pf.stopChan:
+	case <-pf.streamConn.CloseChan():
+		return ErrLostConnectionToPod
+	}
+
+	return nil
+}
+
+// listenOnPort delegates listener creation and waits for connections on requested bind addresses.
+// An error is raised based on address groups (default and localhost) and their failure modes
+func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
+	var errors []error
+	failCounters := make(map[string]int, 2)
+	successCounters := make(map[string]int, 2)
+	for _, addr := range pf.addresses {
+		err := pf.listenOnPortAndAddress(port, addr.protocol, addr.address)
+		if err != nil {
+			errors = append(errors, err)
+			failCounters[addr.failureMode]++
+		} else {
+			successCounters[addr.failureMode]++
+		}
+	}
+	if successCounters["all"] == 0 && failCounters["all"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	if failCounters["any"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	return nil
+}
+
+// listenOnPortAndAddress delegates listener creation and waits for new connections
+// in the background f
+func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	pf.listeners = append(pf.listeners, listener)
+	go pf.waitForConnection(listener, *port)
+	return nil
+}
+
+// getListener creates a listener on the interface targeted by the given hostname on the given port with
+// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create listener: Error %s", err)
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		fmt.Fprintf(pf.out, "Failed to forward from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+		return nil, fmt.Errorf("error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+	}
+	port.Local = uint16(localPortUInt)
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Forwarding from %s -> %d\n", net.JoinHostPort(hostname, strconv.Itoa(int(localPortUInt))), port.Remote)
+	}
+
+	return listener, nil
+}
+
+// waitForConnection waits for new connections to listener and handles them in
+// the background.
+func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+	for {
+		select {
+		case <-pf.streamConn.CloseChan():
+			return
+		default:
+			conn, err := listener.Accept()
+			if err != nil {
+				// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
+				if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+					runtime.HandleError(fmt.Errorf("error accepting connection on port %d: %v", port.Local, err))
+				}
+				return
+			}
+			go pf.handleConnection(conn, port)
+		}
+	}
+}
+
+func (pf *PortForwarder) nextRequestID() int {
+	pf.requestIDLock.Lock()
+	defer pf.requestIDLock.Unlock()
+	id := pf.requestID
+	pf.requestID++
+	return id
+}
+
+// handleConnection copies data between the local connection and the stream to
+// the remote server.
+func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+	defer conn.Close()
+
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Handling connection for %d\n", port.Local)
+	}
+
+	requestID := pf.nextRequestID()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	// we're not writing to this stream
+	errorStream.Close()
+	defer pf.streamConn.RemoveStreams(errorStream)
+
+	errorChan := make(chan error)
+	go func() {
+		message, err := io.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+		close(errorChan)
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	defer pf.streamConn.RemoveStreams(dataStream)
+
+	localError := make(chan struct{})
+	remoteDone := make(chan struct{})
+
+	go func() {
+		// Copy from the remote side to the local port.
+		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
+		}
+
+		// inform the select below that the remote copy is done
+		close(remoteDone)
+	}()
+
+	go func() {
+		// inform server we're not sending any more data after copy unblocks
+		defer dataStream.Close()
+
+		// Copy from the local port to the remote side.
+		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
+			// break out of the select below without waiting for the other copy to finish
+			close(localError)
+		}
+	}()
+
+	// wait for either a local->remote error or for copying from remote->local to finish
+	select {
+	case <-remoteDone:
+	case <-localError:
+	}
+
+	// always expect something on errorChan (it may be nil)
+	err = <-errorChan
+	if err != nil {
+		runtime.HandleError(err)
+		pf.streamConn.Close()
+	}
+}
+
+// Close stops all listeners of PortForwarder.
+func (pf *PortForwarder) Close() {
+	// stop all listeners
+	for _, l := range pf.listeners {
+		if err := l.Close(); err != nil {
+			runtime.HandleError(fmt.Errorf("error closing listener: %v", err))
+		}
+	}
+}
+
+// GetPorts will return the ports that were forwarded; this can be used to
+// retrieve the locally-bound port in cases where the input was port 0. This
+// function will signal an error if the Ready channel is nil or if the
+// listeners are not ready yet; this function will succeed after the Ready
+// channel has been closed.
+func (pf *PortForwarder) GetPorts() ([]ForwardedPort, error) {
+	if pf.Ready == nil {
+		return nil, fmt.Errorf("no Ready channel provided")
+	}
+	select {
+	case <-pf.Ready:
+		return pf.ports, nil
+	default:
+		return nil, fmt.Errorf("listeners not ready")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1307,6 +1307,7 @@ k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
+k8s.io/client-go/tools/portforward
 k8s.io/client-go/tools/reference
 k8s.io/client-go/tools/remotecommand
 k8s.io/client-go/tools/watch


### PR DESCRIPTION
## Motivation
Add the possibility to verify metrics from the Cilium agent pod and validate it has the expected behaviour before and after an action. 

## Changes

- [commit 1](https://github.com/cilium/cilium-cli/pull/1575/commits/36277d8e22cc18328b8422eb2ac91939aa89e451) Add a k8s dialer to be able to port forward `/metrics` endpoint outside of the pod
- [commit 2](https://github.com/cilium/cilium-cli/pull/1575/commits/8d5197c451fd056e345337a3d775ee059f2d8a75) Add the logic to call `/metrics` endpoint and parse the metrics to retrieve them into a nice usable open metrics format
- [commit 3](https://github.com/cilium/cilium-cli/pull/1575/commits/86526acefae7242d946281b0719f1fa494cb3fc5) `policy.go` is a pretty long file now, let's move `Result` with its associated methods in its own file.
- [commit 4](https://github.com/cilium/cilium-cli/pull/1575/commits/36757130512333e191d4dd380e00a3335eff5f94) Make the call to collect metrics in the action
- [commit 5](https://github.com/cilium/cilium-cli/pull/1575/commits/7d5a902f35d8cded916db57600f3ffee6d76dae8) Validate the metrics by defining a new type `metricsCompareFunc` which will compare metrics in a generic way.
- [commit 6](https://github.com/cilium/cilium-cli/pull/1575/commits/18bb78f42845fcedddbf9af6a12d6e562c1f44c4) Add a new scenario very basic with a simple metric to verify the feature is working

## Usage

Implement the operation you want to check on your metrics on `Result`:
```go
func (r Result) ExpectMetricsIncrease(source MetricsSource, metrics ...string) Result {
```

Then use it directly in your expectations by passing a MetricSource type (cilium-agent, cilium-operator...) and the name of the metric you want to check:
```go
return check.ResultOK.ExpectMetricsIncrease(ct.CiliumAgentMetrics(), "cilium_forward_count_total")
```
