### PR TITLE
connectivity: Automatically install IP routes on nodes w/o Cilium for from CIDR tests AND get rid of --datapath

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -73,59 +73,6 @@ jobs:
             kubectl label nodes "${node}" cilium.io/no-schedule=true
           done
 
-      # This is needed for the tests that run with nodes without Cilium.
-      - name: Install static routes
-        run: |
-          EXTERNAL_FROM_CIDRS=($(kubectl get nodes -o jsonpath='{range .items[*]}{.spec.podCIDR}{"\n"}{end}'))
-          EXTERNAL_NODE_IPS=() # Nodes IPs are collected to be passed to the Cilium CLI later on.
-
-          # Loop over each pod CIDR from all nodes.
-          for i in "${!EXTERNAL_FROM_CIDRS[@]}"; do
-            EXTERNAL_FROM_CIDR=${EXTERNAL_FROM_CIDRS[i]}
-
-            if [[ $EXTERNAL_FROM_CIDR =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
-              IP_FAMILY="v4"
-            elif [[ $EXTERNAL_FROM_CIDR =~ ^[0-9a-fA-F:]+/[0-9]+$ ]]; then
-              IP_FAMILY="v6"
-            else
-              echo "ERROR: Malformed pod CIDR '${EXTERNAL_FROM_CIDR}'" >&2
-              exit 1
-            fi
-
-            IFS=',' read -ra NODES_WITHOUT <<< "$NODES_WITHOUT_CILIUM" # Split by comma into an array
-            for WITHOUT in "${NODES_WITHOUT[@]}"; do
-              # Fetch node with a specific pod CIDR.
-              node=$(kubectl get nodes -o jsonpath="{range .items[?(@.spec.podCIDR == '$EXTERNAL_FROM_CIDR')]}{@.metadata.name}{end}")
-              if [[ -z "$node" ]]; then
-                echo "ERROR: Could not find node with .spec.podCIDR matching ${EXTERNAL_FROM_CIDR}" >&2
-                exit 1
-              fi
-              for NODE_IP in $(kubectl get node "$node" -o jsonpath="{.status.addresses[?(@.type == 'InternalIP')].address}"); do
-                # Skip if the node IP's family mismatches with pod CIDR's
-                # family. Cannot create a route with the gateway IP family
-                # mismatching the subnet.
-                if [[ "$IP_FAMILY" == "v4" && ! "$NODE_IP" =~ \. ]]; then
-                  continue
-                elif [[ "$IP_FAMILY" == "v6" && ! "$NODE_IP" =~ \: ]]; then
-                  continue
-                fi
-                # Install static route on the host, towards the pod CIDR via the node IP.
-                docker exec "$WITHOUT" ip route replace "${EXTERNAL_FROM_CIDR}" via "${NODE_IP}"
-                EXTERNAL_NODE_IPS+=("${NODE_IP}")
-              done
-            done
-          done
-
-          # Join the elements with a comma delimiter, or leave them unmodified
-          # if there's only one element so that it can be passed properly to
-          # the CLI.
-          if [[ ${#EXTERNAL_NODE_IPS[@]} -eq 1 ]]; then
-            EXTERNAL_NODE_IPS_PARAM="${EXTERNAL_NODE_IPS[0]}"
-          else
-            EXTERNAL_NODE_IPS_PARAM=$(IFS=','; echo "${EXTERNAL_NODE_IPS[*]}")
-          fi
-          echo "EXTERNAL_NODE_IPS_PARAM=${EXTERNAL_NODE_IPS_PARAM}" >> $GITHUB_ENV
-
       # Install Cilium with HostPort support and enables Prometheus for extended connectivity test.
       - name: Install Cilium
         run: |
@@ -154,7 +101,6 @@ jobs:
         run: |
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
           cilium connectivity test --debug --all-flows --test-namespace test-namespace \
-            --external-from-cidrs="${EXTERNAL_NODE_IPS_PARAM}" \
             --collect-sysdump-on-failure --junit-file connectivity-${{ matrix.mode }}.xml
 
       - name: Upload junit output
@@ -205,7 +151,6 @@ jobs:
       - name: Connectivity test
         run: |
           cilium connectivity test --debug --force-deploy --all-flows --test-namespace test-namespace \
-            --external-from-cidrs="${EXTERNAL_NODE_IPS_PARAM}" \
             --collect-sysdump-on-failure --junit-file connectivity-ipsec-${{ matrix.mode }}.xml
 
       - name: Upload junit output

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   installation-and-connectivity:
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: 50
     strategy:
       matrix:
         mode: ["classic", "helm"]
@@ -187,7 +187,7 @@ jobs:
 
   helm-upgrade-clustermesh:
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     env:
       CILIUM_CLI_MODE: helm

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -101,6 +101,7 @@ jobs:
         run: |
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
           cilium connectivity test --debug --all-flows --test-namespace test-namespace \
+            --include-unsafe-tests \
             --collect-sysdump-on-failure --junit-file connectivity-${{ matrix.mode }}.xml
 
       - name: Upload junit output
@@ -151,6 +152,7 @@ jobs:
       - name: Connectivity test
         run: |
           cilium connectivity test --debug --force-deploy --all-flows --test-namespace test-namespace \
+            --include-unsafe-tests \
             --collect-sysdump-on-failure --junit-file connectivity-ipsec-${{ matrix.mode }}.xml
 
       - name: Upload junit output
@@ -301,7 +303,8 @@ jobs:
       - name: Run the multicluster connectivity tests
         run: |
           cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2 --debug \
-          --collect-sysdump-on-failure --junit-file connectivity-clustermesh.xml
+            --include-unsafe-tests \
+            --collect-sysdump-on-failure --junit-file connectivity-clustermesh.xml
 
       - name: Upload junit output
         if: ${{ always() }}

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -810,10 +810,7 @@ func (a *Action) followFlows(ctx context.Context, ready chan bool) error {
 	// All tests are initiated from the source Pod, so filtering traffic
 	// originating from and destined to the Pod should capture what we need.
 	pod := a.Source()
-	filter := []*flow.FlowFilter{
-		{SourcePod: []string{pod.Name()}},
-		{DestinationPod: []string{pod.Name()}},
-	}
+	filter := pod.FlowFilters()
 
 	// Initiate long-poll against Hubble Relay.
 	b, err := hubbleClient.GetFlows(ctx, &observer.GetFlowsRequest{

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -48,7 +48,7 @@ type Parameters struct {
 	JSONMockImage         string
 	AgentDaemonSetName    string
 	DNSTestServerImage    string
-	Datapath              bool
+	IncludeUnsafeTests    bool
 	AgentPodSelector      string
 	NodeSelector          map[string]string
 	ExternalTarget        string

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -55,8 +55,8 @@ type Parameters struct {
 	ExternalCIDR          string
 	ExternalIP            string
 	ExternalOtherIP       string
-	ExternalFromCIDRs     []string
-	ExternalFromCIDRMasks []int // Derived from ExternalFromCIDRs
+	PodCIDRs              []podCIDRs
+	NodesWithoutCiliumIPs []nodesWithoutCiliumIP
 	JunitFile             string
 
 	K8sVersion           string
@@ -73,6 +73,16 @@ type Parameters struct {
 
 	CollectSysdumpOnFailure bool
 	SysdumpOptions          sysdump.Options
+}
+
+type podCIDRs struct {
+	CIDR   string
+	HostIP string
+}
+
+type nodesWithoutCiliumIP struct {
+	IP   string
+	Mask int
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -592,7 +592,7 @@ func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.
 	for _, e := range ct.params.PodCIDRs {
 		for _, withoutCilium := range ct.nodesWithoutCilium {
 			pod := ct.hostNetNSPodsByNode[withoutCilium]
-			_, err := ct.client.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, hostNetNSDeploymentName,
+			_, err := ct.client.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, hostNetNSDeploymentNameNonCilium,
 				[]string{"ip", "route", verb, e.CIDR, "via", e.HostIP},
 			)
 			ct.Debugf("Modifying (%s) static route on nodes without Cilium (%v): %v",

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -70,8 +70,9 @@ type ConnectivityTest struct {
 
 	lastFlowTimestamps map[string]time.Time
 
-	nodes              map[string]*corev1.Node
-	nodesWithoutCilium []string
+	nodes                 map[string]*corev1.Node
+	nodesWithoutCilium    []string
+	nodesWithoutCiliumMap map[string]struct{}
 
 	manifests      map[string]string
 	helmYAMLValues string

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -266,7 +266,7 @@ func newDaemonSet(p daemonSetParameters) *appsv1.DaemonSet {
 							ReadinessProbe:  p.ReadinessProbe,
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_RAW"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1160,10 +1160,13 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	for _, pod := range hostNetNSPods.Items {
-		ct.hostNetNSPodsByNode[pod.Spec.NodeName] = Pod{
+		_, ok := ct.nodesWithoutCiliumMap[pod.Spec.NodeName]
+		p := Pod{
 			K8sClient: ct.client,
 			Pod:       pod.DeepCopy(),
+			Outside:   ok,
 		}
+		ct.hostNetNSPodsByNode[pod.Spec.NodeName] = p
 	}
 
 	var logOnce sync.Once

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -281,10 +281,12 @@ func (ct *ConnectivityTest) extractFeaturesFromNodes(ctx context.Context, client
 	}
 
 	nodes := []string{}
+	ct.nodesWithoutCiliumMap = make(map[string]struct{})
 	for _, node := range nodeList.Items {
 		node := node
 		if !canNodeRunCilium(&node) {
 			nodes = append(nodes, node.ObjectMeta.Name)
+			ct.nodesWithoutCiliumMap[node.ObjectMeta.Name] = struct{}{}
 		}
 	}
 

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -369,7 +369,7 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 	mode = "Disabled"
 	if kpr := st.KubeProxyReplacement; kpr != nil {
 		mode = kpr.Mode
-		if f := kpr.Features; f != nil {
+		if f := kpr.Features; kpr.Mode != "Disabled" && f != nil {
 			if f.ExternalIPs != nil {
 				result[FeatureKPRExternalIPs] = FeatureStatus{Enabled: f.ExternalIPs.Enabled}
 			}

--- a/connectivity/manifests/echo-ingress-from-cidr.yaml
+++ b/connectivity/manifests/echo-ingress-from-cidr.yaml
@@ -9,6 +9,6 @@ spec:
       kind: echo
   ingress:
   - fromCIDR:
-{{ range $i, $cidr := .ExternalFromCIDRs }}
-    - {{$cidr}}/{{index $.ExternalFromCIDRMasks $i}}
+{{ range $i := .NodesWithoutCiliumIPs }}
+    - {{$i.IP}}/{{$i.Mask}}
 {{ end }}

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -209,6 +209,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			)
 		ct.NewTest("north-south-loadbalancing-with-l7-policy").
 			WithFeatureRequirements(check.RequireFeatureEnabled(check.FeatureNodeWithoutCilium)).
+			WithCiliumVersion(">1.13.2").
 			WithCiliumPolicy(echoIngressL7HTTPFromAnywherePolicyYAML).
 			WithScenarios(
 				tests.OutsideToNodePort(),

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -136,8 +136,8 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
-	cmd.Flags().BoolVar(&params.Datapath, "datapath", false, "Run datapath conformance tests")
-	cmd.Flags().MarkHidden("datapath")
+	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster nodes state")
+	cmd.Flags().MarkHidden("include-unsafe-tests")
 
 	cmd.Flags().StringVar(&params.K8sVersion, "k8s-version", "", "Kubernetes server version in case auto-detection fails")
 	cmd.Flags().StringVar(&params.HelmChartDirectory, "chart-directory", "", "Helm chart directory")

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -133,7 +133,6 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalIP, "external-ip", "1.1.1.1", "IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")
-	cmd.Flags().StringSliceVar(&params.ExternalFromCIDRs, "external-from-cidrs", []string{}, "CIDRs representing nodes without Cilium to be used in connectivity tests")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")


### PR DESCRIPTION
This PR introduces a few changes:

1. Moves IP routes (pod CIDR => node on nodes w/o Cilium) installation to the CLI.
2. Removes `--datapath`, and introduces `--include-unsafe-tests`. The formal removal required a few changes to the flow validation and skipping some tests to make it pass on some GHA workflows.

Please review it per commit.

Successful run - https://github.com/cilium/cilium/pull/25510.