### PR TITLE
Add --encryption to helm install mode

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -161,24 +161,11 @@ jobs:
           cilium uninstall --wait
 
       - name: Install Cilium with IPsec Encryption
-        if: ${{ matrix.mode == 'classic' }}
         run: |
           cilium install \
           --version=${{ env.cilium_version}} \
           --encryption=ipsec \
           --nodes-without-cilium="${NODES_WITHOUT_CILIUM}" \
-          --helm-set kubeProxyReplacement=disabled
-
-      - name: Install Cilium with IPsec Encryption
-        if: ${{ matrix.mode == 'helm' }}
-        run: |
-          kubectl create -n kube-system secret generic cilium-ipsec-keys \
-            --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
-          cilium install \
-          --version=${{ env.cilium_version}} \
-          --nodes-without-cilium="${NODES_WITHOUT_CILIUM}" \
-          --helm-set encryption.enabled=true \
-          --helm-set encryption.type=ipsec \
           --helm-set kubeProxyReplacement=disabled
 
       - name: Enable Relay

--- a/install/install.go
+++ b/install/install.go
@@ -659,6 +659,14 @@ func (k *K8sInstaller) preinstall(ctx context.Context) error {
 			}
 		}
 	}
+
+	if k.params.Encryption == encryptionIPsec {
+		// TODO(aanm) automate this as well in form of helm chart
+		if err := k.createEncryptionSecret(ctx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -809,13 +817,6 @@ func (k *K8sInstaller) Install(ctx context.Context) error {
 			k.Log("Cannot delete %s ClusterRoleBinding: %s", defaults.OperatorClusterRoleName, err)
 		}
 	})
-
-	if k.params.Encryption == encryptionIPsec {
-		// TODO(aanm) automate this as well in form of helm chart
-		if err := k.createEncryptionSecret(ctx); err != nil {
-			return err
-		}
-	}
 
 	ingressClass := k.generateIngressClass()
 	if ingressClass != nil {

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -79,7 +79,6 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().StringVar(&params.KubeProxyReplacement, "kube-proxy-replacement", "disabled", "Enable/disable kube-proxy replacement { disabled | partial | strict }")
 	cmd.Flags().MarkDeprecated("kube-proxy-replacement", "This can now be overridden via `helm-set` (Helm value: `kubeProxyReplacement`).")
 	cmd.Flags().BoolVar(&params.RestartUnmanagedPods, "restart-unmanaged-pods", true, "Restart pods which are not being managed by Cilium")
-	cmd.Flags().StringVar(&params.Encryption, "encryption", "disabled", "Enable encryption of all workloads traffic { disabled | ipsec | wireguard }")
 	// It can be deprecated since we have a helm option for it
 	cmd.Flags().BoolVar(&params.NodeEncryption, "node-encryption", false, "Enable encryption of all node to node traffic")
 	// It can be deprecated since we have a helm option for it
@@ -231,6 +230,7 @@ func addCommonInstallFlags(cmd *cobra.Command, params *install.Parameters) {
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use { tunnel | aws-eni | gke | azure | aks-byocni } (default: autodetected).")
 	cmd.Flags().BoolVar(&params.ListVersions, "list-versions", false, "List all the available versions without actually installing")
 	cmd.Flags().StringSliceVar(&params.NodesWithoutCilium, "nodes-without-cilium", []string{}, "List of node names on which Cilium will not be installed. In Helm installation mode, it's assumed that the no-schedule node labels are present and that the infastructure has set up routing on these nodes to provide connectivity within the Cilium cluster.")
+	cmd.Flags().StringVar(&params.Encryption, "encryption", "disabled", "Enable encryption of all workloads traffic { disabled | ipsec | wireguard }")
 }
 
 // addCommonUninstallFlags adds uninstall command flags that are shared between classic and helm mode.


### PR DESCRIPTION
This enables the helm install to use the --encryption flag by moving the key creation into the shared pre-install hook.

This will un-block the work of bringing the cilium/cilium tests to Helm mode to test new features that require those mode like Spire and the Envoy DS.