### PR TITLE
suite: disable KNP tests when endpoint routes and IPv6 are enabled

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -146,6 +146,16 @@ func RequireFeatureEnabled(feature Feature) FeatureRequirement {
 	}
 }
 
+// RequireFeatureDisabled constructs a FeatureRequirement which expects the
+// feature to be disabled
+func RequireFeatureDisabled(feature Feature) FeatureRequirement {
+	return FeatureRequirement{
+		feature:         feature,
+		requiresEnabled: true,
+		enabled:         false,
+	}
+}
+
 // RequireFeatureMode constructs a FeatureRequirement which expects the feature
 // to be in the given mode
 func RequireFeatureMode(feature Feature, mode string) FeatureRequirement {

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -295,6 +295,9 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 
 	// Run a simple test with k8s Network Policy.
 	ct.NewTest("client-ingress-knp").WithK8SPolicy(clientIngressFromClient2PolicyKNPYAML).
+		// disabled with endpoint routes and IPv6 until #1585 is fixed
+		WithFeatureRequirements(check.RequireFeatureDisabled(check.FeatureEndpointRoutes),
+			check.RequireFeatureDisabled(check.FeatureIPv6)).
 		WithScenarios(
 			tests.ClientToClient(),
 		).
@@ -423,6 +426,9 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 
 	// This k8s policy allows ingress to echo only from client with a label 'other:client'.
 	ct.NewTest("echo-ingress-knp").WithK8SPolicy(echoIngressFromOtherClientPolicyKNPYAML).
+		// disabled with endpoint routes and IPv6 until #1585 is fixed
+		WithFeatureRequirements(check.RequireFeatureDisabled(check.FeatureEndpointRoutes),
+			check.RequireFeatureDisabled(check.FeatureIPv6)).
 		WithScenarios(
 			tests.PodToPod(),
 		).
@@ -456,6 +462,9 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 
 	// This policy allows port 8080 from client to echo, so this should succeed
 	ct.NewTest("client-egress-knp").WithK8SPolicy(clientEgressToEchoPolicyKNPYAML).
+		// disabled with endpoint routes and IPv6 until #1585 is fixed
+		WithFeatureRequirements(check.RequireFeatureDisabled(check.FeatureEndpointRoutes),
+			check.RequireFeatureDisabled(check.FeatureIPv6)).
 		WithScenarios(
 			tests.PodToPod(),
 		)
@@ -468,6 +477,9 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 
 	// This policy allows port 8080 from client to echo (using label match expression, so this should succeed
 	ct.NewTest("client-egress-expression-knp").WithK8SPolicy(clientEgressToEchoExpressionPolicyKNPYAML).
+		// disabled with endpoint routes and IPv6 until #1585 is fixed
+		WithFeatureRequirements(check.RequireFeatureDisabled(check.FeatureEndpointRoutes),
+			check.RequireFeatureDisabled(check.FeatureIPv6)).
 		WithScenarios(
 			tests.PodToPod(),
 		)


### PR DESCRIPTION
disable:
* client-ingress-knp
* echo-ingress-knp
* client-egress-knp
* client-egress-expression-knp

as the tests are currently failing with this configuration.

Issue tracked in https://github.com/cilium/cilium-cli/issues/1585.

test run on Cilium main branch: https://github.com/cilium/cilium/actions/runs/4914096880/jobs/8775022204?pr=25194