### PR TITLE
connectivity: Fix IPv6 skipping when EP routes are on

### DIFF
--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -625,7 +625,7 @@ func (t *Test) ForEachIPFamily(do func(IPFamily)) {
 	// netpols installed (tracked in https://github.com/cilium/cilium/issues/23852
 	// and https://github.com/cilium/cilium/issues/23910). Once both issues
 	// are resolved, we can start testing IPv6 with netpols.
-	if f, ok := t.Context().Feature(FeatureEndpointRoutes); ok && f.Enabled && len(t.cnps) > 0 {
+	if f, ok := t.Context().Feature(FeatureEndpointRoutes); ok && f.Enabled && (len(t.cnps) > 0 || len(t.knps) > 0) {
 		ipFams = []IPFamily{IPFamilyV4}
 	}
 


### PR DESCRIPTION
We recently added the KNP tests, so we need to check for those too. Previously, we checked only for CNPs.

Otherwise, all KNP tests will fail for IPv6 connections among endpoints running on the same host.

Fixes: 33883604 ("connectivity: Add IPv6 tests")