### PR TITLE
.github/workflows: bump AKS BYOCNI workflow timeout

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -46,7 +46,7 @@ jobs:
   installation-and-connectivity:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -167,7 +167,7 @@ jobs:
 
       - name: Wait for test job
         env:
-          timeout: 15m
+          timeout: 30m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &


### PR DESCRIPTION
The AKS BYOCNI workflow has been timing out quite often since being re-enabled. This is mainly due to the additional tests that were added since the workflow was disabled ~5 months ago. Follow commit 13ae2fa3dcee ("gha: Increase timeout for GKE") which increased timeouts for the GKE workflow in a similar fashion and bump the timeout by 15min.

See https://github.com/cilium/cilium-cli/actions/runs/4916363553/jobs/8780012198 for a recent timeout.