### PR TITLE
renovate: fix invalid JSON syntax

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,7 +68,7 @@
         "patch",
         "pin",
         "pinDigest"
-      ]
+      ],
       matchBaseBranches: [
         "main"
       ]


### PR DESCRIPTION
Fixes: 930832e59ffe ("Add renovate configuration")
Fixes: #1592