### PR TITLE
Remove az-binary check

### DIFF
--- a/.github/in-cluster-test-scripts/aks-byocni-install.sh
+++ b/.github/in-cluster-test-scripts/aks-byocni-install.sh
@@ -6,7 +6,6 @@ set -e
 # Install Cilium
 cilium install \
   --version "${CILIUM_VERSION}" \
-  --disable-check=az-binary \
   --datapath-mode=aks-byocni \
   --wait=false \
   --helm-set loadBalancer.l7.backend=envoy \

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -28,9 +28,6 @@ var (
 		k8s.KindKind: {
 			&kindVersionValidation{},
 		},
-		k8s.KindAKS: {
-			&azureVersionValidation{},
-		},
 	}
 
 	clusterNameValidation = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])$`)

--- a/install/azure.go
+++ b/install/azure.go
@@ -16,23 +16,6 @@ import (
 	"github.com/cilium/cilium-cli/internal/utils"
 )
 
-type azureVersionValidation struct{}
-
-func (m *azureVersionValidation) Name() string {
-	return "az-binary"
-}
-
-func (m *azureVersionValidation) Check(_ context.Context, k *K8sInstaller) error {
-	_, err := k.azExec("version")
-	if err != nil {
-		return err
-	}
-
-	k.Log("✅ Detected az binary")
-
-	return nil
-}
-
 type accountInfo struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`


### PR DESCRIPTION
I assert that az-binary check is a bit too excessive since it's not always required to have az binary installed when you are installing Cilium on AKS.

Instead of forcing users to specify `--disable-check=az-binary` flag, let's just fail if az binary is needed but not found. This behavior is consistent with how we handle gcloud binary.