### PR TITLE
Add a function to check if the CLI is in Helm mode

### DIFF
--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium-cli/clustermesh"
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/status"
 )
 
@@ -32,7 +33,7 @@ func newCmdClusterMesh() *cobra.Command {
 		newCmdClusterMeshExternalWorkload(),
 	)
 
-	if os.Getenv("CILIUM_CLI_MODE") == "helm" {
+	if utils.IsInHelmMode() {
 		cmd.AddCommand(
 			newCmdClusterMeshEnableWithHelm(),
 			newCmdClusterMeshDisableWithHelm(),

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/k8s"
 )
 
@@ -79,7 +80,7 @@ cilium connectivity test`,
 		newCmdSysdump(),
 		newCmdVersion(),
 	)
-	if os.Getenv("CILIUM_CLI_MODE") == "helm" {
+	if utils.IsInHelmMode() {
 		cmd.AddCommand(
 			newCmdInstallWithHelm(),
 			newCmdUninstallWithHelm(),

--- a/internal/cli/cmd/hubble.go
+++ b/internal/cli/cmd/hubble.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/hubble"
+	"github.com/cilium/cilium-cli/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,7 @@ func newCmdHubble() *cobra.Command {
 		newCmdPortForwardCommand(),
 		newCmdUI(),
 	)
-	if os.Getenv("CILIUM_CLI_MODE") == "helm" {
+	if utils.IsInHelmMode() {
 		cmd.AddCommand(
 			newCmdHubbleEnableWithHelm(),
 			newCmdHubbleDisableWithHelm(),

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,6 +6,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -33,6 +34,7 @@ type ImagePathMode int
 const (
 	ImagePathExcludeDigest ImagePathMode = iota
 	ImagePathIncludeDigest
+	CLIModeVariableName = "CILIUM_CLI_MODE"
 )
 
 var imageRegexp = regexp.MustCompile(`\A(.*?)(?:(:.*?)(@sha256:[0-9a-f]{64})?)?\z`)
@@ -171,4 +173,9 @@ func Contains(l []string, v string) bool {
 		}
 	}
 	return false
+}
+
+// IsInHelmMode returns true if cilium-cli is in "helm" mode. Otherwise, it returns false.
+func IsInHelmMode() bool {
+	return os.Getenv(CLIModeVariableName) == "helm"
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -5,10 +5,12 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckVersion(t *testing.T) {
@@ -202,4 +204,15 @@ func TestBuildImagePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsInHelmMode(t *testing.T) {
+	orig := os.Getenv(CLIModeVariableName)
+	assert.NoError(t, os.Setenv(CLIModeVariableName, "helm"))
+	assert.True(t, IsInHelmMode())
+	assert.NoError(t, os.Setenv(CLIModeVariableName, "classic"))
+	assert.False(t, IsInHelmMode())
+	assert.NoError(t, os.Setenv(CLIModeVariableName, "random"))
+	assert.False(t, IsInHelmMode())
+	assert.NoError(t, os.Setenv(CLIModeVariableName, orig))
 }


### PR DESCRIPTION
There are multiple places where we check if the CLI is in Helm mode. Add a function utils.IsInHelmMode() so that this logic is in a single place.