### PR TITLE
Add hooks to use cilium-cli as a package

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/internal/cli/cmd"
+	"github.com/cilium/cilium-cli/sysdump"
+)
+
+// NewDefaultCiliumCommand returns a new "cilium" cli cobra command without any additional hooks.
+func NewDefaultCiliumCommand() *cobra.Command {
+	return NewCiliumCommand(&NopHooks{})
+}
+
+// NewCiliumCommand returns a new "cilium" cli cobra command registering all the additional input hooks.
+func NewCiliumCommand(hooks Hooks) *cobra.Command {
+	return cmd.NewCiliumCommand(hooks)
+}
+
+type (
+	Hooks                 = cmd.Hooks
+	ConnectivityTestHooks = cmd.ConnectivityTestHooks
+	SysdumpHooks          = cmd.SysdumpHooks
+)
+
+type NopHooks struct{}
+
+var _ Hooks = &NopHooks{}
+
+func (*NopHooks) AddSysdumpFlags(*pflag.FlagSet)                     {}
+func (*NopHooks) AddSysdumpTasks(*sysdump.Collector) error           { return nil }
+func (*NopHooks) AddConnectivityTestFlags(*pflag.FlagSet)            {}
+func (*NopHooks) AddConnectivityTests(*check.ConnectivityTest) error { return nil }

--- a/cmd/cilium/main.go
+++ b/cmd/cilium/main.go
@@ -10,7 +10,7 @@ import (
 
 	gops "github.com/google/gops/agent"
 
-	"github.com/cilium/cilium-cli/internal/cli/cmd"
+	"github.com/cilium/cilium-cli/cli"
 	_ "github.com/cilium/cilium-cli/internal/logging" // necessary to disable unwanted cfssl log messages
 )
 
@@ -19,7 +19,7 @@ func main() {
 		log.Printf("Unable to start gops: %s", err)
 	}
 
-	if err := cmd.NewDefaultCiliumCommand().Execute(); err != nil {
+	if err := cli.NewDefaultCiliumCommand().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -239,6 +239,22 @@ func (ct *ConnectivityTest) NewTest(name string) *Test {
 	return t
 }
 
+// GetTest returns the test scope for test named "name" if found,
+// a non-nil error otherwise.
+func (ct *ConnectivityTest) GetTest(name string) (*Test, error) {
+	if _, ok := ct.testNames[name]; !ok {
+		return nil, fmt.Errorf("test %s not found", name)
+	}
+
+	for _, t := range ct.tests {
+		if t.name == name {
+			return t, nil
+		}
+	}
+
+	panic("missing test descriptor for a registered name")
+}
+
 // SetupAndValidate sets up and validates the connectivity test infrastructure
 // such as the client pods and validates the deployment of them along with
 // Cilium. This must be run before Run() is called.

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -831,3 +831,7 @@ func (ct *ConnectivityTest) Feature(f Feature) (FeatureStatus, bool) {
 	s, ok := ct.features[f]
 	return s, ok
 }
+
+func (ct *ConnectivityTest) Clients() []*k8s.Client {
+	return ct.clients.clients()
+}

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -583,6 +583,12 @@ func (t *Test) WithSetupFunc(f SetupFunc) *Test {
 	return t
 }
 
+// WithFinalizer registers a finalizer to be executed when Run() returns.
+func (t *Test) WithFinalizer(f func() error) *Test {
+	t.finalizers = append(t.finalizers, f)
+	return t
+}
+
 // NewAction creates a new Action. s must be the Scenario the Action is created
 // for, name should be a visually-distinguishable name, src is the execution
 // Pod of the action, and dst is the network target the Action will connect to.

--- a/connectivity/manifests/template/template.go
+++ b/connectivity/manifests/template/template.go
@@ -1,12 +1,15 @@
-package utils
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package template
 
 import (
 	"bytes"
-	"text/template"
+	"html/template"
 )
 
-// RenderTemplate executes temp with data and returns the result
-func RenderTemplate(temp string, data any) (string, error) {
+// Render executes temp template with data and returns the result
+func Render(temp string, data any) (string, error) {
 	tm, err := template.New("template").Parse(temp)
 	if err != nil {
 		return "", err

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -164,7 +164,7 @@ var (
 	client2Label = map[string]string{"name": "client2"}
 )
 
-func Run(ctx context.Context, ct *check.ConnectivityTest) error {
+func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*check.ConnectivityTest) error) error {
 	if err := ct.SetupAndValidate(ctx); err != nil {
 		return err
 	}
@@ -988,6 +988,10 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 
 	// Tests with DNS redirects to the proxy (e.g., client-egress-l7, dns-only,
 	// and to-fqdns) should always be executed last. See #367 for details.
+
+	if err := addExtraTests(ct); err != nil {
+		return err
+	}
 
 	return ct.Run(ctx)
 }

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -12,8 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/manifests/template"
 	"github.com/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium-cli/internal/utils"
 )
 
 var (
@@ -183,7 +183,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 		"clientEgressL7HTTPMatchheaderSecretYAML":  clientEgressL7HTTPMatchheaderSecretYAML,
 		"echoIngressFromCIDRYAML":                  echoIngressFromCIDRYAML,
 	} {
-		val, err := utils.RenderTemplate(temp, ct.Params())
+		val, err := template.Render(temp, ct.Params())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -20,7 +20,7 @@ var (
 	k8sClient *k8s.Client
 )
 
-func NewDefaultCiliumCommand() *cobra.Command {
+func NewCiliumCommand(hooks Hooks) *cobra.Command {
 	cmd := &cobra.Command{
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// return early for commands that don't require the kubernetes client
@@ -73,11 +73,11 @@ cilium connectivity test`,
 		newCmdBgp(),
 		newCmdClusterMesh(),
 		newCmdConfig(),
-		newCmdConnectivity(),
+		newCmdConnectivity(hooks),
 		newCmdContext(),
 		newCmdHubble(),
 		newCmdStatus(),
-		newCmdSysdump(),
+		newCmdSysdump(hooks),
 		newCmdVersion(),
 	)
 	if utils.IsInHelmMode() {

--- a/internal/cli/cmd/hooks.go
+++ b/internal/cli/cmd/hooks.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/sysdump"
+)
+
+// Hooks to extend the default cilium-cli command with additional functionality.
+type Hooks interface {
+	ConnectivityTestHooks
+	SysdumpHooks
+}
+
+// ConnectivityTestHooks to extend cilium-cli with additional connectivity tests and related flags.
+type ConnectivityTestHooks interface {
+	AddConnectivityTestFlags(flags *pflag.FlagSet)
+	AddConnectivityTests(ct *check.ConnectivityTest) error
+}
+
+// SysdumpHooks to extend cilium-cli with additional sysdump tasks and related flags.
+type SysdumpHooks interface {
+	AddSysdumpFlags(flags *pflag.FlagSet)
+	AddSysdumpTasks(*sysdump.Collector) error
+}


### PR DESCRIPTION
This allows building a version of cilium-cli externally with extended connectivity tests and sysdump tasks.