### PR TITLE
.github/workflows: add missing GH action version annotations

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload junit output
         if: ${{ always() }}
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: connectivity-${{ matrix.mode }}.xml
           path: connectivity-${{ matrix.mode }}.xml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload junit output
         if: ${{ always() }}
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: connectivity-ipsec-${{ matrix.mode }}.xml
           path: connectivity-ipsec-${{ matrix.mode }}.xml
@@ -356,10 +356,10 @@ jobs:
         run: |
           cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2 --debug \
           --collect-sysdump-on-failure --junit-file connectivity-clustermesh.xml
-      
+
       - name: Upload junit output
         if: ${{ always() }}
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: connectivity-clustermesh.xml
           path: connectivity-clustermesh.xml


### PR DESCRIPTION
Follow commit b13b994e7535 (".github/workflows: add GH action version annotations") and also add the version annotations to the workflow steps added by commit eefbd2840e9b ("connectivity test: add junit output"). This is needed so that renovate will follow action version tags while still using digest pinning, see https://docs.renovatebot.com/modules/manager/github-actions/