### PR TITLE
unit test: Restore the original env variable using defer

### DIFF
--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -208,11 +208,13 @@ func TestBuildImagePath(t *testing.T) {
 
 func TestIsInHelmMode(t *testing.T) {
 	orig := os.Getenv(CLIModeVariableName)
+	defer func() {
+		assert.NoError(t, os.Setenv(CLIModeVariableName, orig))
+	}()
 	assert.NoError(t, os.Setenv(CLIModeVariableName, "helm"))
 	assert.True(t, IsInHelmMode())
 	assert.NoError(t, os.Setenv(CLIModeVariableName, "classic"))
 	assert.False(t, IsInHelmMode())
 	assert.NoError(t, os.Setenv(CLIModeVariableName, "random"))
 	assert.False(t, IsInHelmMode())
-	assert.NoError(t, os.Setenv(CLIModeVariableName, orig))
 }


### PR DESCRIPTION
Fixes: 840b570e4515 ("Add a function to check if the CLI is in Helm mode")