### PR TITLE
renovate: schedule Go module updates once a week

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,7 +71,10 @@
       ],
       matchBaseBranches: [
         "main"
-      ]
+      ],
+      "schedule": [
+        "on friday"
+      ],
     },
     {
       "enabled": false,


### PR DESCRIPTION
Otherwise a renovate PR will get created upon every change on the main branch for the dependencies that are not versioned.