### PR TITLE
uninstall: allow ciliumVersion to start with "v"

### DIFF
--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -50,7 +50,7 @@ func NewK8sUninstaller(client k8sInstallerImplementation, p UninstallParameters)
 	if err != nil {
 		uninstaller.Log("Error getting Cilium Version: %s", err)
 	}
-	version, err := semver.Parse(ciliumVersion)
+	version, err := semver.ParseTolerant(ciliumVersion)
 	if err != nil {
 		uninstaller.Log("Error parsing Cilium Version: %s", err)
 	} else {


### PR DESCRIPTION
Without this change, a helm-installed Cilium uninstall will print

    Error parsing Cilium Version: Invalid character(s) found in major number "v1"

failing to autodetect the current Cilium version