### PR TITLE
helm mode: add implementation for clustermesh connect

### DIFF
--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -27,7 +27,6 @@ func newCmdClusterMesh() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newCmdClusterMeshConnect(),
 		newCmdClusterMeshDisconnect(),
 		newCmdClusterMeshStatus(),
 		newCmdClusterMeshExternalWorkload(),
@@ -35,11 +34,13 @@ func newCmdClusterMesh() *cobra.Command {
 
 	if utils.IsInHelmMode() {
 		cmd.AddCommand(
+			newCmdClusterMeshConnectWithHelm(),
 			newCmdClusterMeshEnableWithHelm(),
 			newCmdClusterMeshDisableWithHelm(),
 		)
 	} else {
 		cmd.AddCommand(
+			newCmdClusterMeshConnect(),
 			newCmdClusterMeshEnable(),
 			newCmdClusterMeshDisable(),
 		)
@@ -120,9 +121,7 @@ func newCmdClusterMeshConnect() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
-	cmd.Flags().StringSliceVar(&params.DestinationEndpoints, "destination-endpoint", []string{}, "IP of ClusterMesh service of destination cluster")
-	cmd.Flags().StringSliceVar(&params.SourceEndpoints, "source-endpoint", []string{}, "IP of ClusterMesh service of source cluster")
+	addCommonConnectFlags(cmd, &params)
 
 	return cmd
 }
@@ -393,4 +392,34 @@ func newCmdClusterMeshDisableWithHelm() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func newCmdClusterMeshConnectWithHelm() *cobra.Command {
+	var params = clustermesh.Parameters{
+		Writer: os.Stdout,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "connect",
+		Short: "Connect to a remote cluster",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params.Namespace = namespace
+			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
+			if err := cm.ConnectWithHelm(context.Background()); err != nil {
+				fatalf("Unable to connect cluster: %s", err)
+			}
+			return nil
+		},
+	}
+
+	addCommonConnectFlags(cmd, &params)
+
+	return cmd
+}
+
+func addCommonConnectFlags(cmd *cobra.Command, params *clustermesh.Parameters) {
+	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
+	cmd.Flags().StringSliceVar(&params.DestinationEndpoints, "destination-endpoint", []string{}, "IP of ClusterMesh service of destination cluster")
+	cmd.Flags().StringSliceVar(&params.SourceEndpoints, "source-endpoint", []string{}, "IP of ClusterMesh service of source cluster")
 }


### PR DESCRIPTION
Add an implementation for `clustermesh connect` using Helm.

Like the classic mode implementation, we autodetect the `clustermesh-apiserver` IPs and port numbers in order to write the `endpoints:` configuration. However, rather than generate the certificates in-process, we rely on the `cronJob` (certgen) mode of the Helm chart to generate (and re-generate) all of the ClusterMesh related certs.

As a first pass, we support the same set of flags as the classic mode.

A second pass PR will include all `--helm-*` flags, which will allow the use of `extraDnsNames` for the purpose of Service resolvability, and the use of other PKI modes.

Fixes: #1620 