### PR TITLE
connectivity: Skip IPv6 requests in north-south-loadbalancing-with-l7-policy when running on < 1.14.0 Cilium

### DIFF
--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -655,3 +655,11 @@ func (t *Test) ForEachIPFamily(do func(IPFamily)) {
 func (t *Test) CertificateCAs() map[string][]byte {
 	return t.certificateCAs
 }
+
+func (t *Test) CiliumNetworkPolicies() map[string]*ciliumv2.CiliumNetworkPolicy {
+	return t.cnps
+}
+
+func (t *Test) KubernetesNetworkPolicies() map[string]*networkingv1.NetworkPolicy {
+	return t.knps
+}


### PR DESCRIPTION
https://github.com/cilium/cilium/issues/21954 for the IPv6 path was resolved only for v1.14, but not for v1.13. In order to be able to run the latest connectivity tests on v1.13, we need to skip curl requests to the IPv6 addresses in that particular test.

Fixes: #1627

Signed-off-by: Zhichuan Liang <gray.isovalent.com>