### PR TITLE
sysdump: Don't save cilium-etcd-secrets

### DIFF
--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -20,7 +20,6 @@ import (
 	"github.com/mholt/archiver/v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -626,33 +625,18 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
-			Description: "Collecting Cilium etcd secret",
+			Description: fmt.Sprintf("Checking if %s exists in %s namespace", ciliumEtcdSecretsSecretName, c.Options.CiliumNamespace),
 			Quick:       true,
 			Task: func(ctx context.Context) error {
-				v, err := c.Client.GetSecret(ctx, c.Options.CiliumNamespace, ciliumEtcdSecretsSecretName, metav1.GetOptions{})
+				_, err := c.Client.GetSecret(ctx, c.Options.CiliumNamespace, ciliumEtcdSecretsSecretName, metav1.GetOptions{})
 				if err != nil {
 					if errors.IsNotFound(err) {
-						c.logDebug("Secret %q not found in namespace %q - this is expected when using the CRD KVStore", ciliumEtcdSecretsSecretName, c.Options.CiliumNamespace)
+						c.log("Secret %q not found in namespace %q - this is expected when using the CRD KVStore", ciliumEtcdSecretsSecretName, c.Options.CiliumNamespace)
 						return nil
 					}
 					return fmt.Errorf("failed to collect Cilium etcd secret: %w", err)
 				}
-				// Redact the actual values.
-				for k := range v.Data {
-					v.Data[k] = []byte(redacted)
-				}
-				accessor, err := meta.Accessor(v)
-				if err != nil {
-					return fmt.Errorf("failed to collect Cilium etcd secret: %w", err)
-				}
-				var annotations = accessor.GetAnnotations()
-				if annotations != nil {
-					delete(annotations, corev1.LastAppliedConfigAnnotation)
-					accessor.SetAnnotations(annotations)
-				}
-				if err := c.WriteYAML(ciliumEtcdSecretFileName, v); err != nil {
-					return fmt.Errorf("failed to collect Cilium etcd secret: %w", err)
-				}
+				c.log("Secret %q found in namespace %q", ciliumEtcdSecretsSecretName, c.Options.CiliumNamespace)
 				return nil
 			},
 		},


### PR DESCRIPTION
Redacting sensitive info is error prone. For example, there was a bug that recently got fixed in #1631 where the cilium-cli wasn't redacting fields in last-applied-configuration.

The purpose of this check is to indicate whether cilium-etcd-secrets exists, so let's just do that without actually storing the secret in sysdump. With this change, there will be a line in cilium-sysdump.log.

If the secret exists:

    % grep cilium-etcd-secrets cilium-sysdump.log
    🔍 Checking if cilium-etcd-secrets exists in kube-system namespace
    Secret "cilium-etcd-secrets" found in namespace "kube-system"

If the secret does not exist:

    % grep cilium-etcd-secrets cilium-sysdump.log
    🔍 Checking if cilium-etcd-secrets exists in kube-system namespace
    Secret "cilium-etcd-secrets" not found in namespace "kube-system" - this is expected when using the CRD KVStore