### PR TITLE
upgrade: Check for error before accessing release

### DIFF
--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -190,6 +190,9 @@ func (k *K8sInstaller) UpgradeWithHelm(ctx context.Context, k8sClient genericcli
 		DryRunHelmValues: k.params.DryRunHelmValues,
 	}
 	release, err := helm.Upgrade(ctx, k8sClient, upgradeParams)
+	if err != nil {
+		return err
+	}
 
 	if k.params.DryRun {
 		fmt.Println(release.Manifest)


### PR DESCRIPTION
release is nil if helm.Upgrade() failed.