### PR TITLE
cli: Export Version var to be set externally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 $(TARGET):
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
 		-ldflags "-w -s \
-		-X 'github.com/cilium/cilium-cli/internal/cli/cmd.Version=${VERSION}'" \
+		-X 'github.com/cilium/cilium-cli/cli.Version=${VERSION}'" \
 		-o $(TARGET) \
 		./cmd/cilium
 
@@ -54,7 +54,7 @@ local-release: clean
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
 			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
-				-ldflags "-w -s -X 'github.com/cilium/cilium-cli/internal/cli/cmd.Version=${VERSION}'" \
+				-ldflags "-w -s -X 'github.com/cilium/cilium-cli/cli.Version=${VERSION}'" \
 				-o release/$$OS/$$ARCH/$(TARGET)$$EXT ./cmd/cilium; \
 			tar -czf release/$(TARGET)-$$OS-$$ARCH.tar.gz -C release/$$OS/$$ARCH $(TARGET)$$EXT; \
 			(cd release && sha256sum $(TARGET)-$$OS-$$ARCH.tar.gz > $(TARGET)-$$OS-$$ARCH.tar.gz.sha256sum); \

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -12,6 +12,12 @@ import (
 	"github.com/cilium/cilium-cli/sysdump"
 )
 
+// The following variables are set at compile time via LDFLAGS.
+var (
+	// Version is the software version.
+	Version string
+)
+
 // NewDefaultCiliumCommand returns a new "cilium" cli cobra command without any additional hooks.
 func NewDefaultCiliumCommand() *cobra.Command {
 	return NewCiliumCommand(&NopHooks{})
@@ -19,6 +25,7 @@ func NewDefaultCiliumCommand() *cobra.Command {
 
 // NewCiliumCommand returns a new "cilium" cli cobra command registering all the additional input hooks.
 func NewCiliumCommand(hooks Hooks) *cobra.Command {
+	cmd.SetVersion(Version)
 	return cmd.NewCiliumCommand(hooks)
 }
 

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -18,7 +18,15 @@ var (
 	namespace   string
 
 	k8sClient *k8s.Client
+
+	// version is the version string of the cilium-cli itself
+	version string
 )
+
+// SetVersion sets the version string for the cilium command
+func SetVersion(v string) {
+	version = v
+}
 
 func NewCiliumCommand(hooks Hooks) *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -71,7 +71,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 			}
 
 			// Instantiate the test harness.
-			cc, err := check.NewConnectivityTest(k8sClient, params, Version)
+			cc, err := check.NewConnectivityTest(k8sClient, params, version)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -144,7 +144,7 @@ func newCmdUninstall() *cobra.Command {
 				TestNamespace:   params.TestNamespace,
 				FlowValidation:  check.FlowValidationModeDisabled,
 				Writer:          os.Stdout,
-			}, Version)
+			}, version)
 			if err != nil {
 				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s", err)
 			} else {
@@ -311,7 +311,7 @@ func newCmdUninstallWithHelm() *cobra.Command {
 				TestNamespace:   params.TestNamespace,
 				FlowValidation:  check.FlowValidationModeDisabled,
 				Writer:          os.Stdout,
-			}, Version)
+			}, version)
 			if err != nil {
 				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s", err)
 			} else {

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -36,7 +36,7 @@ func newCmdSysdump(hooks SysdumpHooks) *cobra.Command {
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)
 			// Collect the sysdump.
-			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now(), Version)
+			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now(), version)
 			if err != nil {
 				return fmt.Errorf("failed to create sysdump collector: %w", err)
 			}

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -16,12 +16,6 @@ import (
 	"github.com/cilium/cilium-cli/defaults"
 )
 
-// The following variables are set at compile time via LDFLAGS.
-var (
-	// Version is the software version.
-	Version string
-)
-
 func getLatestStableVersion() string {
 	resp, err := http.Get("https://raw.githubusercontent.com/cilium/cilium/main/stable.txt")
 	if err != nil {
@@ -44,7 +38,7 @@ func newCmdVersion() *cobra.Command {
 		Short: "Display detailed version information",
 		Long:  `Displays information about the version of this software.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("cilium-cli: %s compiled with %v on %v/%v\n", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("cilium-cli: %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 			fmt.Printf("cilium image (default): %s\n", defaults.Version)
 			fmt.Printf("cilium image (stable): %s\n", getLatestStableVersion())
 			if clientOnly {


### PR DESCRIPTION
When building an extended version of cilium-cli with hooks, it is not possible to set Version var with -ldflags because it is located in an internal package.

This commit exports the Version var in the cli package to allow setting it both here and in the extended cilium-cli binaries.