### PR TITLE
ci: fix gke network starvation

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -120,6 +120,9 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --enable-ip-alias \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -100,7 +100,9 @@ jobs:
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -110,7 +110,9 @@ jobs:
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
@@ -134,7 +136,9 @@ jobs:
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \


### PR DESCRIPTION
The `cilium`, and `cilium-cli` use the same GCP project for provisioning GKE clusters.

If the number of simultaneously provisioned clusters is high enough we get an error like below,
```
The network "default" does not have available private IP space in 10.0.0.0/9 to reserve a /14 block for pods for cluster {Zone=us-west2-a, ProjectNum=185287498374, ProjectName=*** ....
```
With current defaults, which are below, the number of clusters that can be provisioned simultaneously is around 31.
- subnetwork (used by nodes) : /22 
- pod cidr :  /14
- service cidr : /20

The current default network ranges are too big for our use cases, per cluster only 2 nodes are provisioned.
The max pods created is 29, and the max services created is 9 

In accordance with network range requirements, the changes below have been made. 
- subnetwork : /26  **it is not used in externalworkloads** 
- pod cidr :  /21 **this is the max allowed range**
- service cidr : /24

With these changes, the number of clusters that can be provisioned simultaneously is more than 3500. 

Note: These changes have already been merged to `cilium` with a recent [PR](https://github.com/cilium/cilium/pull/25597)

Successful run links are below,

[externalworkloads.yaml](https://github.com/cilium/cilium-cli/actions/runs/5065158797?pr=1654)

[gke.yaml](https://github.com/cilium/cilium-cli/actions/runs/5065158803?pr=1654) 

[multicluster.yaml](https://github.com/cilium/cilium-cli/actions/runs/5065158799?pr=1654)