### PR TITLE
check: update tunneling detection logic

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -196,13 +196,24 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 		Mode:    mode,
 	}
 
-	mode = "disabled"
-	if v, ok := cm.Data["tunnel"]; ok {
-		mode = v
-	}
-	result[FeatureTunnel] = FeatureStatus{
-		Enabled: mode != "disabled",
-		Mode:    mode,
+	if versioncheck.MustCompile("<1.14.0")(ct.CiliumVersion) {
+		mode = "disabled"
+		if v, ok := cm.Data["tunnel"]; ok {
+			mode = v
+		}
+		result[FeatureTunnel] = FeatureStatus{
+			Enabled: mode != "disabled",
+			Mode:    mode,
+		}
+	} else {
+		mode = "native"
+		if v, ok := cm.Data["routing-mode"]; ok {
+			mode = v
+		}
+		result[FeatureTunnel] = FeatureStatus{
+			Enabled: mode != "native",
+			Mode:    mode,
+		}
 	}
 
 	result[FeatureIPv4] = FeatureStatus{


### PR DESCRIPTION
make the feature detection logic compatible with the new flag introduced in v1.14 in [1]

[1] https://github.com/cilium/cilium/pull/24561

Towards: https://github.com/cilium/cilium/issues/24151