### PR TITLE
connectivity: add property flag for junit

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -102,7 +102,8 @@ jobs:
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
           cilium connectivity test --debug --all-flows --test-namespace test-namespace \
             --include-unsafe-tests \
-            --collect-sysdump-on-failure --junit-file connectivity-${{ matrix.mode }}.xml
+            --collect-sysdump-on-failure --junit-file connectivity-${{ matrix.mode }}.xml \
+            --junit-property mode=${{ matrix.mode }}
 
       - name: Upload junit output
         if: ${{ always() }}
@@ -153,7 +154,8 @@ jobs:
         run: |
           cilium connectivity test --debug --force-deploy --all-flows --test-namespace test-namespace \
             --include-unsafe-tests \
-            --collect-sysdump-on-failure --junit-file connectivity-ipsec-${{ matrix.mode }}.xml
+            --collect-sysdump-on-failure --junit-file connectivity-ipsec-${{ matrix.mode }}.xml \
+            --junit-property mode=${{ matrix.mode }}
 
       - name: Upload junit output
         if: ${{ always() }}
@@ -304,7 +306,8 @@ jobs:
         run: |
           cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2 --debug \
             --include-unsafe-tests \
-            --collect-sysdump-on-failure --junit-file connectivity-clustermesh.xml
+            --collect-sysdump-on-failure --junit-file connectivity-clustermesh.xml \
+            --junit-property mode=clustermesh
 
       - name: Upload junit output
         if: ${{ always() }}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -58,6 +58,7 @@ type Parameters struct {
 	PodCIDRs              []podCIDRs
 	NodesWithoutCiliumIPs []nodesWithoutCiliumIP
 	JunitFile             string
+	JunitProperties       map[string]string
 
 	K8sVersion           string
 	HelmChartDirectory   string

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -399,14 +399,19 @@ func (ct *ConnectivityTest) writeJunit() error {
 		return nil
 	}
 
+	properties := []junit.Property{
+		{Name: "Args", Value: strings.Join(os.Args[3:], "|")},
+	}
+	for key, val := range ct.Params().JunitProperties {
+		properties = append(properties, junit.Property{Name: key, Value: val})
+	}
+
 	suite := &junit.TestSuite{
 		Name:    "connectivity test",
 		Package: "cilium",
 		Tests:   len(ct.tests),
 		Properties: &junit.Properties{
-			Properties: []junit.Property{
-				{Name: "Args", Value: strings.Join(os.Args[3:], "|")},
-			},
+			Properties: properties,
 		},
 	}
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -134,6 +134,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ExternalIP, "external-ip", "1.1.1.1", "IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
+	cmd.Flags().StringToStringVar(&params.JunitProperties, "junit-property", map[string]string{}, "Add key=value properties to the generated junit file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster nodes state")


### PR DESCRIPTION
These changes add a new key=value flag `--junit-property`
Provided key value pairs will be added to the generated junit file.

Properties will be required to distinguish junit test names in `cilium` connectivity test reporting.
The new flag is added to the kind test.