### PR TITLE
Makefile: bump Go to v1.20.4 for release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /cilium \
-		--volume `pwd`:/cilium docker.io/library/golang:1.20.2-alpine3.17 \
+		--volume `pwd`:/cilium docker.io/library/golang:1.20.4-alpine3.17@sha256:913de96707b0460bcfdfe422796bb6e559fc300f6c53286777805a9a3010a5ea \
 		sh -c "apk add --no-cache setpriv make git && \
 			/usr/bin/setpriv --reuid=$(RELEASE_UID) --regid=$(RELEASE_GID) --clear-groups make GOCACHE=/tmp/gocache local-release"
 


### PR DESCRIPTION
This is currently not covered by renovate. Let's bump it manually for now and also add the correct SHA while at it.