### PR TITLE
renovate: add renovate/stop-updating label on renovate's PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,7 @@
     "enabled": true
   },
   "labels": [
+    "renovate/stop-updating",
     "kind/enhancement",
     "priority/release-blocker"
   ],


### PR DESCRIPTION
When renovate opens a PR, it will keep updating the dependencies as long as the PR is open. This makes it difficult have a green CI run since some dependencies are being updated frequently and we aren't able to merge the PR. Thus, add this label to prevent renovate from updating PRs after opening them.

Same as https://github.com/cilium/cilium/pull/25649