### PR TITLE
connectivity/check: pass metrics to metricsIncrease by pointer

### DIFF
--- a/connectivity/check/metrics.go
+++ b/connectivity/check/metrics.go
@@ -112,7 +112,7 @@ func parseMetrics(reader io.Reader) (promMetricsFamily, error) {
 }
 
 // metricsIncrease verifies for all the metrics that the values increased.
-func metricsIncrease(mf1, mf2 dto.MetricFamily) error {
+func metricsIncrease(mf1, mf2 *dto.MetricFamily) error {
 	metrics1 := mf1.GetMetric()
 	metrics2 := mf2.GetMetric()
 

--- a/connectivity/check/metrics_test.go
+++ b/connectivity/check/metrics_test.go
@@ -122,7 +122,7 @@ func TestMetricsIncrease(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			err := metricsIncrease(tc.before, tc.after)
+			err := metricsIncrease(&tc.before, &tc.after)
 			if tc.err {
 				assert.Error(t, err)
 			} else {

--- a/connectivity/check/result.go
+++ b/connectivity/check/result.go
@@ -179,7 +179,7 @@ func assertMetricsIncrease(metrics ...string) assertMetricsFunc {
 
 			// Additional check needed because previously we do not return in case of error, otherwise we will panic!
 			if bValue != nil && aValue != nil {
-				errM := metricsIncrease(*bValue, *aValue)
+				errM := metricsIncrease(bValue, aValue)
 				if errM != nil {
 					err = errors.Join(err, errM)
 				}


### PR DESCRIPTION
To avoid copying this potentially large type and also work around the following erroneous govet warning:

> copylocks: metricsIncrease passes lock by value: github.com/prometheus/client_model/go.MetricFamily contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)

Ref. https://github.com/cilium/cilium-cli/actions/runs/5087191687?pr=1661