### PR TITLE
sysdump: refactor submitTetragonBugtoolTasks to take defaults as parameters

### DIFF
--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -183,10 +183,3 @@ var (
 		Version:  "v1alpha2",
 	}
 )
-
-var (
-	tetragonAgentContainerName = "tetragon"
-	tetragonBugtoolPrefix      = "tetragon-bugtool"
-	tetragonCliCommand         = "tetra"
-	tetragonTracingPolicy      = "tetragontracingpolicy-<ts>.yaml"
-)

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -47,6 +47,10 @@ const (
 	DefaultCNIConfigMapName                  = "cni-configuration"
 	DefaultTetragonNamespace                 = "kube-system"
 	DefaultTetragonLabelSelector             = "app.kubernetes.io/name=tetragon"
+	DefaultTetragonAgentContainerName        = "tetragon"
+	DefaultTetragonBugtoolPrefix             = "tetragon-bugtool"
+	DefaultTetragonCLICommand                = "tetra"
+	DefaultTetragonTracingPolicy             = "tetragontracingpolicy-<ts>.yaml"
 )
 
 var (


### PR DESCRIPTION
Let submitTetragonBugtoolTasks take these values as parameters rather than from global vars. This e.g. allows to override them based on command line options in a future change.