### PR TITLE
Makefile: fix golangci-lint renovate datasource annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RELEASE_UID ?= $(shell id -u)
 RELEASE_GID ?= $(shell id -g)
 
 # renovate: datasource=docker depName=golangci/golangci-lint
-GOLANGCILINT_WANT_VERSION = 1.52.2
+GOLANGCILINT_WANT_VERSION = v1.52.2
 GOLANGCILINT_IMAGE_SHA = sha256:3d2f4240905054c7efa7f4e98ba145c12a16995bbc3e605300e21400a1665cb6
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
@@ -83,12 +83,12 @@ tags: $$($(GO) list ./...)
 	@ctags $<
 	cscope -R -b -q
 
-ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION),$(GOLANGCILINT_VERSION)))
+ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION:v%=%),$(GOLANGCILINT_VERSION)))
 check:
 	golangci-lint run
 else
 check:
-	docker run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:v$(GOLANGCILINT_WANT_VERSION) golangci-lint run
+	docker run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION) golangci-lint run
 endif
 
 .PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags


### PR DESCRIPTION
This fixes the following error reported in #1599

> Renovate failed to look up the following dependencies: Could not
> determine new digest for update (datasource: docker).
> Files affected: Makefile