### PR TITLE
connectivity/check: store metrics by pointer in TestMetricsIncrease

### DIFF
--- a/connectivity/check/metrics_test.go
+++ b/connectivity/check/metrics_test.go
@@ -99,30 +99,30 @@ func TestMetricsIncrease(t *testing.T) {
 	}
 
 	tt := map[string]struct {
-		before dto.MetricFamily
-		after  dto.MetricFamily
+		before *dto.MetricFamily
+		after  *dto.MetricFamily
 		err    bool
 	}{
 		"metric increases": {
-			before: ciliumForwardCountTotalBefore,
-			after:  ciliumForwardCountTotalAfter,
+			before: &ciliumForwardCountTotalBefore,
+			after:  &ciliumForwardCountTotalAfter,
 			err:    false,
 		},
 		"metrics are equals": {
-			before: ciliumForwardCountTotalBefore,
-			after:  ciliumForwardCountTotalBefore,
+			before: &ciliumForwardCountTotalBefore,
+			after:  &ciliumForwardCountTotalBefore,
 			err:    true,
 		},
 		"metric decreases": {
-			before: ciliumForwardCountTotalAfter,
-			after:  ciliumForwardCountTotalBefore,
+			before: &ciliumForwardCountTotalAfter,
+			after:  &ciliumForwardCountTotalBefore,
 			err:    true,
 		},
 	}
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			err := metricsIncrease(&tc.before, &tc.after)
+			err := metricsIncrease(tc.before, tc.after)
 			if tc.err {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
Avoid the following erroneous govet warning:

> copylocks: literal copies lock value from ciliumForwardCountTotalBefore: github.com/prometheus/client_model/go.MetricFamily contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)

Ref. https://github.com/cilium/cilium-cli/pull/1661/files#annotation_11568423750