### PR TITLE
CI: Change multicluster provisioning to none blocking mode

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -119,16 +119,8 @@ jobs:
             --disk-type pd-standard \
             --disk-size 10GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
-            --preemptible
-
-      - name: Get cluster 2 credentials
-        run: |
-          gcloud container clusters get-credentials ${{ env.clusterName2 }} --zone ${{ env.zone }}
-
-      - name: Create gcloud-free kubeconfig for cluster 2
-        run: |
-          .github/get-kubeconfig.sh
-          mv kubeconfig kubeconfig-cluster2
+            --preemptible \
+            --async
 
       - name: Create GKE cluster 1
         run: |
@@ -145,7 +137,23 @@ jobs:
             --disk-type pd-standard \
             --disk-size 10GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
-            --preemptible
+            --preemptible \
+            --async
+
+      - name: Wait for clusters to be provisioned
+        run: |
+          while [ "$(gcloud container operations list --filter="status=RUNNING AND targetLink~${{ env.clusterNameBase }}" --format="value(name)")" ];do
+            echo "cluster has an ongoing operation, waiting for all operations to finish"; sleep 10
+          done
+
+      - name: Get cluster 2 credentials
+        run: |
+          gcloud container clusters get-credentials ${{ env.clusterName2 }} --zone ${{ env.zone }}
+
+      - name: Create gcloud-free kubeconfig for cluster 2
+        run: |
+          .github/get-kubeconfig.sh
+          mv kubeconfig kubeconfig-cluster2
 
       - name: Get cluster 1 credentials
         run: |


### PR DESCRIPTION
The multicluster test set up two clusters in blocking mode sequentially. Every cluster provisioning takes 4 to 5 min.
This commit changes provisioning to none blocking mode and adds a step to wait for provisioning to finish.

This change would cut the run time by 4 to 5 min.

The [link](https://github.com/cilium/cilium-cli/actions/runs/5133451203) to the run, one failed and successful
but both of the installation steps are successful, which is what counts here.