### PR TITLE
sysdump: gather tetragon namespaced policies

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -1101,3 +1101,7 @@ func (c *Client) CreateEphemeralContainer(ctx context.Context, pod *corev1.Pod, 
 func (c *Client) ListTetragonTracingPolicies(ctx context.Context, opts metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyList, error) {
 	return c.TetragonClientset.CiliumV1alpha1().TracingPolicies().List(ctx, opts)
 }
+
+func (c *Client) ListTetragonTracingPoliciesNamespaced(ctx context.Context, namespace string, opts metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyNamespacedList, error) {
+	return c.TetragonClientset.CiliumV1alpha1().TracingPoliciesNamespaced(namespace).List(ctx, opts)
+}

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -56,6 +56,7 @@ type KubernetesClient interface {
 	ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeList, error)
 	ListCiliumNodeConfigs(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumNodeConfigList, error)
 	ListTetragonTracingPolicies(ctx context.Context, opts metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyList, error)
+	ListTetragonTracingPoliciesNamespaced(ctx context.Context, namespace string, opts metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyNamespacedList, error)
 	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
 	ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error)
 	ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error)

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -51,6 +51,7 @@ const (
 	DefaultTetragonBugtoolPrefix             = "tetragon-bugtool"
 	DefaultTetragonCLICommand                = "tetra"
 	DefaultTetragonTracingPolicy             = "tetragontracingpolicy-<ts>.yaml"
+	DefaultTetragonTracingPolicyNamespaced   = "tetragontracingpolicynamespaced-<ts>.yaml"
 )
 
 var (

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -1152,6 +1152,14 @@ func (c *Collector) Run() error {
 				if err := c.WriteYAML(DefaultTetragonTracingPolicy, v); err != nil {
 					return fmt.Errorf("failed to collect Tetragon tracing policies: %w", err)
 				}
+
+				vn, err := c.Client.ListTetragonTracingPoliciesNamespaced(ctx, corev1.NamespaceAll, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect Tetragon namespaced tracing policies: %w", err)
+				}
+				if err := c.WriteYAML(DefaultTetragonTracingPolicyNamespaced, vn); err != nil {
+					return fmt.Errorf("failed to collect Tetragon tracing policies: %w", err)
+				}
 				return nil
 			},
 		},

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -521,3 +521,16 @@ func (c *fakeClient) GetNamespace(_ context.Context, ns string, _ metav1.GetOpti
 		},
 	}
 }
+
+func (c *fakeClient) ListTetragonTracingPoliciesNamespaced(_ context.Context, _ string, _ metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyNamespacedList, error) {
+	ret := tetragonv1alpha1.TracingPolicyNamespacedList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{},
+		Items:    []tetragonv1alpha1.TracingPolicyNamespaced{},
+	}
+
+	return &ret, nil
+}


### PR DESCRIPTION
Recently, tetragon added namespaced tracing policies (TracingPolicyNamespaced). Collect this as well.

Tested manually on a kind cluster.