### PR TITLE
Do not call utils.CheckVersion() in Helm mode

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -418,7 +418,10 @@ func (p *Parameters) validate() error {
 
 		p.configOverwrites[t[0]] = t[1]
 	}
-	if p.AgentImage != "" || p.OperatorImage != "" || p.RelayImage != "" {
+	if utils.IsInHelmMode() {
+		// Version validation logic does not apply to Helm mode.
+		return nil
+	} else if p.AgentImage != "" || p.OperatorImage != "" || p.RelayImage != "" {
 		return nil
 	} else if err := utils.CheckVersion(p.Version); err != nil {
 		return err

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium-cli/clustermesh"
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/k8s"
 )
 
@@ -46,6 +47,12 @@ func NewK8sUninstaller(client k8sInstallerImplementation, p UninstallParameters)
 		client: client,
 		params: p,
 	}
+
+	// Version detection / validation is unnecessary in Helm mode.
+	if utils.IsInHelmMode() {
+		return uninstaller
+	}
+
 	ciliumVersion, err := client.GetRunningCiliumVersion(context.Background(), p.Namespace)
 	if err != nil {
 		uninstaller.Log("Error getting Cilium Version: %s", err)


### PR DESCRIPTION
2 commits for helm mode:

- for `uninstall`, cilium-cli does not need to know the running cilium version since it simply runs `helm uninstall`.
- for `install`, `--version` specifies the Helm chart version. cilium-cli succeeds or fails depending on whether the specified version either exists or it doesn't. there is no need to perform additional version format check.