### PR TITLE
status: Print Helm chart version in Helm mode

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -536,3 +536,27 @@ func Upgrade(
 
 	return helmClient.RunWithContext(ctx, defaults.HelmReleaseName, params.Chart, params.Values)
 }
+
+// GetParameters contains parameters for helm get operation.
+type GetParameters struct {
+	// Namespace in which the Helm release is installed.
+	Namespace string
+	// Name of the Helm release to get.
+	Name string
+}
+
+// Get returns the Helm release specified by GetParameters.
+func Get(
+	k8sClient genericclioptions.RESTClientGetter,
+	params GetParameters,
+) (*release.Release, error) {
+	actionConfig := action.Configuration{}
+	// Use the default Helm driver (Kubernetes secret).
+	helmDriver := ""
+	logger := func(format string, v ...interface{}) {}
+	if err := actionConfig.Init(k8sClient, params.Namespace, helmDriver, logger); err != nil {
+		return nil, err
+	}
+	helmClient := action.NewGet(&actionConfig)
+	return helmClient.Run(params.Name)
+}

--- a/status/status.go
+++ b/status/status.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/internal/utils"
 )
 
 const (
@@ -105,6 +106,10 @@ type Status struct {
 	// CollectionErrors is the errors that accumulated while collecting the
 	// status
 	CollectionErrors []error `json:"collection_errors,omitempty"`
+
+	// HelmChartVersion is the Helm chart version that is currently installed.
+	// For Helm mode only.
+	HelmChartVersion string `json:"helm_chart_version,omitempty"`
 
 	mutex *sync.Mutex
 }
@@ -346,6 +351,9 @@ func (s *Status) Format() string {
 
 	fmt.Fprintf(w, "Cluster Pods:\t%s\n", formatPodsCount(s.PodsCount))
 
+	if utils.IsInHelmMode() {
+		fmt.Fprintf(w, "Helm chart version:\t%s\n", s.HelmChartVersion)
+	}
 	if len(s.ImageCount) > 0 {
 		header := "Image versions"
 		for name, imageCount := range s.ImageCount {


### PR DESCRIPTION
Print Helm chart version as a part of the "cilium status" output.