### PR TITLE
Helm mode: Use Helm chart version as running version

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -938,6 +938,16 @@ func (c *Client) GetCiliumVersion(ctx context.Context, p *corev1.Pod) (*semver.V
 }
 
 func (c *Client) GetRunningCiliumVersion(ctx context.Context, namespace string) (string, error) {
+	if utils.IsInHelmMode() {
+		release, err := helm.Get(c.RESTClientGetter, helm.GetParameters{
+			Namespace: namespace,
+			Name:      defaults.HelmReleaseName,
+		})
+		if err != nil {
+			return "", err
+		}
+		return release.Chart.Metadata.Version, nil
+	}
 	pods, err := c.ListPods(ctx, namespace, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector})
 	if err != nil {
 		return "", fmt.Errorf("unable to list cilium pods: %w", err)


### PR DESCRIPTION
Modify GetRunningCiliumVersion in Helm mode to return Helm chart version so that the function properly returns the running Cilium version in Helm mode without relying on image tags.