### PR TITLE
install: Add node affinity for Operator

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -150,4 +150,12 @@ var (
 		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=NotIn",
 		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=true",
 	}
+
+	// CiliumOperatorScheduleAffinity is the node affinity to prevent Cilium from being schedule on
+	// nodes labeled with CiliumNoScheduleLabel.
+	CiliumOperatorScheduleAffinity = []string{
+		"operator.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=" + CiliumNoScheduleLabel,
+		"operator.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=NotIn",
+		"operator.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=true",
+	}
 )

--- a/install/helm.go
+++ b/install/helm.go
@@ -291,6 +291,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 	// "cilium.io/no-schedule=true"
 	if len(k.params.NodesWithoutCilium) != 0 {
 		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumScheduleAffinity...)
+		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumOperatorScheduleAffinity...)
 	}
 
 	// Store all the options passed by --config into helm extraConfig


### PR DESCRIPTION
This to make sure that Cilium Operator will not be scheduled to the node having label io.cilium/no-schedule:true