### PR TITLE
External workloads CI fixed.

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -43,8 +43,8 @@ jobs:
     steps:
       - name: Set cluster name
         run: |
-          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}-vm" >> $GITHUB_ENV
-          echo "vmName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}-vm" >> $GITHUB_ENV
+          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "vmName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
External workloads CI was broken due to GKE name limit of up to 40 characters.
Example of successful GKE provisioning: https://github.com/cilium/cilium-cli/actions/runs/5212662316/jobs/9406570993?pr=1709.