### PR TITLE
helm mode: Handle azure.resourceGroup Helm value

### DIFF
--- a/install/azure_test.go
+++ b/install/azure_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package install
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/cli/values"
+)
+
+func TestK8sInstaller_setAzureResourceGroupFromHelmValue(t *testing.T) {
+	nameFromFlag := "name-from-flag"
+	nameFromHelmValue := "name-from-helm-value"
+
+	// Test the case where --azure-resource-group flag is set.
+	installer := &K8sInstaller{
+		params: Parameters{
+			Azure: AzureParameters{ResourceGroupName: nameFromFlag},
+		},
+	}
+	err := installer.setAzureResourceGroupFromHelmValue()
+	assert.NoError(t, err)
+	assert.Equal(t, nameFromFlag, installer.params.Azure.ResourceGroupName)
+
+	// Test the case where azure.resourceGroup Helm value is set.
+	installer = &K8sInstaller{
+		params: Parameters{
+			HelmOpts: values.Options{
+				Values: []string{fmt.Sprintf("azure.resourceGroup=%s", nameFromHelmValue)},
+			},
+		},
+	}
+	err = installer.setAzureResourceGroupFromHelmValue()
+	assert.NoError(t, err)
+	assert.Equal(t, nameFromHelmValue, installer.params.Azure.ResourceGroupName)
+}


### PR DESCRIPTION
Read Azure resource group name from azure.resourceGroup Helm value so that azureRetrieveAKSClusterInfo() doesn't fail in Helm mode.

need this for https://github.com/cilium/cilium/issues/25156