### PR TITLE
sysdump: collect CiliumPodIPPools

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -850,6 +850,10 @@ func (c *Client) ListCiliumNodeConfigs(ctx context.Context, namespace string, op
 	return c.CiliumClientset.CiliumV2alpha1().CiliumNodeConfigs(namespace).List(ctx, opts)
 }
 
+func (c *Client) ListCiliumPodIPPools(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumPodIPPoolList, error) {
+	return c.CiliumClientset.CiliumV2alpha1().CiliumPodIPPools().List(ctx, opts)
+}
+
 func (c *Client) GetLogs(ctx context.Context, namespace, name, container string, sinceTime time.Time, limitBytes int64, previous bool) (string, error) {
 	t := metav1.NewTime(sinceTime)
 	o := corev1.PodLogOptions{

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -55,6 +55,7 @@ type KubernetesClient interface {
 	ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error)
 	ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeList, error)
 	ListCiliumNodeConfigs(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumNodeConfigList, error)
+	ListCiliumPodIPPools(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumPodIPPoolList, error)
 	ListTetragonTracingPolicies(ctx context.Context, opts metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyList, error)
 	ListTetragonTracingPoliciesNamespaced(ctx context.Context, namespace string, opts metav1.ListOptions) (*tetragonv1alpha1.TracingPolicyNamespacedList, error)
 	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -59,6 +59,7 @@ const (
 	ciliumNodesFileName                      = "ciliumnodes-<ts>.yaml"
 	ciliumNodeConfigsFileName                = "ciliumnodeconfigs-<ts>.yaml"
 	ciliumOperatorDeploymentFileName         = "cilium-operator-deployment-<ts>.yaml"
+	ciliumPodIPPoolsFileName                 = "ciliumpodippools-<ts>.yaml"
 	clustermeshApiserverDeploymentFileName   = "clustermesh-apiserver-deployment-<ts>.yaml"
 	cniConfigMapFileName                     = "cni-configmap-<ts>.yaml"
 	cniConfigFileName                        = "cniconf-%s-%s-<ts>.txt"

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -655,6 +655,20 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting Cilium Pod IP Pools",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.ListCiliumPodIPPools(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect Cilium Pod IP pools: %w", err)
+				}
+				if err := c.WriteYAML(ciliumPodIPPoolsFileName, v); err != nil {
+					return fmt.Errorf("failed to collect Cilium Pod IP pools: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: fmt.Sprintf("Checking if %s exists in %s namespace", ciliumEtcdSecretsSecretName, c.Options.CiliumNamespace),
 			Quick:       true,
 			Task: func(ctx context.Context) error {

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -255,6 +255,10 @@ func (c *fakeClient) ListCiliumNodeConfigs(_ context.Context, _ string, _ metav1
 	panic("implement me")
 }
 
+func (c *fakeClient) ListCiliumPodIPPools(_ context.Context, _ metav1.ListOptions) (*ciliumv2alpha1.CiliumPodIPPoolList, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) ListCiliumClusterwideEnvoyConfigs(_ context.Context, _ metav1.ListOptions) (*ciliumv2.CiliumClusterwideEnvoyConfigList, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
The CiliumPodIPPool resource was introduced in https://github.com/cilium/cilium/pull/25824 and
is used to define pod IP pools in the multi-pool IPAM mode. See https://github.com/cilium/cilium/issues/24764 for more information.

Updates cilium/cilium#25470