### PR TITLE
sysdump: Fix wrong CiliumLoadBalancerIPPools collector

### DIFF
--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -644,7 +644,7 @@ func (c *Collector) Run() error {
 			Description: "Collecting Cilium LoadBalancer IP Pools",
 			Quick:       true,
 			Task: func(ctx context.Context) error {
-				v, err := c.Client.ListCiliumBGPPeeringPolicies(ctx, metav1.ListOptions{})
+				v, err := c.Client.ListCiliumLoadBalancerIPPools(ctx, metav1.ListOptions{})
 				if err != nil {
 					return fmt.Errorf("failed to collect Cilium LoadBalancer IP Pools: %w", err)
 				}


### PR DESCRIPTION
Currently, we incorrectly dump CiliumBGPPeeringPolicy for CiliumLoadBalancerIPPools dump. Fix it.

```
$ cat ciliumloadbalancerippools-20230331-074532.yaml
apiVersion: cilium.io/v2alpha1
items:
- apiVersion: cilium.io/v2alpha1
  kind: CiliumBGPPeeringPolicy
  metadata:
...
```