### PR TITLE
clustermesh enable: add enable-kvstoremesh flag

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -479,6 +479,10 @@ type Parameters struct {
 	// EnableExternalWorkloads indicates whether externalWorkloads.enabled Helm value
 	// should be set to true. For Helm mode only.
 	EnableExternalWorkloads bool
+
+	// EnableKVStoreMesh indicates whether kvstoremesh should be enabled.
+	// For Helm mode only.
+	EnableKVStoreMesh bool
 }
 
 func (p Parameters) validateParams() error {
@@ -1899,6 +1903,11 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 				// run the renewal every 4 months on the 1st of the month
 				"schedule": "0 0 1 */4 *",
 			},
+		}
+
+	helmVals["clustermesh"].(map[string]interface{})["apiserver"].(map[string]interface{})["kvstoremesh"] =
+		map[string]interface{}{
+			"enabled": params.EnableKVStoreMesh,
 		}
 
 	return helmVals, nil

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -367,6 +367,7 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&params.EnableExternalWorkloads, "enable-external-workloads", false, "Enable support for external workloads, such as VMs")
+	cmd.Flags().BoolVar(&params.EnableKVStoreMesh, "enable-kvstoremesh", false, "Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore (Cilium >=1.14 only)")
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { LoadBalancer | NodePort | ClusterIP }")
 
 	return cmd


### PR DESCRIPTION
This PR extends the `cilium clustermesh enable` command with a new flag which can be used to enable kvstoremesh (cilium/cilium#26083). The new flag is supported only when using the new Helm mode, and requires cilium >= 1.14 (it has no effect on earlier versions). Related: https://github.com/cilium/cilium/pull/26348