### PR TITLE
sysdump: collect resources & logs of Cilium SPIRE installation

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -69,6 +69,9 @@ const (
 	ClusterMeshRemoteSecretName           = "clustermesh-apiserver-remote-cert"
 	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-cert"
 
+	SPIREServerStatefulSetName = "spire-server"
+	SPIREAgentDaemonSetName    = "spire-agent"
+
 	ConnectivityCheckNamespace = "cilium-test"
 
 	// renovate: datasource=docker

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -70,7 +70,9 @@ const (
 	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-cert"
 
 	SPIREServerStatefulSetName = "spire-server"
+	SPIREServerConfigMapName   = "spire-server"
 	SPIREAgentDaemonSetName    = "spire-agent"
+	SPIREAgentConfigMapName    = "spire-agent"
 
 	ConnectivityCheckNamespace = "cilium-test"
 

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -65,6 +65,9 @@ func initSysdumpFlags(cmd *cobra.Command, options *sysdump.Options, optionPrefix
 	cmd.Flags().StringVar(&options.CiliumOperatorNamespace,
 		optionPrefix+"cilium-operator-namespace", "",
 		"The namespace Cilium operator is running in")
+	cmd.Flags().StringVar(&options.CiliumSPIRENamespace,
+		optionPrefix+"cilium-spire-namespace", "",
+		"The namespace Cilium SPIRE installation is running in")
 	cmd.Flags().StringVar(&options.CiliumDaemonSetSelector,
 		optionPrefix+"cilium-daemon-set-label-selector", sysdump.DefaultCiliumLabelSelector,
 		"The labels used to target Cilium daemon set")

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -496,6 +496,10 @@ func (c *Client) DeleteDaemonSet(ctx context.Context, namespace, name string, op
 	return c.Clientset.AppsV1().DaemonSets(namespace).Delete(ctx, name, opts)
 }
 
+func (c *Client) GetStatefulSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.StatefulSet, error) {
+	return c.Clientset.AppsV1().StatefulSets(namespace).Get(ctx, name, opts)
+}
+
 func (c *Client) GetCRD(ctx context.Context, name string, opts metav1.GetOptions) (*apiextensions.CustomResourceDefinition, error) {
 	return c.ExtensionClientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, opts)
 }

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -34,6 +34,7 @@ type KubernetesClient interface {
 	GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error)
 	GetNamespace(ctx context.Context, namespace string, options metav1.GetOptions) (*corev1.Namespace, error)
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
+	GetStatefulSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.StatefulSet, error)
 	GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error)
 	GetLogs(ctx context.Context, namespace, name, container string, sinceTime time.Time, limitBytes int64, previous bool) (string, error)
 	GetPodsTable(ctx context.Context) (*metav1.Table, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -21,6 +21,8 @@ const (
 	ciliumOperatorDeploymentName       = defaults.OperatorDeploymentName
 	ciliumSPIREServerStatefulSetName   = defaults.SPIREServerStatefulSetName
 	ciliumSPIREAgentDaemonSetName      = defaults.SPIREAgentDaemonSetName
+	ciliumSPIREServerConfigMapName     = defaults.SPIREServerConfigMapName
+	ciliumSPIREAgentConfigMapName      = defaults.SPIREAgentConfigMapName
 	clustermeshApiserverDeploymentName = defaults.ClusterMeshDeploymentName
 	hubbleContainerName                = "hubble"
 	hubbleDaemonSetName                = "hubble"
@@ -44,7 +46,9 @@ const (
 	ciliumEnvoyDaemonsetFileName             = "cilium-envoy-daemonset-<ts>.yaml"
 	ciliumEnvoyConfigMapFileName             = "cilium-envoy-configmap-<ts>.yaml"
 	ciliumSPIREAgentDaemonsetFileName        = "cilium-spire-agent-daemonset-<ts>.yaml"
+	ciliumSPIREAgentConfigMapFileName        = "cilium-spire-agent-configmap-<ts>.yaml"
 	ciliumSPIREServerStatefulSetFileName     = "cilium-spire-server-statefulset-<ts>.yaml"
+	ciliumSPIREServerConfigMapFileName       = "cilium-spire-server-configmap-<ts>.yaml"
 	ciliumIngressesFileName                  = "ciliumingresses-<ts>.yaml"
 	ciliumEgressNATPoliciesFileName          = "ciliumegressnatpolicies-<ts>.yaml"
 	ciliumEgressGatewayPoliciesFileName      = "ciliumegressgatewaypolicies-<ts>.yaml"

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -19,6 +19,8 @@ const (
 	ciliumConfigMapName                = defaults.ConfigMapName
 	ciliumEtcdSecretsSecretName        = "cilium-etcd-secrets"
 	ciliumOperatorDeploymentName       = defaults.OperatorDeploymentName
+	ciliumSPIREServerStatefulSetName   = defaults.SPIREServerStatefulSetName
+	ciliumSPIREAgentDaemonSetName      = defaults.SPIREAgentDaemonSetName
 	clustermeshApiserverDeploymentName = defaults.ClusterMeshDeploymentName
 	hubbleContainerName                = "hubble"
 	hubbleDaemonSetName                = "hubble"

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -43,6 +43,8 @@ const (
 	ciliumDaemonSetFileName                  = "cilium-daemonset-<ts>.yaml"
 	ciliumEnvoyDaemonsetFileName             = "cilium-envoy-daemonset-<ts>.yaml"
 	ciliumEnvoyConfigMapFileName             = "cilium-envoy-configmap-<ts>.yaml"
+	ciliumSPIREAgentDaemonsetFileName        = "cilium-spire-agent-daemonset-<ts>.yaml"
+	ciliumSPIREServerStatefulSetFileName     = "cilium-spire-server-statefulset-<ts>.yaml"
 	ciliumIngressesFileName                  = "ciliumingresses-<ts>.yaml"
 	ciliumEgressNATPoliciesFileName          = "ciliumegressnatpolicies-<ts>.yaml"
 	ciliumEgressGatewayPoliciesFileName      = "ciliumegressgatewaypolicies-<ts>.yaml"

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -64,4 +64,8 @@ var (
 	// DefaultCiliumNamespaces will be used to attempt to autodetect what namespace Cilium is installed in
 	// unless otherwise specified.
 	DefaultCiliumNamespaces = []string{"kube-system", "cilium"}
+
+	// DefaultCiliumSPIRENamespaces will be used to attempt to autodetect what namespace Cilium SPIRE is installed in
+	// unless otherwise specified.
+	DefaultCiliumSPIRENamespaces = []string{"kube-system", "cilium", "cilium-spire"}
 )

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -1200,6 +1200,42 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting the Cilium SPIRE agent configuration",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetConfigMap(ctx, c.Options.CiliumSPIRENamespace, ciliumSPIREAgentConfigMapName, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						c.logWarn("ConfigMap %q not found in namespace %q - this is expected if SPIRE installation is not enabled", ciliumSPIREAgentConfigMapName, c.Options.CiliumSPIRENamespace)
+						return nil
+					}
+					return fmt.Errorf("failed to collect the Cilium SPIRE agent configuration: %w", err)
+				}
+				if err := c.WriteYAML(ciliumSPIREAgentConfigMapFileName, v); err != nil {
+					return fmt.Errorf("failed to collect the Cilium SPIRE agent configuration: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting the Cilium SPIRE server configuration",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetConfigMap(ctx, c.Options.CiliumSPIRENamespace, ciliumSPIREServerConfigMapName, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						c.logWarn("ConfigMap %q not found in namespace %q - this is expected if SPIRE installation is not enabled", ciliumSPIREServerConfigMapName, c.Options.CiliumSPIRENamespace)
+						return nil
+					}
+					return fmt.Errorf("failed to collect the Cilium SPIRE server configuration: %w", err)
+				}
+				if err := c.WriteYAML(ciliumSPIREServerConfigMapFileName, v); err != nil {
+					return fmt.Errorf("failed to collect the Cilium SPIRE server configuration: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			CreatesSubtasks: true,
 			Description:     "Collecting platform-specific data",
 			Quick:           true,

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -1164,6 +1164,42 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting the Cilium SPIRE server statefulset",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetStatefulSet(ctx, c.Options.CiliumSPIRENamespace, ciliumSPIREServerStatefulSetName, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						c.logWarn("StatefulSet %q not found in namespace %q - this is expected if SPIRE installation is not enabled", ciliumSPIREServerStatefulSetName, c.Options.CiliumSPIRENamespace)
+						return nil
+					}
+					return fmt.Errorf("failed to collect the Cilium SPIRE server statefulset: %w", err)
+				}
+				if err := c.WriteYAML(ciliumSPIREServerStatefulSetFileName, v); err != nil {
+					return fmt.Errorf("failed to collect the Cilium SPIRE server statefulset: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting the Cilium SPIRE agent daemonset",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetDaemonSet(ctx, c.Options.CiliumSPIRENamespace, ciliumSPIREAgentDaemonSetName, metav1.GetOptions{})
+				if err != nil {
+					if errors.IsNotFound(err) {
+						c.logWarn("Daemonset %q not found in namespace %q - this is expected if SPIRE installation is not enabled", ciliumSPIREAgentDaemonSetName, c.Options.CiliumSPIRENamespace)
+						return nil
+					}
+					return fmt.Errorf("failed to collect the Cilium SPIRE agent daemonset: %w", err)
+				}
+				if err := c.WriteYAML(ciliumSPIREAgentDaemonsetFileName, v); err != nil {
+					return fmt.Errorf("failed to collect the Cilium SPIRE agent daemonset: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			CreatesSubtasks: true,
 			Description:     "Collecting platform-specific data",
 			Quick:           true,

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -326,6 +326,10 @@ func (c *fakeClient) GetDaemonSet(_ context.Context, _, _ string, _ metav1.GetOp
 	return nil, nil
 }
 
+func (c *fakeClient) GetStatefulSet(_ context.Context, _, _ string, _ metav1.GetOptions) (*appsv1.StatefulSet, error) {
+	return nil, nil
+}
+
 func (c *fakeClient) GetDeployment(_ context.Context, _, _ string, _ metav1.GetOptions) (*appsv1.Deployment, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This PR adds resources & logs of the Cilium SPIRE installation (mutual authentication) to the Cilium CLI SysDump.

* Logs of agent & server
* DaemonSet of agent
* StatefulSet of server
* ConfigMaps of agent & server

By default, SPIRE gets installed into the namespace `cilium-spire` during the installation of Cilium. Therefore, it was necessary to add an additional "namespace detection". The detection defaults to the Cilium namespace in case of a failure.