### PR TITLE
.github/workflows: don't error out if pkill finds no processes

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Uninstall cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --wait
 
       - name: Install Cilium with IPsec Encryption


### PR DESCRIPTION
The pkill invocation in the kind workflow is meant to kill background tasks started earlier in the workflow. It seems like some of them exit of their own accord, with tests still passing.

Ignore the pkill error code 1 which indicates that no processes were matched / signalled:

       1      No processes matched or none of them could be signalled.

Ref. https://github.com/cilium/cilium/issues/26075