### PR TITLE
Minor fixes for error messages on failure to disable Hubble

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -161,8 +161,8 @@ func newCmdUninstall() *cobra.Command {
 				})
 			if err != nil {
 				fmt.Printf("⚠ ️ Failed to initialize Hubble uninstaller: %s\n", err)
-			} else if h.Disable(ctx, true) != nil {
-				fmt.Printf("ℹ️  Failed to disable Hubble. This is expected if Hubble is not enabled: %s\n", err)
+			} else if err = h.Disable(ctx, true); err != nil {
+				fmt.Printf("ℹ️  Failed to disable Hubble: %s\n", err)
 			}
 			uninstaller := install.NewK8sUninstaller(k8sClient, params)
 			if err := uninstaller.Uninstall(context.Background()); err != nil {

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -146,7 +146,7 @@ func newCmdUninstall() *cobra.Command {
 				Writer:          os.Stdout,
 			}, version)
 			if err != nil {
-				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s", err)
+				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s\n", err)
 			} else {
 				cc.UninstallResources(ctx, params.Wait)
 			}
@@ -160,9 +160,9 @@ func newCmdUninstall() *cobra.Command {
 					HelmChartDirectory:   params.HelmChartDirectory,
 				})
 			if err != nil {
-				fmt.Printf("⚠ ️ Failed to initialize Hubble uninstaller: %s", err)
+				fmt.Printf("⚠ ️ Failed to initialize Hubble uninstaller: %s\n", err)
 			} else if h.Disable(ctx, true) != nil {
-				fmt.Printf("ℹ️  Failed to disable Hubble. This is expected if Hubble is not enabled: %s", err)
+				fmt.Printf("ℹ️  Failed to disable Hubble. This is expected if Hubble is not enabled: %s\n", err)
 			}
 			uninstaller := install.NewK8sUninstaller(k8sClient, params)
 			if err := uninstaller.Uninstall(context.Background()); err != nil {
@@ -313,7 +313,7 @@ func newCmdUninstallWithHelm() *cobra.Command {
 				Writer:          os.Stdout,
 			}, version)
 			if err != nil {
-				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s", err)
+				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s\n", err)
 			} else {
 				cc.UninstallResources(ctx, params.Wait)
 			}


### PR DESCRIPTION
Here are a few minor fixes for some error messages from the CLI, in particular on uninstall when trying to disable Hubble.

- internal/cli/cmd: Add line breaks after error messages
- internal/cli/cmd: Fix error displayed on failure to disable Hubble
