### PR TITLE
renovate: let renovate update default Cilium version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -135,6 +135,14 @@
       "matchDepNames": [
         "golangci/golangci-lint"
       ]
+    },
+    {
+      // Group cilium updates to overrule grouping of version updates in the GHA files.
+      // Without this, cilium updates are not in sync for GHA files and other usages.
+      "groupName": "cilium",
+      "matchDepNames": [
+        "cilium/cilium"
+      ]
     }
   ],
   "regexManagers": [
@@ -168,7 +176,8 @@
       // similar to the examples shown here:
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
       "matchStrings": [
-        "\/\/ renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\""
+        "\/\/ renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\"",
+        "\/\/ renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+Version = \"(?<currentValue>.*)\""
       ]
     }
   ]

--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -38,6 +38,7 @@ concurrency:
 env:
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.3
   kubectl_version: v1.23.6
 

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   region: us-east-2
+  # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.3
   kubectl_version: v1.23.6
 

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   region: us-east-2
+  # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.3
   kubectl_version: v1.23.6
 

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -28,6 +28,7 @@ concurrency:
 env:
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
+  # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.3
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   zone: us-west2-a
+  # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.3
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -15,6 +15,7 @@ env:
   KIND_CONFIG: .github/kind-config.yaml
   TIMEOUT: 2m
   LOG_TIME: 30m
+  # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.3
   kubectl_version: v1.23.6
 

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   zone: us-west2-a
+  # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.3
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -6,6 +6,9 @@ package defaults
 import "time"
 
 const (
+	// renovate: datasource=github-releases depName=cilium/cilium
+	Version = "v1.13.3"
+
 	AgentContainerName      = "cilium-agent"
 	AgentServiceAccountName = "cilium"
 	AgentClusterRoleName    = "cilium"
@@ -86,7 +89,6 @@ const (
 	ConnectivityDNSTestServerImage = "docker.io/coredns/coredns:1.10.1@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
 
 	ConfigMapName = "cilium-config"
-	Version       = "v1.13.3"
 
 	StatusWaitDuration = 5 * time.Minute
 


### PR DESCRIPTION
Let renovate update the Cilium version which is installed by default and used in GH actions workflows. This avoid creating these update PRs manually, see e.g. https://github.com/cilium/cilium-cli/pull/1686

Example PR bumping to Cilium v1.13.4: https://github.com/tklauser/cilium-cli/pull/16