### PR TITLE
GHA: extend 'install-cilium-cli' to build from source

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,9 @@ inputs:
     description: 'Cilium CLI release version'
   ci-version:
     description: 'Cilium CLI CI build version'
+  local-path:
+    description: 'Path to the local copy of the Cilium CLI repository'
+    default: '*/cilium-cli'
   binary-dir:
     description: 'Directory to store Cilium CLI executable'
     required: true
@@ -16,15 +19,40 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check if we should build the Cilium CLI from source
+      id: build-cli
+      shell: bash
+      run: |
+        CLI_PATH=$(find . -iwholename '${{ inputs.local-path }}' -type d | head -n 1)
+        echo path="${CLI_PATH}" >> $GITHUB_OUTPUT
+
+    - name: Setup Go
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      if: ${{ steps.build-cli.outputs.path != '' }}
+      with:
+        go-version-file: '${{ steps.build-cli.outputs.path }}/go.mod'
+        cache: true
+        cache-dependency-path: '${{ steps.build-cli.outputs.path }}/go.sum'
+
+    - name: Build Cilium CLI from source
+      if: ${{ steps.build-cli.outputs.path != '' }}
+      shell: bash
+      run: |
+        cd ${{ steps.build-cli.outputs.path }}
+        make TARGET=${{ inputs.binary-name }}
+        # Install the binary in a separate step (rather than executing make install)
+        # to avoid building the binary as root, which would cause issues with caching.
+        sudo mv ${{ inputs.binary-name }} ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
+
     - name: Check Required Version
-      if: ${{ inputs.release-version == '' && inputs.ci-version == '' }}
+      if: ${{ steps.build-cli.outputs.path == '' && inputs.release-version == '' && inputs.ci-version == '' }}
       shell: bash
       run: |
         echo "'release-version' or 'ci-version' has to be specified!"
         exit 42
 
-    - name: Install Released Cilium CLI 
-      if: ${{ inputs.release-version != '' }}
+    - name: Install Released Cilium CLI
+      if: ${{ steps.build-cli.outputs.path == '' && inputs.release-version != '' }}
       shell: bash
       run: |
         curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ inputs.release-version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
@@ -34,7 +62,7 @@ runs:
         rm cilium-linux-amd64.tar.gz{,.sha256sum}
 
     - name: Install Cilium CLI from CI
-      if: ${{ inputs.ci-version != '' }}
+      if: ${{ steps.build-cli.outputs.path == '' && inputs.ci-version != '' }}
       shell: bash
       run: |
         cid=$(docker create quay.io/cilium/cilium-cli-ci:${{ inputs.ci-version }} ls)


### PR DESCRIPTION
This PR extends the 'install-cilium-cli' composite workflow to additionally support building the cilium CLI from source if the corresponding repository is available locally.