### PR TITLE
defaults: update connectivity test alpine curl image version

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -80,7 +80,7 @@ const (
 	ConnectivityCheckNamespace = "cilium-test"
 
 	// renovate: datasource=docker
-	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.6.0@sha256:408430f548a8390089b9b83020148b0ef80b0be1beb41a98a8bfe036709c196e"
+	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.7.0@sha256:ccd0ed9da1752bab88a807647ad3cec65d460d281ab88988b60d70148783e751"
 	// renovate: datasource=docker
 	ConnectivityPerformanceImage = "quay.io/cilium/network-perf:a816f935930cb2b40ba43230643da4d5751a5711@sha256:679d3a370c696f63884da4557a4466f3b5569b4719bb4f86e8aac02fbe390eea"
 	// renovate: datasource=docker


### PR DESCRIPTION
Update alpine-curl to v1.7.0, version is retrieved from[ this workflow](https://github.com/cilium/alpine-curl/actions/runs/5378553798/jobs/9758619474).