### PR TITLE
connectivity: Add op=Exists toleration for test-conn-disrupt

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -602,6 +602,9 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				Labels:   map[string]string{"app": "test-conn-disrupt-server"},
 				Command:  []string{"tcd-server", "8000"},
 				Port:     8000,
+				Tolerations: []corev1.Toleration{
+					{Operator: corev1.TolerationOpExists},
+				},
 			})
 			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(testConnDisruptServerDeploymentName), metav1.CreateOptions{})
 			if err != nil {
@@ -648,6 +651,9 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
 				},
 				ReadinessProbe: readinessProbe,
+				Tolerations: []corev1.Toleration{
+					{Operator: corev1.TolerationOpExists},
+				},
 			})
 
 			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(testConnDisruptClientDeploymentName), metav1.CreateOptions{})


### PR DESCRIPTION
It was observed on a Kind cluster, that during Cilium upgrade (v1.13.4 -> main) kubelet set the taint node.kubernetes.io/network-unavailable which evicted test-conn-disrupt pods. This resulted in a false negative in the upgrade tests.

Fix the issue by tolerating any taint.