### PR TITLE
connectivity: Remove test-conn-disrupt tolerations

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -600,9 +600,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				Labels:   map[string]string{"app": "test-conn-disrupt-server"},
 				Command:  []string{"tcd-server", "8000"},
 				Port:     8000,
-				Tolerations: []corev1.Toleration{
-					{Operator: corev1.TolerationOpExists},
-				},
 			})
 			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(testConnDisruptServerDeploymentName), metav1.CreateOptions{})
 			if err != nil {
@@ -649,9 +646,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
 				},
 				ReadinessProbe: readinessProbe,
-				Tolerations: []corev1.Toleration{
-					{Operator: corev1.TolerationOpExists},
-				},
 			})
 
 			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(testConnDisruptClientDeploymentName), metav1.CreateOptions{})


### PR DESCRIPTION
Unfortunately, the op=Exists toleration (127d9b8c2d) made the upgrade pods to be scheduled on nodes which do not run Cilium.

The upgrade issue got resolved by setting "cni.uninstall=false", so let's remove the toleration.