### PR TITLE
Helm mode: Handle "cluster.name" Helm value

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -192,10 +192,10 @@ jobs:
       KIND_CONFIG_2: .github/kind-config-2.yaml
       # helm/kind-action will override the "name:" provided in the kind config with "chart-testing" unless these are
       # specified as inputs. These must also match the suffix here for CLUSTER1 and CLUSTER2.
-      CLUSTER_NAME_1: c1
-      CLUSTER_NAME_2: c2
-      CLUSTER1: kind-c1
-      CLUSTER2: kind-c2
+      CLUSTER_NAME_1: c.1
+      CLUSTER_NAME_2: c.2
+      CLUSTER1: kind-c.1
+      CLUSTER2: kind-c.2
 
     steps:
       - name: Checkout
@@ -238,7 +238,7 @@ jobs:
             --helm-set bpf.monitorAggregation=none \
             --helm-set cni.chainingMode=portmap \
             --helm-set cluster.id=1 \
-            --helm-set cluster.name=cluster1
+            --helm-set cluster.name=$CLUSTER1
 
       - name: Create kind cluster 2
         uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
@@ -255,14 +255,15 @@ jobs:
             --helm-set bpf.monitorAggregation=none \
             --helm-set cni.chainingMode=portmap \
             --helm-set cluster.id=2 \
-            --helm-set cluster.name=cluster2
+            --helm-set cluster.name=$CLUSTER2
 
       - name: Enable ClusterMesh on cluster 1 using helm-based upgrade
         run: |
           cilium upgrade --reuse-values --context $CLUSTER1 \
             --wait=true \
             --helm-set clustermesh.useAPIServer=true \
-            --helm-set clustermesh.apiserver.service.type=NodePort
+            --helm-set clustermesh.apiserver.service.type=NodePort \
+            --helm-set clustermesh.apiserver.tls.server.extraDnsNames={"$CLUSTER1.mesh.cilium.io,$CLUSTER2.mesh.cilium.io"}
 
       - name: Copy CA cert from cluster 1 to cluster 2
         run: |
@@ -277,7 +278,8 @@ jobs:
           cilium upgrade --reuse-values --context $CLUSTER2 \
             --wait=true \
             --helm-set clustermesh.useAPIServer=true \
-            --helm-set clustermesh.apiserver.service.type=NodePort
+            --helm-set clustermesh.apiserver.service.type=NodePort \
+            --helm-set clustermesh.apiserver.tls.server.extraDnsNames={"$CLUSTER1.mesh.cilium.io,$CLUSTER2.mesh.cilium.io"}
 
       - name: Rename the secrets expected by the clustermesh connect command
         run: |

--- a/install/autodetect_test.go
+++ b/install/autodetect_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package install
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/getter"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getClusterName(t *testing.T) {
+	assert.Equal(t, "", getClusterName(nil))
+
+	opts := values.Options{}
+	vals, err := opts.MergeValues(getter.All(cli.New()))
+	assert.NoError(t, err)
+	assert.Equal(t, "", getClusterName(vals))
+
+	opts = values.Options{JSONValues: []string{"cluster={}"}}
+	vals, err = opts.MergeValues(getter.All(cli.New()))
+	assert.NoError(t, err)
+	assert.Equal(t, "", getClusterName(vals))
+
+	opts = values.Options{Values: []string{"cluster.name=my-cluster"}}
+	vals, err = opts.MergeValues(getter.All(cli.New()))
+	assert.NoError(t, err)
+	assert.Equal(t, "my-cluster", getClusterName(vals))
+}


### PR DESCRIPTION
- Refactor preinstall to call HelmOpts.MergeValues() once at the top of
  the function, and pass the merged values to autodetectAndValidate().
- Set install.Parameters.ClusterName to cluster.name Helm value if it's
  not empty.
- Skip the cluster name validation altogether in Helm mode. I boldly
  assert that any input validation must be performed inside the Helm
  chart, and not in cilium-cli. This ensures that the validation logic
  is consistent between "helm install" and "cilium install".

Fixes: #490

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>