### PR TITLE
connectivity: Ignore failedToListCRDs error

### DIFF
--- a/connectivity/tests/errors.go
+++ b/connectivity/tests/errors.go
@@ -135,6 +135,7 @@ const (
 	localIDRestoreFail  = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
 	routerIPMismatch    = "Mismatch of router IPs found during restoration"
 	emptyIPNodeIDAlloc  = "Attempt to allocate a node ID for an empty node IP address"
+	failedToListCRDs    = "the server could not find the requested resource" // cf. https://github.com/cilium/cilium/issues/16425
 )
 
 // The list is adopted from cilium/cilium/test/helper/utils.go
@@ -161,5 +162,5 @@ var errorMsgsWithExceptions = map[string][]string{
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	"level=error": {"Error in delegate stream, restarting"},
+	"level=error": {"Error in delegate stream, restarting", failedToListCRDs},
 }


### PR DESCRIPTION
I was overly naive to ignore level=errors exceptions. So far we hit only failedToListCRDs \[1\]. Let's add it as an exception.

\[1\]: https://github.com/cilium/cilium/issues/26591

Reported-by: Sebastian Wicki <sebastian@isovalent.com>