### PR TITLE
Extend upgrade test for IPsec key rotation test

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -64,10 +64,11 @@ type Parameters struct {
 	JunitFile             string
 	JunitProperties       map[string]string
 
-	IncludeConnDisruptTest      bool
-	ConnDisruptTestSetup        bool
-	ConnDisruptTestRestartsPath string
-	FlushCT                     bool
+	IncludeConnDisruptTest        bool
+	ConnDisruptTestSetup          bool
+	ConnDisruptTestRestartsPath   string
+	ConnDisruptTestXfrmErrorsPath string
+	FlushCT                       bool
 
 	K8sVersion           string
 	HelmChartDirectory   string

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -64,10 +64,10 @@ type Parameters struct {
 	JunitFile             string
 	JunitProperties       map[string]string
 
-	IncludeUpgradeTest    bool
-	UpgradeTestSetup      bool
-	UpgradeTestResultPath string
-	FlushCT               bool
+	IncludeConnDisruptTest      bool
+	ConnDisruptTestSetup        bool
+	ConnDisruptTestRestartsPath string
+	FlushCT                     bool
 
 	K8sVersion           string
 	HelmChartDirectory   string

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -588,7 +588,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	}
 
 	// Deploy test-conn-disrupt actors
-	if ct.params.UpgradeTestSetup {
+	if ct.params.ConnDisruptTestSetup {
 		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.GetOptions{})
 		if err != nil {
 			ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), testConnDisruptServerDeploymentName)
@@ -1031,7 +1031,7 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 		}
 	}
 
-	if ct.params.IncludeUpgradeTest {
+	if ct.params.IncludeConnDisruptTest {
 		srcList = append(srcList, testConnDisruptClientDeploymentName)
 		dstList = append(dstList, testConnDisruptServerDeploymentName)
 	}

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -211,6 +211,10 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			tests.NoInterruptedConnections(),
 		)
 
+		ct.NewTest("no-ipsec-xfrm-errors").
+			WithFeatureRequirements(check.RequireFeatureMode(check.FeatureEncryptionPod, "ipsec")).
+			WithScenarios(tests.NoIPsecXfrmErrors())
+
 		if ct.Params().ConnDisruptTestSetup {
 			// Exit early, as --conn-disrupt-test-setup is only needed to deploy pods which
 			// will be used by another invocation of "cli connectivity test" (with

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -205,16 +205,16 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 		return ct.Run(ctx)
 	}
 
-	// Upgrade Test
-	if ct.Params().IncludeUpgradeTest {
-		ct.NewTest("post-upgrade").WithScenarios(
+	// Conn disrupt Test
+	if ct.Params().IncludeConnDisruptTest {
+		ct.NewTest("no-interrupted-connections").WithScenarios(
 			tests.NoInterruptedConnections(),
 		)
 
-		if ct.Params().UpgradeTestSetup {
-			// Exit early, as --upgrade-setup is only needed to deploy pods which
+		if ct.Params().ConnDisruptTestSetup {
+			// Exit early, as --conn-disrupt-test-setup is only needed to deploy pods which
 			// will be used by another invocation of "cli connectivity test" (with
-			// include --include-upgrade-tests"
+			// include --include-conn-disrupt-test"
 			return ct.Run(ctx)
 		}
 

--- a/connectivity/tests/ipsec_xfrm.go
+++ b/connectivity/tests/ipsec_xfrm.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	gojson "encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/defaults"
+)
+
+type ciliumMetricsXfrmError struct {
+	Labels struct {
+		Error string `json:"error"`
+		Type  string `json:"type"`
+	} `json:"labels"`
+	Name  string `json:"name"`
+	Value uint64 `json:"value"`
+}
+
+func NoIPsecXfrmErrors() check.Scenario {
+	return &noIPsecXfrmErrors{}
+}
+
+type noIPsecXfrmErrors struct{}
+
+func (n *noIPsecXfrmErrors) Name() string {
+	return "no-ipsec-xfrm-error"
+}
+
+func (n *noIPsecXfrmErrors) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	crtXfrmErrors := n.collectXfrmErrors(ctx, t)
+
+	if ct.Params().ConnDisruptTestSetup {
+		n.storeIPsecXfrmErrors(t, crtXfrmErrors)
+		return
+	}
+
+	prevXfrmErrors := n.loadIPsecXfrmErrors(t)
+	for node, crtErr := range crtXfrmErrors {
+		if preErr, found := prevXfrmErrors[node]; !found {
+			t.Fatalf("Could not found Node %s xfrm errors", node)
+		} else if preErr != crtErr {
+			t.Fatalf("Node %s xfrm errors were changed (previous errors: %s, current errors: %s)",
+				node, preErr, crtErr)
+		}
+	}
+}
+
+func (n *noIPsecXfrmErrors) collectXfrmErrors(ctx context.Context, t *check.Test) map[string]string {
+
+	xfrmErrors := map[string]string{}
+
+	client := t.Context().K8sClient()
+	nodes, err := client.ListNodes(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Unable to list nodes: %s", err)
+	}
+	if len(nodes.Items) == 0 {
+		t.Fatal("No nodes found")
+	}
+
+	for _, node := range nodes.Items {
+		ciliumPods, err := client.ListPods(ctx, "kube-system",
+			metav1.ListOptions{LabelSelector: defaults.AgentPodSelector, FieldSelector: "spec.nodeName=" + node.GetName()})
+		if err != nil {
+			t.Fatalf("Unable to list cilium pods: %s", err)
+		}
+		if len(ciliumPods.Items) == 0 {
+			t.Fatalf("No cilium pods found")
+		}
+
+		encryptStatus, err := client.ExecInPod(ctx, "kube-system", ciliumPods.Items[0].GetName(), "",
+			[]string{"cilium", "metrics", "list", "-ojson", "-pcilium_ipsec_xfrm_error"})
+		if err != nil {
+			t.Fatalf("Unable to get cilium ipsec xfrm error metrics: %s", err)
+		}
+
+		xErrors := []string{}
+		xfrmMetrics := []ciliumMetricsXfrmError{}
+		if err := json.Unmarshal(encryptStatus.Bytes(), &xfrmMetrics); err != nil {
+			t.Fatalf("Unable to unmarshal cilium ipsec xfrm error metrics: %s", err)
+		}
+		for _, xfrmMetric := range xfrmMetrics {
+			if xfrmMetric.Value > 0 {
+				xErrors = append(xErrors,
+					fmt.Sprintf("%s_%s:%d",
+						xfrmMetric.Labels.Type, xfrmMetric.Labels.Error, xfrmMetric.Value))
+			}
+			sort.Strings(xErrors)
+			xfrmErrors[node.GetName()] = strings.Join(xErrors, ",")
+		}
+	}
+	return xfrmErrors
+}
+
+func (n *noIPsecXfrmErrors) storeIPsecXfrmErrors(t *check.Test, xfrmErrors map[string]string) {
+	ct := t.Context()
+	file, err := os.Create(ct.Params().ConnDisruptTestXfrmErrorsPath)
+	if err != nil {
+		t.Fatalf("Failed to create %q file for writing disrupt test temp results: %s",
+			ct.Params().ConnDisruptTestXfrmErrorsPath, err)
+	}
+	defer file.Close()
+
+	j, err := gojson.Marshal(xfrmErrors)
+	if err != nil {
+		t.Fatalf("Failed to marshal JSON: %s", err)
+	}
+
+	if _, err := file.Write(j); err != nil {
+		t.Fatalf("Failed to write conn disrupt test temp result into file: %s", err)
+	}
+}
+
+func (n *noIPsecXfrmErrors) loadIPsecXfrmErrors(t *check.Test) map[string]string {
+	b, err := os.ReadFile(t.Context().Params().ConnDisruptTestXfrmErrorsPath)
+	if err != nil {
+		t.Fatalf("Failed to read conn disrupt test result files: %s", err)
+	}
+	xfrmErrors := map[string]string{}
+	if err := gojson.Unmarshal(b, &xfrmErrors); err != nil {
+		t.Fatalf("Failed to unmarshal JSON test result file: %s", err)
+	}
+	return xfrmErrors
+}

--- a/connectivity/tests/upgrade.go
+++ b/connectivity/tests/upgrade.go
@@ -21,13 +21,13 @@ import (
 // The test case consists of three steps:
 //
 // 1. Deploying pods and a service which establish the long-lived connections
-// (done by "--upgrade-test-setup"). The client pods ("test-conn-disrupt-client")
+// (done by "--conn-disrupt-test-setup"). The client pods ("test-conn-disrupt-client")
 // establish connections via ClusterIP ("test-conn-disrupt") to server pods
 // ("test-conn-disrupt-server"). As there former pods come first before the latter,
 // the former pods can crash which increases the pod restart counter. The step
 // is responsible for storing the restart counter too.
 // 2. Do Cilium upgrade.
-// 3. Run the test ("--include-upgrade-test"). The test checks the restart
+// 3. Run the test ("--include-conn-disrupt-test"). The test checks the restart
 // counters, and compares them against the previously stored ones. A mismatch
 // indicates that a connection was interrupted.
 func NoInterruptedConnections() check.Scenario {
@@ -58,12 +58,12 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 	}
 
 	// Only store restart counters which will be used later when running the same
-	// test case, but w/o --upgrade-test-setup.
-	if ct.Params().UpgradeTestSetup {
-		file, err := os.Create(ct.Params().UpgradeTestResultPath)
+	// test case, but w/o --conn-disrupt-test-setup.
+	if ct.Params().ConnDisruptTestSetup {
+		file, err := os.Create(ct.Params().ConnDisruptTestRestartsPath)
 		if err != nil {
-			t.Fatalf("Failed to create %q file for writing upgrade test temp results: %s",
-				ct.Params().UpgradeTestResultPath, err)
+			t.Fatalf("Failed to create %q file for writing conn disrupt test temp results: %s",
+				ct.Params().ConnDisruptTestRestartsPath, err)
 		}
 		defer file.Close()
 
@@ -77,15 +77,15 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		}
 
 		if _, err := file.Write(j); err != nil {
-			t.Fatalf("Failed to write upgrade test temp result into file: %s", err)
+			t.Fatalf("Failed to write conn disrupt test temp result into file: %s", err)
 		}
 
 		return
 	}
 
-	b, err := os.ReadFile(ct.Params().UpgradeTestResultPath)
+	b, err := os.ReadFile(ct.Params().ConnDisruptTestRestartsPath)
 	if err != nil {
-		t.Fatalf("Failed to read upgrade test result files: %s", err)
+		t.Fatalf("Failed to read conn disrupt test result files: %s", err)
 	}
 	prevRestartCount := make(map[string]string)
 	if err := gojson.Unmarshal(b, &prevRestartCount); err != nil {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -172,9 +172,9 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 
 	initSysdumpFlags(cmd, &params.SysdumpOptions, "sysdump-", hooks)
 
-	cmd.Flags().BoolVar(&params.IncludeUpgradeTest, "include-upgrade-test", false, "Include upgrade test")
-	cmd.Flags().BoolVar(&params.UpgradeTestSetup, "upgrade-test-setup", false, "Set up upgrade test dependencies")
-	cmd.Flags().StringVar(&params.UpgradeTestResultPath, "upgrade-test-result-path", "/tmp/cilium-upgrade-test-restart-counts", "Upgrade test temporary result file (used internally)")
+	cmd.Flags().BoolVar(&params.IncludeConnDisruptTest, "include-conn-disrupt-test", false, "Include conn disrupt test")
+	cmd.Flags().BoolVar(&params.ConnDisruptTestSetup, "conn-disrupt-test-setup", false, "Set up conn disrupt test dependencies")
+	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 
 	hooks.AddConnectivityTestFlags(cmd.Flags())

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -175,6 +175,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.IncludeConnDisruptTest, "include-conn-disrupt-test", false, "Include conn disrupt test")
 	cmd.Flags().BoolVar(&params.ConnDisruptTestSetup, "conn-disrupt-test-setup", false, "Set up conn disrupt test dependencies")
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
+	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 
 	hooks.AddConnectivityTestFlags(cmd.Flags())


### PR DESCRIPTION
This PR extends upgrade test, so IPsec key rotation interruption test can base on the same workflow.

The expected test flow is:

1. Run "cilium-cli connectivity test --conn-disrupt-test-setup --include-conn-disrupt-test" to deploy connectivity sensitive pods, then record the current restart counts and xfrm error counts.
2. Perform IPsec key rotation. This part can be done in the cilium's ci-e2e.
3. Run "cilium-cli connectivity test --include-conn-disrupt-test" to check restart counts and xfrm error counts again, test fails if any diff is found.

Partially Fixes: https://github.com/cilium/cilium/issues/26350

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>