### PR TITLE
connectivity: don't wait for service backends if the IP family is disabled

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1269,7 +1269,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 
 		for _, agent := range ct.CiliumPods() {
 			if _, ok := nodes[agent.NodeName()]; ok {
-				if err := WaitForServiceEndpoints(ctx, ct, agent, s, 1); err != nil {
+				if err := WaitForServiceEndpoints(ctx, ct, agent, s, 1, ct.Features.IPFamilies()); err != nil {
 					return err
 				}
 			}

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -111,6 +111,21 @@ func (fs FeatureSet) MatchRequirements(reqs ...FeatureRequirement) bool {
 	return true
 }
 
+// IPFamilies returns the list of enabled IP families.
+func (fs FeatureSet) IPFamilies() []IPFamily {
+	var families []IPFamily
+
+	if fs.MatchRequirements(RequireFeatureEnabled(FeatureIPv4)) {
+		families = append(families, IPFamilyV4)
+	}
+
+	if fs.MatchRequirements(RequireFeatureEnabled(FeatureIPv6)) {
+		families = append(families, IPFamilyV6)
+	}
+
+	return families
+}
+
 // deriveFeatures derives additional features based on the status of other features
 func (fs FeatureSet) deriveFeatures() error {
 	fs[FeatureHostPort] = FeatureStatus{


### PR DESCRIPTION
0dccab2ea3f1 ("connectivity: wait for service propagation in agents") introduced an additional check to wait until all test services have been synchronized by cilium agents before starting the actual tests. Yet, this check will never succeed if the cluster is configured in dual stack mode, but only one IP family is enabled by Cilium. Indeed, the backends for the disabled IP family will never be populated. Hence, let's skip this check if the ClusterIP belongs to a disabled IP family.

Fixes: 0dccab2ea3f1 ("connectivity: wait for service propagation in agents")
Reported-by: Donia Chaiehloudj