### PR TITLE
Create a separate RESTClientGetter for Helm client

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1945,7 +1945,7 @@ func EnableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameter
 		ResetValues: false,
 		ReuseValues: true,
 	}
-	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetterForHelm, upgradeParams)
 	return err
 }
 
@@ -1965,12 +1965,12 @@ func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Paramete
 		ResetValues: false,
 		ReuseValues: true,
 	}
-	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetterForHelm, upgradeParams)
 	return err
 }
 
 func getRelease(kc *k8s.Client, namespace string) (*release.Release, error) {
-	client := kc.RESTClientGetter
+	client := kc.RESTClientGetterForHelm
 	release, err := helm.GetCurrentRelease(client, namespace, defaults.HelmReleaseName)
 	if err != nil {
 		return nil, err
@@ -2084,7 +2084,7 @@ func (k *K8sClusterMesh) ConnectWithHelm(ctx context.Context) error {
 	// Enable clustermesh using a Helm Upgrade command against our target cluster
 	k.Log("ℹ️ Configuring Cilium in cluster '%s' to connect to cluster '%s'",
 		localClient.ClusterName(), remoteClient.ClusterName())
-	_, err = helm.Upgrade(ctx, localClient.RESTClientGetter, upgradeParams)
+	_, err = helm.Upgrade(ctx, localClient.RESTClientGetterForHelm, upgradeParams)
 	if err != nil {
 		return err
 	}
@@ -2093,7 +2093,7 @@ func (k *K8sClusterMesh) ConnectWithHelm(ctx context.Context) error {
 	k.Log("ℹ️ Configuring Cilium in cluster '%s' to connect to cluster '%s'",
 		remoteClient.ClusterName(), localClient.ClusterName())
 	upgradeParams.Values = remoteHelmValues
-	_, err = helm.Upgrade(ctx, remoteClient.RESTClientGetter, upgradeParams)
+	_, err = helm.Upgrade(ctx, remoteClient.RESTClientGetterForHelm, upgradeParams)
 	if err != nil {
 		return err
 	}
@@ -2187,7 +2187,7 @@ func (k *K8sClusterMesh) DisconnectWithHelm(ctx context.Context) error {
 	// Disconnect clustermesh using a Helm Upgrade command against our target cluster
 	k.Log("ℹ️ Configuring Cilium in cluster '%s' to disconnect from cluster '%s'",
 		localClient.ClusterName(), remoteClient.ClusterName())
-	if _, err = helm.Upgrade(ctx, localClient.RESTClientGetter, upgradeParams); err != nil {
+	if _, err = helm.Upgrade(ctx, localClient.RESTClientGetterForHelm, upgradeParams); err != nil {
 		return err
 	}
 
@@ -2195,7 +2195,7 @@ func (k *K8sClusterMesh) DisconnectWithHelm(ctx context.Context) error {
 	k.Log("ℹ️ Configuring Cilium in cluster '%s' to disconnect from cluster '%s'",
 		remoteClient.ClusterName(), localClient.ClusterName())
 	upgradeParams.Values = remoteHelmValues
-	if _, err = helm.Upgrade(ctx, remoteClient.RESTClientGetter, upgradeParams); err != nil {
+	if _, err = helm.Upgrade(ctx, remoteClient.RESTClientGetterForHelm, upgradeParams); err != nil {
 		return err
 	}
 	k.Log("✅ Disconnected clusters %s and %s!", localClient.ClusterName(), remoteClient.ClusterName())

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -863,7 +863,7 @@ func EnableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameter
 		ResetValues: false,
 		ReuseValues: true,
 	}
-	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetterForHelm, upgradeParams)
 	return err
 }
 
@@ -882,6 +882,6 @@ func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Paramete
 		ResetValues: false,
 		ReuseValues: true,
 	}
-	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetter, upgradeParams)
+	_, err = helm.Upgrade(ctx, k8sClient.RESTClientGetterForHelm, upgradeParams)
 	return err
 }

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -281,7 +281,7 @@ cilium install --context kind-cluster1 --helm-set cluster.id=1 --helm-set cluste
 				return err
 			}
 			cmd.SilenceUsage = true
-			if err := installer.InstallWithHelm(context.Background(), k8sClient.RESTClientGetter); err != nil {
+			if err := installer.InstallWithHelm(context.Background(), k8sClient.RESTClientGetterForHelm); err != nil {
 				fatalf("Unable to install Cilium: %s", err)
 			}
 			return nil
@@ -319,7 +319,7 @@ func newCmdUninstallWithHelm() *cobra.Command {
 				cc.UninstallResources(ctx, params.Wait)
 			}
 			uninstaller := install.NewK8sUninstaller(k8sClient, params)
-			if err := uninstaller.UninstallWithHelm(ctx, k8sClient.RESTClientGetter); err != nil {
+			if err := uninstaller.UninstallWithHelm(ctx, k8sClient.RESTClientGetterForHelm); err != nil {
 				fatalf("Unable to uninstall Cilium:  %s", err)
 			}
 			return nil
@@ -359,7 +359,7 @@ cilium upgrade --helm-set cluster.id=1 --helm-set cluster.name=cluster1
 				return err
 			}
 			cmd.SilenceUsage = true
-			if err := installer.UpgradeWithHelm(context.Background(), k8sClient.RESTClientGetter); err != nil {
+			if err := installer.UpgradeWithHelm(context.Background(), k8sClient.RESTClientGetterForHelm); err != nil {
 				fatalf("Unable to upgrade Cilium: %s", err)
 			}
 			return nil

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -545,7 +545,7 @@ func (k *K8sStatusCollector) status(ctx context.Context) *Status {
 				if !ok {
 					return fmt.Errorf("failed to initialize Helm client")
 				}
-				release, err := helm.Get(client.RESTClientGetter, helm.GetParameters{
+				release, err := helm.Get(client.RESTClientGetterForHelm, helm.GetParameters{
 					Namespace: k.params.Namespace,
 					Name:      defaults.HelmReleaseName,
 				})


### PR DESCRIPTION
Sharing the same RESTClientGetter between Helm client and direct Kubernetes API calls causes "concurrent map read and map write" fatal error as reported in #1794. Introduce a dedicated RESTClientGetter for Helm client so that you don't have to worry about synchronizing access to the same RESTClientGetter. No sharing, no concurrent map read and map write. Problem solved.

Fixes: #1794