### PR TITLE
hooks: Add new hook SetupAndValidate()

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -4,6 +4,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -39,7 +41,8 @@ type NopHooks struct{}
 
 var _ Hooks = &NopHooks{}
 
-func (*NopHooks) AddSysdumpFlags(*pflag.FlagSet)                     {}
-func (*NopHooks) AddSysdumpTasks(*sysdump.Collector) error           { return nil }
-func (*NopHooks) AddConnectivityTestFlags(*pflag.FlagSet)            {}
-func (*NopHooks) AddConnectivityTests(*check.ConnectivityTest) error { return nil }
+func (*NopHooks) AddSysdumpFlags(*pflag.FlagSet)                                  {}
+func (*NopHooks) AddSysdumpTasks(*sysdump.Collector) error                        { return nil }
+func (*NopHooks) AddConnectivityTestFlags(*pflag.FlagSet)                         {}
+func (*NopHooks) AddConnectivityTests(*check.ConnectivityTest) error              { return nil }
+func (*NopHooks) SetupAndValidate(context.Context, *check.ConnectivityTest) error { return nil }

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -1054,7 +1054,7 @@ func (a *Action) validateMetric(ctx context.Context, node string, result Metrics
 		select {
 		case <-ctx.Done():
 			// Context timeout is reached, let's exit.
-			a.Failf("failed to collect metrics on node %s, context timeout: %w", node, ctx.Err().Error())
+			a.Failf("failed to collect metrics on node %s, context timeout: %s\n", node, ctx.Err())
 			return
 		case <-ticker.C:
 			// Ticker is delivered, let's retry.

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -260,7 +260,7 @@ func (ct *ConnectivityTest) GetTest(name string) (*Test, error) {
 // SetupAndValidate sets up and validates the connectivity test infrastructure
 // such as the client pods and validates the deployment of them along with
 // Cilium. This must be run before Run() is called.
-func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context) error {
+func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context, setupAndValidateExtras func(ctx context.Context, ct *ConnectivityTest) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -276,6 +276,10 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context) error {
 		return err
 	}
 	if err := ct.detectFeatures(ctx); err != nil {
+		return err
+	}
+	// Setup and validate all the extras coming from extended functionalities.
+	if err := setupAndValidateExtras(ctx, ct); err != nil {
 		return err
 	}
 	if err := ct.getNodes(ctx); err != nil {

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -168,6 +168,11 @@ func (s Service) Name() string {
 	return s.Service.Namespace + "/" + s.Service.Name
 }
 
+// NameWithoutNamespace returns the name of the service without the namespace.
+func (s Service) NameWithoutNamespace() string {
+	return s.Service.Name
+}
+
 // Scheme returns the string 'http'.
 func (s Service) Scheme() string {
 	// We only have http services for now.

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -169,8 +168,9 @@ var (
 	client2Label = map[string]string{"name": "client2"}
 )
 
-func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*check.ConnectivityTest) error) error {
-	if err := ct.SetupAndValidate(ctx); err != nil {
+func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*check.ConnectivityTest) error,
+	addExtraSetup func(context.Context, *check.ConnectivityTest) error) error {
+	if err := ct.SetupAndValidate(ctx, addExtraSetup); err != nil {
 		return err
 	}
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -90,7 +90,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 			// and end the goroutine without returning.
 			go func() {
 				defer func() { done <- struct{}{} }()
-				err = connectivity.Run(ctx, cc, hooks.AddConnectivityTests)
+				err = connectivity.Run(ctx, cc, hooks.AddConnectivityTests, hooks.SetupAndValidate)
 
 				// If Fatal() was called in the test suite, the statement below won't fire.
 				finished = true

--- a/internal/cli/cmd/hooks.go
+++ b/internal/cli/cmd/hooks.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
@@ -18,6 +20,7 @@ type Hooks interface {
 
 // ConnectivityTestHooks to extend cilium-cli with additional connectivity tests and related flags.
 type ConnectivityTestHooks interface {
+	SetupAndValidate(ctx context.Context, ct *check.ConnectivityTest) error
 	AddConnectivityTestFlags(flags *pflag.FlagSet)
 	AddConnectivityTests(ct *check.ConnectivityTest) error
 }


### PR DESCRIPTION
- In order to extend the possibility to setup and initialise for extended functionalities, a new hook is needed `SetupAndValidate`. 
- Create a method on service (like for pod) NameWithoutNamespace() to remove the namespace prefix. It will enable to make call to the domain easily.
- Realised that an error log was not properly formatted, just fixing it (not related to the PR).
