### PR TITLE
Eksctl version pinned.

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   region: us-east-2
+  eksctl_version: v0.147.0
   # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.4
   kubectl_version: v1.23.6
@@ -57,7 +58,7 @@ jobs:
 
       - name: Install eksctl CLI
         run: |
-          curl -LO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
+          curl -LO "https://github.com/weaveworks/eksctl/releases/download/${{ env.eksctl_version }}/eksctl_$(uname -s)_amd64.tar.gz"
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   region: us-east-2
+  eksctl_version: v0.147.0
   # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.13.4
   kubectl_version: v1.23.6
@@ -57,7 +58,7 @@ jobs:
 
       - name: Install eksctl CLI
         run: |
-          curl -LO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
+          curl -LO "https://github.com/weaveworks/eksctl/releases/download/${{ env.eksctl_version }}/eksctl_$(uname -s)_amd64.tar.gz"
           sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
           rm eksctl_$(uname -s)_amd64.tar.gz
 


### PR DESCRIPTION
This is fix for the below error in pipeline:
```
Error: unable to describe cluster control plane: operation error EKS: DescribeCluster, https response error StatusCode: 404, RequestID: 007b2aae-2936-44cb-9cbf-4958dd3df8c2, ResourceNotFoundException: No cluster found for name: cilium-cilium-cli-5505927612-1-classic.
```

Successful runs: https://github.com/cilium/cilium-cli/actions/runs/5510195812/jobs/10044035655?pr=1817

**The latest CI EKS related tests failed which is expected due to the issue with `eksctls` tool.**