### PR TITLE
GHA: fix 'install-cilium-cli' issue when building from source

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,11 +38,11 @@ runs:
       if: ${{ steps.build-cli.outputs.path != '' }}
       shell: bash
       run: |
-        cd ${{ steps.build-cli.outputs.path }}
-        make TARGET=${{ inputs.binary-name }}
+        TARGET=/tmp/cilium
+        make -C ${{ steps.build-cli.outputs.path }} TARGET=${TARGET}
         # Install the binary in a separate step (rather than executing make install)
         # to avoid building the binary as root, which would cause issues with caching.
-        sudo mv ${{ inputs.binary-name }} ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
+        sudo mv ${TARGET} ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
 
     - name: Check Required Version
       if: ${{ steps.build-cli.outputs.path == '' && inputs.release-version == '' && inputs.ci-version == '' }}


### PR DESCRIPTION
This PR modifies the install-cilium-cli action to respect the specified destination path also when it is relative. Additionally, the binary is now built in a temporary directory to mimic the behavior of the other steps, and prevent possible name clashes.