### PR TITLE
Improve the clustermesh status command

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -462,7 +462,6 @@ type Parameters struct {
 	WaitDuration         time.Duration
 	DestinationEndpoints []string
 	SourceEndpoints      []string
-	SkipServiceCheck     bool
 	ApiserverImage       string
 	ApiserverVersion     string
 	CreateCA             bool

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1272,10 +1272,7 @@ func (k *K8sClusterMesh) statusConnectivity(ctx context.Context) (*ConnectivityS
 		if k.params.Wait {
 			if err == nil {
 				if status.NotReady > 0 {
-					err = fmt.Errorf("%d clusters not ready", status.NotReady)
-				}
-				if len(status.Errors) > 0 {
-					err = fmt.Errorf("%d clusters have errors", len(status.Errors))
+					err = fmt.Errorf("%d nodes are not ready", status.NotReady)
 				}
 			}
 

--- a/clustermesh/clustermesh_test.go
+++ b/clustermesh/clustermesh_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
@@ -202,6 +203,74 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 				return
 			}
 			assert.Equal(t, u.e, ee)
+		})
+	}
+}
+
+func TestRemoteClusterStatusToError(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   *models.RemoteCluster
+		expected string
+	}{
+		{
+			name:     "nil status",
+			expected: "unknown status",
+		},
+		{
+			name:     "not connected",
+			status:   &models.RemoteCluster{Status: "foo"},
+			expected: "foo",
+		},
+		{
+			name:     "connected, unknown config",
+			status:   &models.RemoteCluster{Connected: true},
+			expected: "remote cluster configuration retrieval status unknown",
+		},
+		{
+			name: "connected, config not found",
+			status: &models.RemoteCluster{
+				Connected: true, Config: &models.RemoteClusterConfig{Required: true}},
+			expected: "remote cluster configuration required but not found",
+		},
+		{
+			name: "connected, config not required, sync status unknown",
+			status: &models.RemoteCluster{
+				Connected: true, Config: &models.RemoteClusterConfig{}},
+			expected: "synchronization status unknown",
+		},
+		{
+			name: "connected, config found, no resource type synced",
+			status: &models.RemoteCluster{
+				Connected: true,
+				Config:    &models.RemoteClusterConfig{Required: true, Retrieved: true},
+				Synced:    &models.RemoteClusterSynced{},
+			},
+			expected: "synchronization in progress for endpoints, identities, nodes, services",
+		},
+		{
+			name: "connected, config found, some resource type not synced",
+			status: &models.RemoteCluster{
+				Connected: true,
+				Config:    &models.RemoteClusterConfig{Required: true, Retrieved: true},
+				Synced:    &models.RemoteClusterSynced{Endpoints: true, Nodes: true, Services: true},
+			},
+			expected: "synchronization in progress for identities",
+		},
+		{
+			name: "none of the above",
+			status: &models.RemoteCluster{
+				Connected: true,
+				Config:    &models.RemoteClusterConfig{Required: true, Retrieved: true},
+				Synced:    &models.RemoteClusterSynced{Endpoints: true, Identities: true, Nodes: true, Services: true},
+			},
+			expected: "not ready",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, remoteClusterStatusToError(tt.status).Error())
 		})
 	}
 }

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -179,7 +179,6 @@ func newCmdClusterMeshStatus() *cobra.Command {
 
 	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait until status is successful")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait")
-	cmd.Flags().BoolVar(&params.SkipServiceCheck, "skip-service-check", false, "Do not require service IP of remote cluster to be available")
 	cmd.Flags().StringVarP(&params.Output, "output", "o", status.OutputSummary, "Output format. One of: json, summary")
 
 	return cmd

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -130,7 +130,6 @@ func NewWaitObserver(ctx context.Context, p WaitParameters) *WaitObserver {
 	w := &WaitObserver{
 		ctx:         ctx,
 		params:      p,
-		lastWarning: time.Now(),
 		waitStarted: time.Now(),
 	}
 

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -92,7 +92,7 @@ func (k *K8sStatusCollector) ClusterMeshConnectivity(ctx context.Context, cilium
 
 	status, err := k.client.CiliumStatus(ctx, k.params.Namespace, ciliumPod)
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine cilium status: %w", err)
+		return nil, err
 	}
 
 	if status.ClusterMesh == nil {


### PR DESCRIPTION
This PR includes a set of improvements for the `cilium clustermesh status` command, to simplify troubleshooting and reduce CI flakiness:

* Always check the readiness of the clustermesh-apiserver deployment.
* Report a node as not ready also when the configuration has not yet been detected (as the secret modification has not propagated yet).
* Report explicit errors about why a node is not ready, based on the additional information introduced in https://github.com/cilium/cilium/pull/26788 (e.g., etcd connection, cluster configuration retrieval, data synchronization).
* Remove duplicate checks and fix inaccuracies in output messages.

Please refer to the individual commit messages for additional information.

Fixes: https://github.com/cilium/cilium-cli/issues/1773

~~I'm currently marking this PR as ready for review as it makes sense that the review occurs in parallel with that of https://github.com/cilium/cilium/pull/26788, so that possible modifications can be synchronized. The commit with the go.mod changes will be dropped before merging.~~