### PR TITLE
Partly revert "connectivity: enable IPv6 test fort per-endpoint routing"

### DIFF
--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -725,6 +725,17 @@ func (t *Test) collectSysdump() {
 
 func (t *Test) ForEachIPFamily(do func(IPFamily)) {
 	ipFams := []IPFamily{IPFamilyV4, IPFamilyV6}
+
+	// The per-endpoint routes feature is broken with IPv6 on < v1.14 when there
+	// are any netpols installed (https://github.com/cilium/cilium/issues/23852
+	// and https://github.com/cilium/cilium/issues/23910).
+	if f, ok := t.Context().Feature(FeatureEndpointRoutes); ok &&
+		f.Enabled && (len(t.cnps) > 0 || len(t.knps) > 0) &&
+		versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) {
+
+		ipFams = []IPFamily{IPFamilyV4}
+	}
+
 	for _, ipFam := range ipFams {
 		switch ipFam {
 		case IPFamilyV4:


### PR DESCRIPTION
This commit partly reverts 6c20d0da12 by adding the exclusion check for < v1.14. The EP issue for v6 was resolved only in >= v1.14.0

The successful run on v1.13 - https://github.com/cilium/cilium/actions/runs/5574065263/jobs/10182228218. I'm going to fix the failed 9th job in [a separate PR](https://github.com/cilium/cilium/pull/26856).

#agony-of-cli-cilium-repo-split