### PR TITLE
Pick up SPIRE status messages from cilium-agent

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -218,6 +218,10 @@ func (s *Status) parseStatusResponse(deployment, podName string, r *models.Statu
 		s.parseCiliumSubsystemStatus(deployment, podName, "Kvstore", r.Kvstore)
 	}
 
+	if r.AuthCertificateProvider != nil {
+		s.parseCiliumSubsystemStatus(deployment, podName, "AuthCertificateProvider", r.AuthCertificateProvider)
+	}
+
 	if len(r.Controllers) > 0 {
 		for _, ctrl := range r.Controllers {
 			if ctrl.Status == nil || ctrl.Status.ConsecutiveFailureCount == 0 {


### PR DESCRIPTION
This parses the SPIRE connection status if enabled. And will surface errors if present. This also makes sure `--wait` will wait on SPIRE to be up and running in e2e tests.

Fixes https://github.com/cilium/cilium-cli/issues/1821
Uses https://github.com/cilium/cilium/pull/26896 for agent status


```
user@maartje-XPS-9315 ~/g/s/g/c/cilium-cli (main)> ./cilium status
    /¯¯\
 /¯¯\__/¯¯\    Cilium:          2 errors
 \__/¯¯\__/    Operator:        OK
 /¯¯\__/¯¯\    Hubble Relay:    disabled
 \__/¯¯\__/    ClusterMesh:     disabled
    \__/

Deployment        cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
DaemonSet         cilium             Desired: 2, Ready: 2/2, Available: 2/2
Containers:       cilium             Running: 2
                  cilium-operator    Running: 1
Cluster Pods:     3/3 managed by Cilium
Image versions    cilium             localhost:5000/cilium/cilium-dev:local: 2
                  cilium-operator    localhost:5000/cilium/operator-generic:local: 1
Errors:           cilium             cilium-9zwgp    Spire: not connected to SPIRE server
                  cilium             cilium-m2zs7    Spire: not connected to SPIRE server
```