### PR TITLE
kind: Configure external targets inside the cluster

### DIFF
--- a/.github/external-targets/certs.yaml
+++ b/.github/external-targets/certs.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+ name: ca-cert
+spec:
+ secretName: ca
+ isCA: true
+ issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+ commonName: "cilium.io"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: external-target-cert
+spec:
+  secretName: external-target-cert
+  dnsNames:
+  - "chart-testing-worker2"
+  - "chart-testing-worker3"
+  ipAddresses:
+  - "${worker2_ip}"
+  - "${worker3_ip}"
+  issuerRef:
+    name: ca-cert-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-cert-issuer
+spec:
+ ca:
+   secretName: ca

--- a/.github/external-targets/nginx.yaml
+++ b/.github/external-targets/nginx.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data:
+  nginx.conf: |
+    server {
+        listen       80;
+        listen       443 ssl;
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+        ssl_certificate     /etc/cert/tls.crt;
+        ssl_certificate_key /etc/cert/tls.key;
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cilium.io/no-schedule
+                operator: In
+                values:
+                - "true"
+      hostNetwork: true
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: cert
+              mountPath: "/etc/cert/"
+              readOnly: true
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+      volumes:
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+          items:
+            - key: nginx.conf
+              path: nginx.conf
+      - name: cert
+        secret:
+          secretName: external-target-cert

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -1,5 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: chart-testing
 nodes:
   - role: control-plane
     image: kindest/node:v1.19.11
@@ -13,8 +14,15 @@ nodes:
           taints: []
   - role: worker
     image: kindest/node:v1.19.11
+  # Two extra nodes without Cilium to use for --external-ip and --external-other-ip.
   - role: worker
     image: kindest/node:v1.19.11
+    labels:
+      cilium.io/no-schedule: "true"
+  - role: worker
+    image: kindest/node:v1.19.11
+    labels:
+      cilium.io/no-schedule: "true"
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -65,15 +65,7 @@ jobs:
       - name: Set NODES_WITHOUT_CILIUM
         run: |
           # To add more elements, keep it comma-separated.
-          echo "NODES_WITHOUT_CILIUM=chart-testing-worker2" >> $GITHUB_ENV
-
-      - name: Label nodes
-        if: ${{ matrix.mode == 'helm' }}
-        run: |
-          IFS=',' read -ra nodes <<< "$NODES_WITHOUT_CILIUM"
-          for node in "${nodes[@]}"; do
-            kubectl label nodes "${node}" cilium.io/no-schedule=true
-          done
+          echo "NODES_WITHOUT_CILIUM=chart-testing-worker2,chart-testing-worker3" >> $GITHUB_ENV
 
       # Install Cilium with HostPort support and enables Prometheus for extended connectivity test.
       - name: Install Cilium
@@ -99,13 +91,36 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Set up external targets
+        id: external_targets
+        run: |
+          export worker2_ip=$(kubectl get nodes chart-testing-worker2 -o=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+          export worker3_ip=$(kubectl get nodes chart-testing-worker3 -o=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+          echo "worker2_ip=${worker2_ip}" >> $GITHUB_OUTPUT
+          echo "worker3_ip=${worker3_ip}" >> $GITHUB_OUTPUT
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+          kubectl rollout status -n cert-manager deployment.apps/cert-manager
+          kubectl rollout status -n cert-manager deployment.apps/cert-manager-webhook
+          kubectl create ns external-targets
+          cat .github/external-targets/certs.yaml | envsubst | kubectl apply -n external-targets -f -
+          until kubectl get secret -n external-targets external-target-cert &> /dev/null; do sleep 1s; done
+          kubectl apply -n external-targets -f .github/external-targets/nginx.yaml
+          kubectl rollout status -n external-targets ds/nginx
+
       - name: Connectivity Test
         run: |
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
           cilium connectivity test --debug --all-flows --test-namespace test-namespace \
             --include-unsafe-tests \
             --collect-sysdump-on-failure --junit-file cilium-junit-${{ matrix.mode }}-1.xml \
-            --junit-property mode=${{ matrix.mode }} --junit-property type=no-tunnel
+            --junit-property mode=${{ matrix.mode }} --junit-property type=no-tunnel \
+            --curl-insecure \
+            --external-target chart-testing-worker2 \
+            --external-target-ca-namespace=external-targets \
+            --external-target-ca-name=ca \
+            --external-cidr 172.18.0.0/16 \
+            --external-ip ${{ steps.external_targets.outputs.worker2_ip }} \
+            --external-other-ip ${{ steps.external_targets.outputs.worker3_ip }}
 
       - name: Uninstall cilium
         run: |
@@ -149,7 +164,14 @@ jobs:
           cilium connectivity test --debug --force-deploy --all-flows --test-namespace test-namespace \
             --include-unsafe-tests \
             --collect-sysdump-on-failure --junit-file cilium-junit-${{ matrix.mode }}-2.xml \
-            --junit-property mode=${{ matrix.mode }} --junit-property type=ipsec
+            --junit-property mode=${{ matrix.mode }} --junit-property type=ipsec \
+            --curl-insecure \
+            --external-target chart-testing-worker2 \
+            --external-target-ca-namespace=external-targets \
+            --external-target-ca-name=ca \
+            --external-cidr 172.18.0.0/16 \
+            --external-ip ${{ steps.external_targets.outputs.worker2_ip }} \
+            --external-other-ip ${{ steps.external_targets.outputs.worker3_ip }}
 
       - name: Upload JUnit
         if: ${{ always() }}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -84,6 +84,9 @@ type Parameters struct {
 
 	CollectSysdumpOnFailure bool
 	SysdumpOptions          sysdump.Options
+
+	ExternalTargetCANamespace string
+	ExternalTargetCAName      string
 }
 
 type podCIDRs struct {

--- a/connectivity/manifests/client-egress-l7-tls.yaml
+++ b/connectivity/manifests/client-egress-l7-tls.yaml
@@ -29,8 +29,8 @@ specs:
           name: externaltarget-tls # internal certificate to terminate in cluster
       originatingTLS:
         secret:
-          namespace: "{{.TestNamespace}}"
-          name: cabundle # public CA bundle to validate external target
+          namespace: "{{.ExternalTargetCANamespace}}"
+          name: "{{.ExternalTargetCAName}}" # public CA bundle to validate external target
       rules:
         http:
         - method: "GET"

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -1067,7 +1067,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 	}
 
 	if ct.Params().IncludeUnsafeTests {
-		ct.NewTest("check-log-errors").WithScenarios(tests.NoErrorsInLogs())
+		ct.NewTest("check-log-errors").WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion))
 	}
 
 	return ct.Run(ctx)

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -134,6 +134,8 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Timestamp, "timestamp", "t", false, "Show timestamp in messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 	cmd.Flags().StringVar(&params.ExternalTarget, "external-target", "one.one.one.one", "Domain name to use as external target in connectivity tests")
+	cmd.Flags().StringVar(&params.ExternalTargetCANamespace, "external-target-ca-namespace", defaults.ConnectivityCheckNamespace, "Namespace of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
+	cmd.Flags().StringVar(&params.ExternalTargetCAName, "external-target-ca-name", "cabundle", "Name of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalIP, "external-ip", "1.1.1.1", "IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")


### PR DESCRIPTION
3 commits:

- add `--external-target-ca-{name,namespace}` flags to override CA bundle secret for client-egress-l7-tls tests.
- add an error log exception for "Unable to find identity of previously used CIDR" message for cilium version <1.14. see https://github.com/cilium/cilium/issues/26881 for details.
- set up external targets inside the cluster for the kind workflow.