### PR TITLE
fix(cli-example): optimize the example of the 'install' command line.

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -268,7 +268,7 @@ cilium install
 
 # Install Cilium into Kubernetes context "kind-cluster1" and also set cluster
 # name and ID to prepare for multi-cluster capabilities.
-cilium install --context kind-cluster1 --helm-set cluster.id=1 --helm-set cluster.name=cluster1
+cilium install --context kind-cluster1 --set cluster.id=1 --set cluster.name=cluster1
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params.Namespace = namespace


### PR DESCRIPTION
Since `--helm-set` is an alias of `--set` and only `--set` is listed in help, it would be confusing when example still use

```
# Install Cilium into Kubernetes context "kind-cluster1" and also set cluster
# name and ID to prepare for multi-cluster capabilities.
cilium install --context kind-cluster1 --helm-set cluster.id=1 --helm-set cluster.name=cluster1
```
Instead we should use set as follows

```
# Install Cilium into Kubernetes context "kind-cluster1" and also set cluster
# name and ID to prepare for multi-cluster capabilities.
cilium install --context kind-cluster1 --set cluster.id=1 --set cluster.name=cluster1
```
This way, users can easily find the correct flag in the `--help` command.