### PR TITLE
metrics: Set first retrieved metrics to 0 if absent

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -1046,7 +1046,7 @@ func (a *Action) validateMetric(ctx context.Context, node string, result Metrics
 			a.Debugf("failed to check metrics on node %s: %s\n", node, err)
 		} else {
 			// Metrics check succeed, let's exit.
-			a.Debugf("checked metrics properly on node %s: %s\n", node)
+			a.Debugf("checked metrics properly on node %s\n", node)
 			return
 
 		}

--- a/connectivity/check/result.go
+++ b/connectivity/check/result.go
@@ -167,19 +167,17 @@ func assertMetricsIncrease(metrics ...string) assertMetricsFunc {
 	return func(before, after map[string]*dto.MetricFamily) error {
 		var err error
 		for _, metricName := range metrics {
-			bValue, ok := before[metricName]
-			if !ok {
-				err = errors.Join(err, fmt.Errorf("metric %s has not been retrieved before action", metricName))
-			}
+			// beforeValue can be absent, we will consider it as nil by default.
+			beforeValue := before[metricName]
 
-			aValue, ok := after[metricName]
+			afterValue, ok := after[metricName]
 			if !ok {
 				err = errors.Join(err, fmt.Errorf("metric %s has not been retrieved after action", metricName))
 			}
 
 			// Additional check needed because previously we do not return in case of error, otherwise we will panic!
-			if bValue != nil && aValue != nil {
-				errM := metricsIncrease(bValue, aValue)
+			if afterValue != nil {
+				errM := metricsIncrease(beforeValue, afterValue)
 				if errM != nil {
 					err = errors.Join(err, errM)
 				}

--- a/connectivity/check/result_test.go
+++ b/connectivity/check/result_test.go
@@ -115,7 +115,7 @@ func TestExpectMetricsToIncrease(t *testing.T) {
 			metricsAfter:  metricsBefore,
 			wantErr:       true,
 		},
-		"metric name not present in the metrics before": {
+		"metric name not present in the metrics before, counters should be set 0": {
 			metrics: "cilium_forward_count_total",
 			source: MetricsSource{
 				Name: components.CiliumAgentName,
@@ -124,7 +124,7 @@ func TestExpectMetricsToIncrease(t *testing.T) {
 			},
 			metricsBefore: otherMetric,
 			metricsAfter:  metricsAfter,
-			wantErr:       true,
+			wantErr:       false,
 		},
 		"metric name not present in the metrics after": {
 			metrics:       "cilium_forward_count_total",


### PR DESCRIPTION
When a cluster is freshly deployed and no traffic was observed, certain metrics does not appear yet.  This commit intents to set to 0 the counters of the MetricFamily if the metric was not present.

Testing on a fresh cluster:

No metrics at the beginning, set to 0:
```
2023/07/25 10:45:42 [WARNING] metric xxx was not found before the action was run
2023/07/25 10:45:42 [WARNING] metric xxx counters was set to 0
```

Finally checked the metrics properly:
```
🐛 Forwarding from [::1]:60476 -> 9967

🐛 Handling connection for 60476

  🐛 checked metrics properly on node kind-worker

  🐛 Finalizing Test external-cilium-dns-proxy
  🐛 Pod kube-system/cilium-dzmnb's current policy revision: 2
  🐛 Pod kube-system/cilium-wmvfn's current policy revision: 2
  ℹ️  📜 Deleting CiliumNetworkPolicy 'dns-via-proxy-for-client' from namespace 'cilium-test'..
  🐛 Pod kind-kind/kube-system/cilium-dzmnb revision > 2
  🐛 Pod kind-kind/kube-system/cilium-wmvfn revision > 2
  🐛 📜 Successfully deleted 1 CiliumNetworkPolicies

✅ All 1 tests (4 actions) successful, 54 tests skipped, 0 scenarios skipped.
```