### PR TITLE
connectivity: extend node to node encryption tests

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -212,7 +212,7 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 	}
 
 	if versioncheck.MustCompile("<1.14.0")(ct.CiliumVersion) {
-		mode = "disabled"
+		mode = "vxlan"
 		if v, ok := cm.Data["tunnel"]; ok {
 			mode = v
 		}
@@ -221,13 +221,16 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 			Mode:    mode,
 		}
 	} else {
-		mode = "native"
+		mode = "tunnel"
 		if v, ok := cm.Data["routing-mode"]; ok {
 			mode = v
 		}
-		tunnelProto := ""
+
+		tunnelProto := "vxlan"
 		if mode != "native" {
-			tunnelProto = cm.Data["tunnel-protocol"]
+			if v, ok := cm.Data["tunnel-protocol"]; ok {
+				tunnelProto = v
+			}
 		}
 
 		result[FeatureTunnel] = FeatureStatus{


### PR DESCRIPTION
This PR extends the node-to-node encryption tests. Before no actions would fail when running them with encryption disabled (Before https://github.com/cilium/cilium/pull/26712 it was 1/3, because the tunneling feature wasn't correctly detected) in one of my environments (WireGuard, tunnel, vxlan, endpointRoutes). I've adapted them so they work with native routing and tunneling with WireGuard (as far as I could test it), i.e. all actions fail when encryption is disabled and succeed if it is enabled.

The first two commits are just some minor cleanup and documentation in the feature detection. Feedback regarding the detection preference comment is especially welcome.


Output before:
```
[=] Test [node-to-node-encryption]
  [-] Scenario [node-to-node-encryption/node-to-node-encryption]
  🐛 Detected cilium_vxlan iface for communication among client and server nodes
  🐛 Running in bg: tcpdump -i cilium_vxlan --immediate-mode -w /tmp/node-to-node-encryption.pcap src host 10.244.2.111 and dst host 192.168.179.114 and icmp -c 1
  [.] Action [node-to-node-encryption/node-to-node-encryption/ping-ipv4: cilium-test/client-c4bfddc44-jgzxz (10.244.2.111) -> cilium-test/host-netns-h6nn8 (192.168.179.114:0)]
  🐛 Executing command [ping -c 1 -W 2 -w 10 192.168.179.114]
  🐛 Detected cilium_vxlan iface for communication among client and server nodes
  🐛 Running in bg: tcpdump -i cilium_vxlan --immediate-mode -w /tmp/node-to-node-encryption.pcap src host 192.168.179.108 and dst host 192.168.179.114 and icmp -c 1
  [.] Action [node-to-node-encryption/node-to-node-encryption/ping-ipv4: cilium-test/host-netns-2k57p (192.168.179.108) -> cilium-test/host-netns-h6nn8 (192.168.179.114:0)]
  🐛 Executing command [ping -c 1 -W 2 -w 10 192.168.179.114]
  🐛 Detected cilium_vxlan iface for communication among client and server nodes
  🐛 Running in bg: tcpdump -i cilium_vxlan --immediate-mode -w /tmp/node-to-node-encryption.pcap src host 192.168.179.108 and dst host 10.244.1.159 and tcp -c 1
  [.] Action [node-to-node-encryption/node-to-node-encryption/curl-ipv4: cilium-test/host-netns-2k57p (192.168.179.108) -> cilium-test/echo-other-node-646976b7dd-nxl4x (10.244.1.159:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.244.1.159:8080]
```

Output after:
```
[=] Test [node-to-node-encryption]
  [-] Scenario [node-to-node-encryption/node-to-node-encryption]
  🐛 Running /bin/sh -c ip -o route get 192.168.179.114 | grep -oE 'dev [^ ]*' | cut -d' ' -f2
  🐛 Running /bin/sh -c ip -o route get 192.168.179.114 | grep -oE 'src [^ ]*' | cut -d' ' -f2
  🐛 Running in bg: tcpdump -i ens5 --immediate-mode -w /tmp/node-to-node-encryption.pcap src host 192.168.179.108 and dst host 192.168.179.114 and icmp
  [.] Action [node-to-node-encryption/node-to-node-encryption/ping-ipv4: cilium-test/client-c4bfddc44-jgzxz (10.244.2.111) -> cilium-test/host-netns-h6nn8 (192.168.179.114:0)]
  🐛 Executing command [ping -c 1 -W 2 -w 10 192.168.179.114]
  ❌ Captured unencrypted pkt (count=1 packet)
  🐛 Captured pkts:
10:44:05.285615 IP 192.168.179.108 > 192.168.179.114: ICMP echo request, id 11628, seq 1, length 64

  🐛 Running /bin/sh -c ip -o route get 192.168.179.114 | grep -oE 'dev [^ ]*' | cut -d' ' -f2
  🐛 Running /bin/sh -c ip -o route get 192.168.179.114 | grep -oE 'src [^ ]*' | cut -d' ' -f2
  🐛 Running in bg: tcpdump -i ens5 --immediate-mode -w /tmp/node-to-node-encryption.pcap src host 192.168.179.108 and dst host 192.168.179.114 and icmp
  [.] Action [node-to-node-encryption/node-to-node-encryption/ping-ipv4: cilium-test/host-netns-2k57p (192.168.179.108) -> cilium-test/host-netns-h6nn8 (192.168.179.114:0)]
  🐛 Executing command [ping -c 1 -W 2 -w 10 192.168.179.114]
  ❌ Captured unencrypted pkt (count=1 packet)
  🐛 Captured pkts:
10:44:07.285568 IP 192.168.179.108 > 192.168.179.114: ICMP echo request, id 2, seq 1, length 64

  🐛 Running /bin/sh -c ip -o route get 10.244.1.159 | grep -oE 'dev [^ ]*' | cut -d' ' -f2
  🐛 Running /bin/sh -c ip -o route get 10.244.1.159 | grep -oE 'src [^ ]*' | cut -d' ' -f2
  🐛 Running in bg: tcpdump -i cilium_vxlan --immediate-mode -w /tmp/node-to-node-encryption.pcap src host 10.244.2.4 and dst host 10.244.1.159 and tcp
  [.] Action [node-to-node-encryption/node-to-node-encryption/curl-ipv4: cilium-test/host-netns-2k57p (192.168.179.108) -> cilium-test/echo-other-node-646976b7dd-nxl4x (10.244.1.159:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.244.1.159:8080]
  ❌ Captured unencrypted pkt (count=6 packets)
  🐛 Captured pkts:
10:44:09.107766 IP 10.244.2.4.55498 > 10.244.1.159.8080: Flags [S], seq 1124524169, win 64860, options [mss 1410,sackOK,TS val 2752214173 ecr 0,nop,wscale 7], length 0
10:44:09.108262 IP 10.244.2.4.55498 > 10.244.1.159.8080: Flags [.], ack 766383770, win 507, options [nop,nop,TS val 2752214174 ecr 3559090258], length 0
10:44:09.108331 IP 10.244.2.4.55498 > 10.244.1.159.8080: Flags [P.], seq 0:80, ack 1, win 507, options [nop,nop,TS val 2752214174 ecr 3559090258], length 80: HTTP: GET / HTTP/1.1
10:44:09.109436 IP 10.244.2.4.55498 > 10.244.1.159.8080: Flags [.], ack 2446, win 498, options [nop,nop,TS val 2752214175 ecr 3559090259], length 0
10:44:09.109563 IP 10.244.2.4.55498 > 10.244.1.159.8080: Flags [F.], seq 80, ack 2446, win 502, options [nop,nop,TS val 2752214175 ecr 3559090259], length 0
10:44:09.110085 IP 10.244.2.4.55498 > 10.244.1.159.8080: Flags [.], ack 2447, win 502, options [nop,nop,TS val 2752214176 ecr 3559090260], length 0
```