### PR TITLE
fix: Changed regex to include capital letters.

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -31,7 +31,7 @@ var (
 		},
 	}
 
-	clusterNameValidation = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])$`)
+	clusterNameValidation = regexp.MustCompile(`^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])$`)
 )
 
 func (p Parameters) checkDisabled(name string) bool {


### PR DESCRIPTION
Fixes #1871 

Helm validates capital letters during name check of clusters. Extended the same for cilium cli.