### PR TITLE
dockerfile: include CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@
 
 FROM docker.io/library/golang:1.20.4-alpine3.16@sha256:6469405d7297f82d56195c90a3270b0806ef4bd897aa0628477d9959ab97a577 as builder
 WORKDIR /go/src/github.com/cilium/cilium-cli
-RUN apk add --no-cache git make
+RUN apk add --no-cache git make ca-certificates
 COPY . .
 RUN make
 
 FROM docker.io/library/busybox:stable-glibc@sha256:7338d0c72c655d6534670ed72590cdc99afc9c559958c47eb3a5a17a7520a75c
 LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /go/src/github.com/cilium/cilium-cli/cilium /usr/local/bin/cilium
 RUN ["wget", "-P", "/usr/local/bin", "https://dl.k8s.io/release/v1.23.6/bin/linux/amd64/kubectl"]
 RUN ["chmod", "+x", "/usr/local/bin/kubectl"]


### PR DESCRIPTION
Busybox does not include CA certificates by default, which causes https requests to fail during certificate verification. For instance, the Cilium CLI fails to retrieve the hem chart with the following error:

```
looks like "https://helm.cilium.io" is not a valid chart repository or cannot be reached: Get "https://helm.cilium.io/index.yaml": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

Hence, let's propagate the CA certificates from the builder container.

Note: this error did not show up previously because the helm charts were vendored inside the CLI binary, hence avoiding the need to contact an external website. The v1.14 one, instead, is not vendored (yet?), hence causing all workflows to fail due to the impossibility of reaching `helm.cilium.io`. 