### PR TITLE
implement helm get values with sysdump

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -74,6 +74,9 @@ func initSysdumpFlags(cmd *cobra.Command, options *sysdump.Options, optionPrefix
 	cmd.Flags().StringVar(&options.CiliumEnvoyLabelSelector,
 		optionPrefix+"cilium-envoy-label-selector", sysdump.DefaultCiliumEnvoyLabelSelector,
 		"The labels used to target Cilium Envoy pods")
+	cmd.Flags().StringVar(&options.CiliumHelmReleaseName,
+		"cilium-helm-release-name", sysdump.DefaultCiliumHelmReleaseName,
+		"The Cilium Helm release name for which to get values")
 	cmd.Flags().StringVar(&options.CiliumOperatorLabelSelector,
 		optionPrefix+"cilium-operator-label-selector", sysdump.DefaultCiliumOperatorLabelSelector,
 		"The labels used to target Cilium operator pods")

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -41,6 +41,7 @@ type KubernetesClient interface {
 	GetSecret(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Secret, error)
 	GetCiliumVersion(ctx context.Context, p *corev1.Pod) (*semver.Version, error)
 	GetVersion(ctx context.Context) (string, error)
+	GetHelmValues(ctx context.Context, releaseName string, namespace string) (string, error)
 	ListCiliumBGPPeeringPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumBGPPeeringPolicyList, error)
 	ListCiliumCIDRGroups(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumCIDRGroupList, error)
 	ListCiliumClusterwideNetworkPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumClusterwideNetworkPolicyList, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -74,6 +74,7 @@ const (
 	cniConfigMapFileName                     = "cni-configmap-<ts>.yaml"
 	cniConfigFileName                        = "cniconf-%s-%s-<ts>.txt"
 	eniconfigsFileName                       = "aws-eniconfigs-<ts>.yaml"
+	ciliumHelmValuesFileName                 = "cilium-helm-values-<ts>.yaml"
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
 	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"
 	hubbleFlowsFileName                      = "hubble-flows-%s-<ts>.json"

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -6,6 +6,8 @@ package sysdump
 import (
 	"runtime"
 	"time"
+
+	"github.com/cilium/cilium-cli/defaults"
 )
 
 const (
@@ -41,6 +43,7 @@ const (
 	DefaultTetragonCLICommand                = "tetra"
 	DefaultTetragonTracingPolicy             = "tetragontracingpolicy-<ts>.yaml"
 	DefaultTetragonTracingPolicyNamespaced   = "tetragontracingpolicynamespaced-<ts>.yaml"
+	DefaultCiliumHelmReleaseName             = defaults.HelmReleaseName
 )
 
 var (

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -46,6 +46,8 @@ type Options struct {
 	CiliumDaemonSetSelector string
 	// The labels used to target Cilium Envoy pods.
 	CiliumEnvoyLabelSelector string
+	// The release name of Cilium Helm chart.
+	CiliumHelmReleaseName string
 	// The labels used to target Cilium Node Init daemon set. Usually, this label is same as CiliumNodeInitLabelSelector.
 	CiliumNodeInitDaemonSetSelector string
 	// The labels used to target Cilium Node Init pods.
@@ -1533,6 +1535,26 @@ func (c *Collector) Run() error {
 			},
 		})
 	}
+
+	helmTasks := []Task{
+		{
+			CreatesSubtasks: true,
+			Description:     "Collecting Helm values from the release",
+			Quick:           true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetHelmValues(ctx, c.Options.CiliumHelmReleaseName, c.Options.CiliumNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get the helm values from the release: %w", err)
+				}
+				if err := c.WriteString(ciliumHelmValuesFileName, v); err != nil {
+					return fmt.Errorf("failed to write the helm values to the file: %w", err)
+				}
+				return nil
+			},
+		},
+	}
+
+	tasks = append(tasks, helmTasks...)
 	// Append tasks added by AddTasks.
 	tasks = append(tasks, c.additionalTasks...)
 

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -350,6 +350,10 @@ func (c *fakeClient) GetVersion(_ context.Context) (string, error) {
 	panic("implement me")
 }
 
+func (c *fakeClient) GetHelmValues(_ context.Context, _ string, _ string) (string, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) ListCiliumCIDRGroups(_ context.Context, _ metav1.ListOptions) (*ciliumv2alpha1.CiliumCIDRGroupList, error) {
 	panic("implement me")
 }

--- a/vendor/helm.sh/helm/v3/pkg/cli/output/output.go
+++ b/vendor/helm.sh/helm/v3/pkg/cli/output/output.go
@@ -1,0 +1,140 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/gosuri/uitable"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
+)
+
+// Format is a type for capturing supported output formats
+type Format string
+
+const (
+	Table Format = "table"
+	JSON  Format = "json"
+	YAML  Format = "yaml"
+)
+
+// Formats returns a list of the string representation of the supported formats
+func Formats() []string {
+	return []string{Table.String(), JSON.String(), YAML.String()}
+}
+
+// FormatsWithDesc returns a list of the string representation of the supported formats
+// including a description
+func FormatsWithDesc() map[string]string {
+	return map[string]string{
+		Table.String(): "Output result in human-readable format",
+		JSON.String():  "Output result in JSON format",
+		YAML.String():  "Output result in YAML format",
+	}
+}
+
+// ErrInvalidFormatType is returned when an unsupported format type is used
+var ErrInvalidFormatType = fmt.Errorf("invalid format type")
+
+// String returns the string representation of the Format
+func (o Format) String() string {
+	return string(o)
+}
+
+// Write the output in the given format to the io.Writer. Unsupported formats
+// will return an error
+func (o Format) Write(out io.Writer, w Writer) error {
+	switch o {
+	case Table:
+		return w.WriteTable(out)
+	case JSON:
+		return w.WriteJSON(out)
+	case YAML:
+		return w.WriteYAML(out)
+	}
+	return ErrInvalidFormatType
+}
+
+// ParseFormat takes a raw string and returns the matching Format.
+// If the format does not exists, ErrInvalidFormatType is returned
+func ParseFormat(s string) (out Format, err error) {
+	switch s {
+	case Table.String():
+		out, err = Table, nil
+	case JSON.String():
+		out, err = JSON, nil
+	case YAML.String():
+		out, err = YAML, nil
+	default:
+		out, err = "", ErrInvalidFormatType
+	}
+	return
+}
+
+// Writer is an interface that any type can implement to write supported formats
+type Writer interface {
+	// WriteTable will write tabular output into the given io.Writer, returning
+	// an error if any occur
+	WriteTable(out io.Writer) error
+	// WriteJSON will write JSON formatted output into the given io.Writer,
+	// returning an error if any occur
+	WriteJSON(out io.Writer) error
+	// WriteYAML will write YAML formatted output into the given io.Writer,
+	// returning an error if any occur
+	WriteYAML(out io.Writer) error
+}
+
+// EncodeJSON is a helper function to decorate any error message with a bit more
+// context and avoid writing the same code over and over for printers.
+func EncodeJSON(out io.Writer, obj interface{}) error {
+	enc := json.NewEncoder(out)
+	err := enc.Encode(obj)
+	if err != nil {
+		return errors.Wrap(err, "unable to write JSON output")
+	}
+	return nil
+}
+
+// EncodeYAML is a helper function to decorate any error message with a bit more
+// context and avoid writing the same code over and over for printers
+func EncodeYAML(out io.Writer, obj interface{}) error {
+	raw, err := yaml.Marshal(obj)
+	if err != nil {
+		return errors.Wrap(err, "unable to write YAML output")
+	}
+
+	_, err = out.Write(raw)
+	if err != nil {
+		return errors.Wrap(err, "unable to write YAML output")
+	}
+	return nil
+}
+
+// EncodeTable is a helper function to decorate any error message with a bit
+// more context and avoid writing the same code over and over for printers
+func EncodeTable(out io.Writer, table *uitable.Table) error {
+	raw := table.Bytes()
+	raw = append(raw, []byte("\n")...)
+	_, err := out.Write(raw)
+	if err != nil {
+		return errors.Wrap(err, "unable to write table output")
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1056,6 +1056,7 @@ helm.sh/helm/v3/pkg/chart
 helm.sh/helm/v3/pkg/chart/loader
 helm.sh/helm/v3/pkg/chartutil
 helm.sh/helm/v3/pkg/cli
+helm.sh/helm/v3/pkg/cli/output
 helm.sh/helm/v3/pkg/cli/values
 helm.sh/helm/v3/pkg/downloader
 helm.sh/helm/v3/pkg/engine


### PR DESCRIPTION
include the helm get values in the sysdump collecting, and it will try to grab the user provide value and write to a file. when users provides a sysdump file, we don't have to ask the user to submit a separate helm value file. 

in this implementation, we just grab the latest value and user provide values for cilium. in the future, there can be more enhancement for this.

1. we can provide more options to collect previous version or the rendered helm values for everything.


btw, this is my first golang/OSS PR. feel free to let me know what I can do to make this better