### PR TITLE
Update peers.go - add explanation

### DIFF
--- a/bgp/peers.go
+++ b/bgp/peers.go
@@ -101,7 +101,7 @@ func (s *Status) fetchPeeringStateFromPod(ctx context.Context, pod *corev1.Pod) 
 	cmd := []string{"cilium", "bgp", "peers", "-o", "json"}
 	output, err := s.client.ExecInPod(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch bgp state from %s: %v", pod.Name, err)
+		return nil, fmt.Errorf("failed to fetch bgp state from %s: %v - requires cilium >= v0.14.0", pod.Name, err)
 	}
 
 	bgpPeers := make([]*models.BgpPeer, 0)


### PR DESCRIPTION
Documentation wasn't clear about the need for Cilium to be at a version v0.14.0 or more, add a message to make it clear to users, so we know what to do in case of a negative return