### PR TITLE
Update missing dependencies to Go 1.21

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,16 +28,16 @@ linters-settings:
   goimports:
     local-prefixes: github.com/cilium/cilium-cli
   gosimple:
-    go: "1.20"
+    go: "1.21"
   govet:
     enable-all: true
     disable:
       - fieldalignment
       - shadow
   staticcheck:
-    go: "1.20"
+    go: "1.21"
   unused:
-    go: "1.20"
+    go: "1.21"
 
 issues:
   # This also warns about credential name variables which are false positives.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/library/golang:1.20.4-alpine3.16@sha256:6469405d7297f82d56195c90a3270b0806ef4bd897aa0628477d9959ab97a577 as builder
+FROM docker.io/library/golang:1.21.0-alpine3.18@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f as builder
 WORKDIR /go/src/github.com/cilium/cilium-cli
 RUN apk add --no-cache git make ca-certificates
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ release:
 	docker run \
 		--rm \
 		--workdir /cilium \
-		--volume `pwd`:/cilium docker.io/library/golang:1.20.4-alpine3.17@sha256:913de96707b0460bcfdfe422796bb6e559fc300f6c53286777805a9a3010a5ea \
+		--volume `pwd`:/cilium docker.io/library/golang:1.21.0-alpine3.18@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f \
 		sh -c "apk add --no-cache setpriv make git && \
 			/usr/bin/setpriv --reuid=$(RELEASE_UID) --regid=$(RELEASE_GID) --clear-groups make GOCACHE=/tmp/gocache local-release"
 


### PR DESCRIPTION
Renovate didn't catch these updates in commit 307aa320d53f ("chore(deps): update dependency go to v1.21.0"), update them to Go 1.21 manually. Also bump the release build to use alpine 3.18 while at it.

Fixes: 307aa320d53f ("chore(deps): update dependency go to v1.21.0")