### PR TITLE
install: remove deprecated kube-proxy-replacement CLI flag

### DIFF
--- a/install/helm.go
+++ b/install/helm.go
@@ -258,12 +258,6 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 			helmMapOpts["ipam.mode"] = k.params.IPAM
 		}
 
-		// TODO: remove when removing "kube-proxy-replacement" flag (marked as
-		// deprecated), kept for backwards compatibility
-		if k.params.KubeProxyReplacement != "" && k.params.UserSetKubeProxyReplacement {
-			helmMapOpts["kubeProxyReplacement"] = k.params.KubeProxyReplacement
-		}
-
 		// TODO: remove when removing "config" flag (marked as deprecated), kept
 		// for backwards compatibility
 		if k.bgpEnabled() {

--- a/install/install.go
+++ b/install/install.go
@@ -307,7 +307,6 @@ var (
 		"cluster-name":             "cluster.name",
 		"ipam":                     "ipam.mode",
 		"ipv4-native-routing-cidr": "ipv4NativeRoutingCIDR",
-		"kube-proxy-replacement":   "kubeProxyReplacement",
 		"node-encryption":          "encryption.nodeEncryption",
 		"operator-image":           "operator.image.override",
 	}
@@ -332,7 +331,6 @@ type Parameters struct {
 	IPv4NativeRoutingCIDR string
 	ClusterID             int
 	IPAM                  string
-	KubeProxyReplacement  string
 	Azure                 AzureParameters
 	RestartUnmanagedPods  bool
 	Encryption            string
@@ -390,7 +388,7 @@ type Parameters struct {
 	// APIVersions defines extra kubernetes api resources that can be passed to helm for capabilities validation,
 	// specifically for CRDs.
 	APIVersions []string
-	// UserSetKubeProxyReplacement will be set as true if user passes helm opt or commadline flag for the Kube-Proxy replacement.
+	// UserSetKubeProxyReplacement will be set as true if user passes helm opt for the Kube-Proxy replacement.
 	UserSetKubeProxyReplacement bool
 
 	// DryRun writes resources to be installed to stdout without actually installing them. For Helm

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -26,9 +26,7 @@ import (
 func (k *K8sInstaller) Upgrade(ctx context.Context) error {
 	k.autodetect(ctx)
 
-	// no need to determine KPR setting on upgrade, keep the setting configured with the old
-	// version.
-	if err := k.detectDatapathMode(false); err != nil {
+	if err := k.detectDatapathMode(); err != nil {
 		return err
 	}
 

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -41,9 +41,7 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 			params.Namespace = namespace
 
 			cmd.Flags().Visit(func(f *pflag.Flag) {
-				if f.Name == "kube-proxy-replacement" {
-					params.UserSetKubeProxyReplacement = true
-				} else if f.Name == "helm-set" && strings.Contains(f.Value.String(), "kubeProxyReplacement") {
+				if f.Name == "helm-set" && strings.Contains(f.Value.String(), "kubeProxyReplacement") {
 					params.UserSetKubeProxyReplacement = true
 				}
 			})
@@ -75,9 +73,6 @@ cilium install --context kind-cluster1 --cluster-id 1 --cluster-name cluster1
 	cmd.Flags().IntVar(&params.ClusterID, "cluster-id", 0, "Unique cluster identifier for multi-cluster")
 	cmd.Flags().MarkDeprecated("cluster-id", "This can now be overridden via `helm-set` (Helm value: `cluster.id`).")
 	cmd.Flags().StringVar(&params.InheritCA, "inherit-ca", "", "Inherit/import CA from another cluster")
-	// It can be deprecated since we have a helm option for it
-	cmd.Flags().StringVar(&params.KubeProxyReplacement, "kube-proxy-replacement", "disabled", "Enable/disable kube-proxy replacement { disabled | partial | strict }")
-	cmd.Flags().MarkDeprecated("kube-proxy-replacement", "This can now be overridden via `helm-set` (Helm value: `kubeProxyReplacement`).")
 	cmd.Flags().BoolVar(&params.RestartUnmanagedPods, "restart-unmanaged-pods", true, "Restart pods which are not being managed by Cilium")
 	cmd.Flags().StringVar(&params.Encryption, "encryption", "disabled", "Enable encryption of all workloads traffic { disabled | ipsec | wireguard }")
 	// It can be deprecated since we have a helm option for it


### PR DESCRIPTION
The `--kube-proxy-replacement` flag has been marked as deprecated for a while in favor of `--helm-set kubeProxyReplacement=<value>`. It's no longer used in cilium/cilium or cilium/cilium-cli CI. Remove the flag and get rid of some incomplete KPR mode auto-detection.