### PR TITLE
clustermesh: add support for max-connected-clusters

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -131,6 +131,10 @@ const (
 
 	// HelmRepository specifies Helm repository to download Cilium charts from.
 	HelmRepository = "https://helm.cilium.io"
+
+	// ClustermeshMaxConnectedClusters is the default number of the maximum
+	// number of clusters that should be allowed to connect to the Clustermesh.
+	ClustermeshMaxConnectedClusters = 255
 )
 
 var (


### PR DESCRIPTION
The flag 'max-connected-clusters' is a cilium-agent option that allows the user to extend the number of clusters that can be connected in a Clustermesh. This changes the maximum ClusterID that can be used, and thus cilium-cli will now validate according to the agent's configuration.

Additionally, all clusters in a Clustermesh must be configured with the same 'max-connected-clusters', and this is now validated on connection.

Associated PR introducing `max-connected-clusters`  option: https://github.com/cilium/cilium/pull/27520