### PR TITLE
connectivity: display reason for skipping Tests and Scenarios

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -43,6 +43,7 @@ type ConnectivityTest struct {
 	// CiliumVersion is the detected or assumed version of the Cilium agent
 	CiliumVersion semver.Version
 
+	// Features contains the features enabled on the running Cilium cluster
 	Features FeatureSet
 
 	// Parameters to the test suite, specified by the CLI user.

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -17,14 +17,15 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cilium/cilium/api/v1/observer"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/api/v1/observer"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/junit"
@@ -313,7 +314,7 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context, setupAndValida
 			return fmt.Errorf("unable to create hubble client: %s", err)
 		}
 	}
-	if ct.Features.MatchRequirements(RequireFeatureEnabled(FeatureNodeWithoutCilium)) {
+	if match, _ := ct.Features.MatchRequirements(RequireFeatureEnabled(FeatureNodeWithoutCilium)); match {
 		if err := ct.detectPodCIDRs(ctx); err != nil {
 			return fmt.Errorf("unable to detect pod CIDRs: %w", err)
 		}
@@ -413,9 +414,8 @@ func (ct *ConnectivityTest) Run(ctx context.Context) error {
 }
 
 // skip marks the Test as skipped.
-func (ct *ConnectivityTest) skip(t *Test) {
-	ct.Log()
-	ct.Logf("[=] Skipping Test [%s]", t.Name())
+func (ct *ConnectivityTest) skip(t *Test, reason string) {
+	ct.Logf("[=] Skipping Test [%s] (%s)", t.Name(), reason)
 	t.skipped = true
 }
 

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -93,7 +93,7 @@ func (s FeatureStatus) String() string {
 	return fmt.Sprintf("%s:%s", str, s.Mode)
 }
 
-// FeatureSet contains the status
+// FeatureSet contains the FeatureStatus of a collection of Features.
 type FeatureSet map[Feature]FeatureStatus
 
 // MatchRequirements returns true if the FeatureSet fs satisfies all the

--- a/connectivity/check/features_test.go
+++ b/connectivity/check/features_test.go
@@ -7,11 +7,11 @@ import "testing"
 
 func TestFeatureSetMatchRequirements(t *testing.T) {
 	features := FeatureSet{}
-	matches := features.MatchRequirements()
+	matches, _ := features.MatchRequirements()
 	if !matches {
 		t.Error("empty requirements should always match")
 	}
-	matches = features.MatchRequirements(RequireFeatureEnabled(FeatureL7Proxy))
+	matches, _ = features.MatchRequirements(RequireFeatureEnabled(FeatureL7Proxy))
 	if matches {
 		t.Error("empty features should not match any requirement")
 	}
@@ -19,11 +19,11 @@ func TestFeatureSetMatchRequirements(t *testing.T) {
 	features[FeatureL7Proxy] = FeatureStatus{
 		Enabled: true,
 	}
-	matches = features.MatchRequirements()
+	matches, _ = features.MatchRequirements()
 	if !matches {
 		t.Error("empty requirements should always match")
 	}
-	matches = features.MatchRequirements(RequireFeatureEnabled(FeatureL7Proxy))
+	matches, _ = features.MatchRequirements(RequireFeatureEnabled(FeatureL7Proxy))
 	if !matches {
 		t.Errorf("expected features %v to match feature %v", features, FeatureL7Proxy)
 	}
@@ -33,20 +33,20 @@ func TestFeatureSetMatchRequirements(t *testing.T) {
 		Enabled: true,
 		Mode:    cniMode,
 	}
-	matches = features.MatchRequirements()
+	matches, _ = features.MatchRequirements()
 	if !matches {
 		t.Error("empty requirements should always match")
 	}
-	matches = features.MatchRequirements(RequireFeatureEnabled(FeatureL7Proxy))
+	matches, _ = features.MatchRequirements(RequireFeatureEnabled(FeatureL7Proxy))
 	if !matches {
 		t.Errorf("expected features %v to match feature %v", features, FeatureL7Proxy)
 	}
-	matches = features.MatchRequirements(RequireFeatureEnabled(FeatureCNIChaining), RequireFeatureMode(FeatureCNIChaining, cniMode))
+	matches, _ = features.MatchRequirements(RequireFeatureEnabled(FeatureCNIChaining), RequireFeatureMode(FeatureCNIChaining, cniMode))
 	if !matches {
 		t.Errorf("expected features %v to match feature %v with mode %v", features, FeatureCNIChaining, cniMode)
 	}
 	cniMode = "generic-veth"
-	matches = features.MatchRequirements(RequireFeatureEnabled(FeatureCNIChaining), RequireFeatureMode(FeatureCNIChaining, cniMode))
+	matches, _ = features.MatchRequirements(RequireFeatureEnabled(FeatureCNIChaining), RequireFeatureMode(FeatureCNIChaining, cniMode))
 	if matches {
 		t.Errorf("features %v unexpectedly matched feature %v with mode %v", features, FeatureCNIChaining, cniMode)
 	}


### PR DESCRIPTION
I wanted to re-run a specific Test for reproducing a CI failure, but was surprised to see the test wouldn't run despite targeting it explicitly with --test. The test in question being north-south-loadbalancing, has a feature constraint that was not met in my environment. Thus began the printf rabbit hole.

This patch introduces skip reasons included in brackets after each skipped Test or Scenario. Currently, only one reason is shown, but care was taken to pick the most surprising reason for a skip. For example, excluding all tests by means of `--test "!.*"` would still display feature or version constraints despite the obvious test exclusion.

Some example output (using '--test no-policies/pod-to-world'):

```
[=] Test [no-policies]
  [-] Skipping Scenario [no-policies/pod-to-cidr] (skipped by user)
...
  [-] Scenario [no-policies/pod-to-world]
  [.] Action [no-policies/pod-to-world/http-to-one.one.one.one-0: ... (10.244.1.89) -> ... (one.one.one.one:80)]
...
  [-] Skipping Scenario [no-policies/pod-to-host] (skipped by user)
  [-] Skipping Scenario [no-policies/pod-to-external-workload] (skipped by user)
[=] Skipping Test [no-policies-from-outside] (feature node-without-cilium is disabled)
[=] Skipping Test [no-policies-extra] (skipped by user)
```

Since the amount of output generated by the connectivity tests has grown quite a bit since I last worked on it, I removed the first ct.Log() in ConnectivityTest.Skip() to make the output a little more compact.

RequiredCiliumVSN was renamed and changed to a string since storing the semver.Range does not allow communicating the original version constraint to the user.

A few internal methods on Test were shuffled around to keep concerns separated.