### PR TITLE
clustermesh: Add support for kubernetes service annotations

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -121,6 +121,8 @@ func (k *K8sClusterMesh) generateService() (*corev1.Service, error) {
 			k.Log("⚠️  Using service type NodePort may fail when nodes are removed from the cluster!")
 		}
 		svc.Spec.Type = corev1.ServiceType(k.params.ServiceType)
+
+		svc.ObjectMeta.Annotations = k.params.ServiceAnnotations
 	} else {
 		switch k.flavor.Kind {
 		case k8s.KindGKE:
@@ -460,6 +462,7 @@ type K8sClusterMesh struct {
 type Parameters struct {
 	Namespace            string
 	ServiceType          string
+	ServiceAnnotations   map[string]string
 	DestinationContext   string
 	Wait                 bool
 	WaitDuration         time.Duration

--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -71,6 +71,7 @@ func newCmdClusterMeshEnable() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { ClusterIP | LoadBalancer | NodePort }")
+	cmd.Flags().StringToStringVar(&params.ServiceAnnotations, "service-annotation", map[string]string{}, "Annotation to add to the Kubernetes service. Can be specified multiple times")
 	cmd.Flags().StringVar(&params.ApiserverImage, "apiserver-image", "", "Container image for clustermesh-apiserver")
 	cmd.Flags().StringVar(&params.ApiserverVersion, "apiserver-version", "", "Container image version for clustermesh-apiserver")
 	cmd.Flags().BoolVar(&params.CreateCA, "create-ca", true, "Automatically create CA if needed")


### PR DESCRIPTION
Add a `--service-annotation` argument so that custom annotations can be added to the Kubernetes Service when clustermesh is being enabled.  
A use case for this flag is to create a private NLB in AWS instead of a public classic LB:
> cilium clustermesh enable --service-type LoadBalancer --service-annotation 'service.beta.kubernetes.io/aws-load-balancer-internal=0.0.0.0/0' --service-annotation 'service.beta.kubernetes.io/aws-load-balancer-type=nlb'