### PR TITLE
Scrape Kubernetes metrics in sysdump

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -345,6 +345,17 @@ func (c *Client) GetPod(ctx context.Context, namespace, name string, opts metav1
 	return c.Clientset.CoreV1().Pods(namespace).Get(ctx, name, opts)
 }
 
+func (c *Client) GetRaw(ctx context.Context, path string) (string, error) {
+	result := c.Clientset.CoreV1().RESTClient().Get().AbsPath(path).Do(ctx)
+
+	response, err := result.Raw()
+	if err != nil {
+		return "", err
+	}
+	return string(response), nil
+
+}
+
 func (c *Client) CreatePod(ctx context.Context, namespace string, pod *corev1.Pod, opts metav1.CreateOptions) (*corev1.Pod, error) {
 	return c.Clientset.CoreV1().Pods(namespace).Create(ctx, pod, opts)
 }

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -28,6 +28,7 @@ type KubernetesClient interface {
 	CreateEphemeralContainer(ctx context.Context, pod *corev1.Pod, ec *corev1.EphemeralContainer) (*corev1.Pod, error)
 	CreatePod(ctx context.Context, namespace string, pod *corev1.Pod, opts metav1.CreateOptions) (*corev1.Pod, error)
 	GetPod(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Pod, error)
+	GetRaw(ctx context.Context, path string) (string, error)
 	DeletePod(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
 	ExecInPod(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error)
 	ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -86,6 +86,7 @@ const (
 	kubernetesEventsFileName                 = "k8s-events-<ts>.yaml"
 	kubernetesEventsTableFileName            = "k8s-events-<ts>.html"
 	kubernetesLeasesFileName                 = "k8s-leases-<ts>.yaml"
+	kubernetesMetricsFileName                = "k8s-metrics-<ts>.yaml"
 	kubernetesNamespacesFileName             = "k8s-namespaces-<ts>.yaml"
 	kubernetesNetworkPoliciesFileName        = "k8s-networkpolicies-<ts>.yaml"
 	kubernetesNodesFileName                  = "k8s-nodes-<ts>.yaml"

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -442,6 +442,20 @@ func (c *Collector) Run() error {
 				return nil
 			},
 		},
+		{
+			Description: "Collecting Kubernetes metrics",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				result, err := c.Client.GetRaw(ctx, "/metrics")
+				if err != nil {
+					return fmt.Errorf("failed to collect Kubernetes metrics: %w", err)
+				}
+				if err := c.WriteString(kubernetesMetricsFileName, result); err != nil {
+					return fmt.Errorf("failed to collect Kubernetes metrics: %w", err)
+				}
+				return nil
+			},
+		},
 	}
 
 	ciliumTasks := []Task{

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -283,6 +283,10 @@ func (c *fakeClient) GetPod(_ context.Context, _, _ string, _ metav1.GetOptions)
 	panic("implement me")
 }
 
+func (c *fakeClient) GetRaw(_ context.Context, _ string) (string, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) CreatePod(_ context.Context, _ string, _ *corev1.Pod, _ metav1.CreateOptions) (*corev1.Pod, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
Fixes https://github.com/cilium/cilium-cli/issues/1923

As mentioned in the issue above, this is not ideal as there might be many k8s-apiserver instances, also behind LB, but at least it will give us some insights into the k8s control plane health.