### PR TITLE
connectivity: Add secondary network NodePort tests

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -69,6 +69,7 @@ type Parameters struct {
 	ConnDisruptTestRestartsPath   string
 	ConnDisruptTestXfrmErrorsPath string
 	FlushCT                       bool
+	SecondaryNetworkIface         string
 
 	K8sVersion           string
 	HelmChartDirectory   string

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -66,7 +66,9 @@ type ConnectivityTest struct {
 	ingressService    map[string]Service
 	externalWorkloads map[string]ExternalWorkload
 
-	hostNetNSPodsByNode map[string]Pod
+	hostNetNSPodsByNode      map[string]Pod
+	secondaryNetworkNodeIPv4 map[string]string // node name => secondary ip
+	secondaryNetworkNodeIPv6 map[string]string // node name => secondary ip
 
 	tests     []*Test
 	testNames map[string]struct{}
@@ -182,24 +184,26 @@ func NewConnectivityTest(client *k8s.Client, p Parameters, version string) (*Con
 	}
 
 	k := &ConnectivityTest{
-		client:              client,
-		params:              p,
-		version:             version,
-		ciliumPods:          make(map[string]Pod),
-		echoPods:            make(map[string]Pod),
-		echoExternalPods:    make(map[string]Pod),
-		clientPods:          make(map[string]Pod),
-		perfClientPods:      make(map[string]Pod),
-		perfServerPod:       make(map[string]Pod),
-		PerfResults:         make(map[PerfTests]PerfResult),
-		echoServices:        make(map[string]Service),
-		ingressService:      make(map[string]Service),
-		externalWorkloads:   make(map[string]ExternalWorkload),
-		hostNetNSPodsByNode: make(map[string]Pod),
-		nodes:               make(map[string]*corev1.Node),
-		tests:               []*Test{},
-		testNames:           make(map[string]struct{}),
-		lastFlowTimestamps:  make(map[string]time.Time),
+		client:                   client,
+		params:                   p,
+		version:                  version,
+		ciliumPods:               make(map[string]Pod),
+		echoPods:                 make(map[string]Pod),
+		echoExternalPods:         make(map[string]Pod),
+		clientPods:               make(map[string]Pod),
+		perfClientPods:           make(map[string]Pod),
+		perfServerPod:            make(map[string]Pod),
+		PerfResults:              make(map[PerfTests]PerfResult),
+		echoServices:             make(map[string]Service),
+		ingressService:           make(map[string]Service),
+		externalWorkloads:        make(map[string]ExternalWorkload),
+		hostNetNSPodsByNode:      make(map[string]Pod),
+		secondaryNetworkNodeIPv4: make(map[string]string),
+		secondaryNetworkNodeIPv6: make(map[string]string),
+		nodes:                    make(map[string]*corev1.Node),
+		tests:                    []*Test{},
+		testNames:                make(map[string]struct{}),
+		lastFlowTimestamps:       make(map[string]time.Time),
 	}
 
 	return k, nil
@@ -876,6 +880,14 @@ func (ct *ConnectivityTest) ClientPods() map[string]Pod {
 
 func (ct *ConnectivityTest) HostNetNSPodsByNode() map[string]Pod {
 	return ct.hostNetNSPodsByNode
+}
+
+func (ct *ConnectivityTest) SecondaryNetworkNodeIPv4() map[string]string {
+	return ct.secondaryNetworkNodeIPv4
+}
+
+func (ct *ConnectivityTest) SecondaryNetworkNodeIPv6() map[string]string {
+	return ct.secondaryNetworkNodeIPv6
 }
 
 func (ct *ConnectivityTest) PerfServerPod() map[string]Pod {

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -180,6 +180,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")
+	cmd.Flags().StringVar(&params.SecondaryNetworkIface, "secondary-network-iface", "", "Secondary network iface name (e.g., to test NodePort BPF on multiple networks)")
 
 	hooks.AddConnectivityTestFlags(cmd.Flags())
 


### PR DESCRIPTION
First, this commit introduces "--secondary-network-iface" flag. The flag is used to determine a secondary network IP addr of each node.

Second, the commit extends the NodePort from outside tests. When the aforementioned flag is set, in addition to the regular curl request, the test case sends HTTP requests to an IP addr on each Cilium node which is set to the "--secondary-network-face".

Testing PR https://github.com/cilium/cilium/pull/27738 (https://github.com/cilium/cilium/actions/runs/6010840377/job/16303159003)

cc @julianwiedmann @borkmann 