### PR TITLE
Add pod-to-pod strict mode tests

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -27,13 +27,14 @@ import (
 type Feature string
 
 const (
-	FeatureCNIChaining        Feature = "cni-chaining"
-	FeatureMonitorAggregation Feature = "monitor-aggregation"
-	FeatureL7Proxy            Feature = "l7-proxy"
-	FeatureHostFirewall       Feature = "host-firewall"
-	FeatureICMPPolicy         Feature = "icmp-policy"
-	FeatureTunnel             Feature = "tunnel"
-	FeatureEndpointRoutes     Feature = "endpoint-routes"
+	FeatureCNIChaining         Feature = "cni-chaining"
+	FeatureMonitorAggregation  Feature = "monitor-aggregation"
+	FeatureL7Proxy             Feature = "l7-proxy"
+	FeatureHostFirewall        Feature = "host-firewall"
+	FeatureICMPPolicy          Feature = "icmp-policy"
+	FeatureTunnel              Feature = "tunnel"
+	FeatureEndpointRoutes      Feature = "endpoint-routes"
+	FeatureCiliumEndpointSlice Feature = "cilium-endpoint-slice"
 
 	FeatureKPRMode                Feature = "kpr-mode"
 	FeatureKPRExternalIPs         Feature = "kpr-external-ips"
@@ -49,8 +50,9 @@ const (
 
 	FeatureHealthChecking Feature = "health-checking"
 
-	FeatureEncryptionPod  Feature = "encryption-pod"
-	FeatureEncryptionNode Feature = "encryption-node"
+	FeatureEncryptionPod    Feature = "encryption-pod"
+	FeatureEncryptionNode   Feature = "encryption-node"
+	FeatureStrictEncryption Feature = "encryption-strict"
 
 	FeatureIPv4 Feature = "ipv4"
 	FeatureIPv6 Feature = "ipv6"
@@ -241,6 +243,15 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 			Enabled: mode != "native",
 			Mode:    tunnelProto,
 		}
+	}
+
+	result[FeatureStrictEncryption] = FeatureStatus{
+		Enabled: cm.Data["enable-encryption-strict-mode"] == "true",
+		Mode:    cm.Data["encryption-strict-mode-cidr"],
+	}
+
+	result[FeatureCiliumEndpointSlice] = FeatureStatus{
+		Enabled: cm.Data["enable-cilium-endpoint-slice"] == "true",
 	}
 
 	result[FeatureIPv4] = FeatureStatus{

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -753,6 +753,20 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 		)
 
 	if ct.Params().IncludeUnsafeTests {
+		ct.NewTest("pod-to-pod-strict-wireguard-encryption").
+			WithFeatureRequirements(
+				check.RequireFeatureEnabled(check.FeatureEncryptionPod),
+				check.RequireFeatureEnabled(check.FeatureStrictEncryption),
+				check.RequireFeatureEnabled(check.FeatureIPv4), // strict encryption only supported for IPv4
+				check.RequireFeatureDisabled(check.FeatureIPv6),
+				check.RequireFeatureEnabled(check.FeatureCiliumEndpointSlice),
+			).
+			WithScenarios(
+				tests.PodToPodStrictEncryption(),
+			)
+	}
+
+	if ct.Params().IncludeUnsafeTests {
 		ct.NewTest("egress-gateway").
 			WithCiliumEgressGatewayPolicy(egressGatewayPolicyYAML, check.CiliumEgressGatewayPolicyParams{}).
 			WithIPRoutesFromOutsideToPodCIDRs().

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -143,7 +143,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringToStringVar(&params.JunitProperties, "junit-property", map[string]string{}, "Add key=value properties to the generated junit file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
-	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster nodes state")
+	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster state")
 	cmd.Flags().MarkHidden("include-unsafe-tests")
 
 	cmd.Flags().StringVar(&params.K8sVersion, "k8s-version", "", "Kubernetes server version in case auto-detection fails")


### PR DESCRIPTION
This PR implements the pod-to-pod strict mode tests in the cilium-cli test suite. Currently, there are similar tests inside the legacy vagrant test suite (https://github.com/cilium/cilium/blob/836598a317565d4c53c678bb09173ae9fee5f54b/test/k8s/datapath_configuration.go#L387). 

With this PR we could deprecate and remove the vagrant tests if we add strict mode versions to Cilium's conformance CI. The difference is that the vagrant tests control the Kubernetes environment and cilium configuration for each test. Therefore the test coverage regarding different cilium configurations is easier to achieve. 

My question is: If the vagrant tests are "legacy", what is the best way to implement potentially disrupting tests which need to perform changes to the K8s environment? It seems like that this test suite was originally developed to implement tests which the user can execute in their production environment without any disruption. I guess this is the discussion you have right now: https://github.com/cilium/design-cfps/pull/9#discussion_r1218651510.