### PR TITLE
connectivity: Delete test-conn-disrupt pods after running tests

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -414,6 +414,17 @@ func (ct *ConnectivityTest) Run(ctx context.Context) error {
 		wg.Wait()
 	}
 
+	// Delete conn disrupt pods after running tests. Otherwise, after calling
+	// --flush-ct they might get into crashloop state from which it takes time
+	// to recover, which makes subsequent tests to fail.
+	if ct.Params().IncludeConnDisruptTest && !ct.Params().ConnDisruptTestSetup {
+		for _, client := range ct.Clients() {
+			if err := ct.DeleteConnDisruptTestDeployment(ctx, client); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Report the test results.
 	return ct.report()
 }

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -397,6 +397,9 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			if err := ct.deleteDeployments(ctx, client); err != nil {
 				return err
 			}
+			if err := ct.DeleteConnDisruptTestDeployment(ctx, client); err != nil {
+				return err
+			}
 		}
 
 		_, err := client.GetNamespace(ctx, ct.params.TestNamespace, metav1.GetOptions{})
@@ -1055,14 +1058,10 @@ func (ct *ConnectivityTest) deleteDeployments(ctx context.Context, client *k8s.C
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, clientDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, client2DeploymentName, metav1.DeleteOptions{})
-	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
-	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, echoSameNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, echoOtherNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, clientDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, client2DeploymentName, metav1.DeleteOptions{})
-	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
-	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteService(ctx, ct.params.TestNamespace, echoSameNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteService(ctx, ct.params.TestNamespace, echoOtherNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteConfigMap(ctx, ct.params.TestNamespace, corednsConfigMapName, metav1.DeleteOptions{})
@@ -1079,6 +1078,17 @@ func (ct *ConnectivityTest) deleteDeployments(ctx context.Context, client *k8s.C
 			_, err = client.GetNamespace(ctx, ct.params.TestNamespace, metav1.GetOptions{})
 		}
 	}
+
+	return nil
+}
+
+func (ct *ConnectivityTest) DeleteConnDisruptTestDeployment(ctx context.Context, client *k8s.Client) error {
+	ct.Logf("🔥 [%s] Deleting test-conn-disrupt deployments...", client.ClusterName())
+	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteService(ctx, ct.params.TestNamespace, testConnDisruptServiceName, metav1.DeleteOptions{})
 
 	return nil
 }


### PR DESCRIPTION
In the CI upgrade tests we sometimes see the following:

    The failure connectivity test failed: timeout reached waiting for
    deployment cilium-test/test-conn-disrupt-client to become ready
    (last error: only 3 of 5 replicas are available)

@jschwinger233 pointed out that it might be related to "--flush-ct", because according to some output of "kubectl get po", the test-conn-disrupt client pods crashed at the end of last connectivity test, when the "--flush-ct" took place.

Tested with https://github.com/cilium/cilium/pull/27966