### PR TITLE
connectivity: Expose test-conn-disrupt dispatch period

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -68,6 +68,7 @@ type Parameters struct {
 	ConnDisruptTestSetup          bool
 	ConnDisruptTestRestartsPath   string
 	ConnDisruptTestXfrmErrorsPath string
+	ConnDisruptDispatchInterval   uint
 	FlushCT                       bool
 	SecondaryNetworkIface         string
 

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -6,6 +6,7 @@ package check
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -671,7 +672,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				Port:     8000,
 				Command: []string{
 					"tcd-client",
-					"--dispatch-interval", "10", // 10ms
+					"--dispatch-interval", strconv.Itoa(int(ct.params.ConnDisruptDispatchInterval)),
 					fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
 				},
 				ReadinessProbe: readinessProbe,

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -178,6 +178,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.ConnDisruptTestSetup, "conn-disrupt-test-setup", false, "Set up conn disrupt test dependencies")
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")
+	cmd.Flags().UintVar(&params.ConnDisruptDispatchInterval, "conn-disrupt-dispatch-interval (ms)", 10, "TCP packet dispatch interval in ms")
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")
 	cmd.Flags().StringVar(&params.SecondaryNetworkIface, "secondary-network-iface", "", "Secondary network iface name (e.g., to test NodePort BPF on multiple networks)")


### PR DESCRIPTION
Expose the test-conn-disrupt --dispatch-interval via --conn-disrupt-dispatch-interval.

Suggested-by: Michi Mutsuzaki <michi@isovalent.com>