### PR TITLE
connectivity: convert conn-disrupt-dispatch-interval to duration

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -68,7 +68,7 @@ type Parameters struct {
 	ConnDisruptTestSetup          bool
 	ConnDisruptTestRestartsPath   string
 	ConnDisruptTestXfrmErrorsPath string
-	ConnDisruptDispatchInterval   uint
+	ConnDisruptDispatchInterval   time.Duration
 	FlushCT                       bool
 	SecondaryNetworkIface         string
 

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -672,7 +672,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				Port:     8000,
 				Command: []string{
 					"tcd-client",
-					"--dispatch-interval", strconv.Itoa(int(ct.params.ConnDisruptDispatchInterval)),
+					"--dispatch-interval", strconv.Itoa(int(ct.params.ConnDisruptDispatchInterval.Milliseconds())),
 					fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
 				},
 				ReadinessProbe: readinessProbe,

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -178,7 +178,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.ConnDisruptTestSetup, "conn-disrupt-test-setup", false, "Set up conn disrupt test dependencies")
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")
-	cmd.Flags().UintVar(&params.ConnDisruptDispatchInterval, "conn-disrupt-dispatch-interval (ms)", 10, "TCP packet dispatch interval in ms")
+	cmd.Flags().DurationVar(&params.ConnDisruptDispatchInterval, "conn-disrupt-dispatch-interval", 10*time.Millisecond, "TCP packet dispatch interval")
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")
 	cmd.Flags().StringVar(&params.SecondaryNetworkIface, "secondary-network-iface", "", "Secondary network iface name (e.g., to test NodePort BPF on multiple networks)")


### PR DESCRIPTION
It's more commonplace to use DurationVar to specify duration CLI flags and gives users more flexibility.

Example usage:

    $ cilium connectivity test --conn-disrupt-dispatch-interval 20ms

Fixes: 67b8025b4d43 ("connectivity: Expose test-conn-disrupt dispatch period")