### PR TITLE
connectivity: Add retries to PodToPod curl commands

### DIFF
--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -52,9 +52,13 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 			t.ForEachIPFamily(func(ipFam check.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
 					if s.method == "" {
-						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFam))
+						a.ExecInPod(ctx, ct.CurlCommand(
+							echo, ipFam, "--retry", "5",
+						))
 					} else {
-						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFam, "-X", s.method))
+						a.ExecInPod(ctx, ct.CurlCommand(
+							echo, ipFam, "--retry", "5", "-X", s.method,
+						))
 					}
 
 					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))


### PR DESCRIPTION
This commit adds retries to the curl commands in the PodToPod scenario. The goal of adding this change is to try and address the Cilium CI flake cilium/cilium#27762.