### PR TITLE
golangci-lint: enable goheader check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - gocheckcompilerdirectives
     - goerr113
     - gofmt
+    - goheader
     - goimports
     - gosec
     - gosimple
@@ -25,6 +26,13 @@ linters:
     - unused
 
 linters-settings:
+  goheader:
+    values:
+      regexp:
+        PROJECT: 'Cilium|Hubble'
+    template: |-
+      SPDX-License-Identifier: Apache-2.0
+      Copyright Authors of {{ PROJECT }}
   goimports:
     local-prefixes: github.com/cilium/cilium-cli
   gosimple:

--- a/clustermesh/clustermesh_test.go
+++ b/clustermesh/clustermesh_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package clustermesh
 
 import (

--- a/connectivity/check/action_test.go
+++ b/connectivity/check/action_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package check
 
 import (

--- a/connectivity/check/secrets.go
+++ b/connectivity/check/secrets.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package check
 
 import (

--- a/connectivity/check/test_test.go
+++ b/connectivity/check/test_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package check
 
 import (

--- a/connectivity/tests/dummy.go
+++ b/connectivity/tests/dummy.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package tests
 
 import (

--- a/connectivity/tests/health.go
+++ b/connectivity/tests/health.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Authors of Cilium
+// Copyright Authors of Cilium
 
 package tests
 

--- a/install/helm.go
+++ b/install/helm.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
+
 // Copyright The Helm Authors.
 
 package install

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
+
 // Copyright The Helm Authors.
 
 package helm


### PR DESCRIPTION
To make sure all Go files have a proper copyright header. Also add the copyright header to files where it was previously missing.

Ref. https://github.com/cilium/cilium-cli/pull/1986/files#r1337029656