### PR TITLE
connectivity: test referencing nodes by CIDR

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -60,6 +60,7 @@ type Parameters struct {
 	ExternalIP            string
 	ExternalOtherIP       string
 	PodCIDRs              []podCIDRs
+	NodeCIDRs             []string
 	NodesWithoutCiliumIPs []nodesWithoutCiliumIP
 	JunitFile             string
 	JunitProperties       map[string]string

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -62,6 +62,9 @@ const (
 	FeatureCNP Feature = "cilium-network-policy"
 	FeatureKNP Feature = "k8s-network-policy"
 
+	// Whether or not CIDR selectors can match node IPs
+	FeatureCIDRMatchNodes Feature = "cidr-match-nodes"
+
 	FeatureAuthSpiffe Feature = "mutual-auth-spiffe"
 
 	FeatureIngressController Feature = "ingress-controller"
@@ -264,6 +267,10 @@ func (ct *ConnectivityTest) extractFeaturesFromConfigMap(ctx context.Context, cl
 
 	result[FeatureEgressGateway] = FeatureStatus{
 		Enabled: cm.Data["enable-ipv4-egress-gateway"] == "true",
+	}
+
+	result[FeatureCIDRMatchNodes] = FeatureStatus{
+		Enabled: strings.Contains(cm.Data["policy-cidr-match-mode"], "nodes"),
 	}
 
 	return nil

--- a/connectivity/manifests/client-egress-to-cidr-node-knp.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-node-knp.yaml
@@ -1,0 +1,15 @@
+# This policy allows packets to all node IPs
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: client-egress-to-node-cidr
+spec:
+  podSelector:
+    matchLabels:
+      kind: client
+  egress:
+    - to:
+{{- range .NodeCIDRs }}
+        - ipBlock:
+            cidr: {{.}}
+{{- end }}

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -115,6 +115,9 @@ var (
 	//go:embed manifests/client-egress-to-cidr-external-knp.yaml
 	clientEgressToCIDRExternalPolicyKNPYAML string
 
+	//go:embed manifests/client-egress-to-cidr-node-knp.yaml
+	clientEgressToCIDRNodeKNPYAML string
+
 	//go:embed manifests/client-egress-to-cidr-external-deny.yaml
 	clientEgressToCIDRExternalDenyPolicyYAML string
 
@@ -181,6 +184,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 	for key, temp := range map[string]string{
 		"clientEgressToCIDRExternalPolicyYAML":     clientEgressToCIDRExternalPolicyYAML,
 		"clientEgressToCIDRExternalPolicyKNPYAML":  clientEgressToCIDRExternalPolicyKNPYAML,
+		"clientEgressToCIDRNodeKNPYAML":            clientEgressToCIDRNodeKNPYAML,
 		"clientEgressToCIDRExternalDenyPolicyYAML": clientEgressToCIDRExternalDenyPolicyYAML,
 		"clientEgressL7HTTPPolicyYAML":             clientEgressL7HTTPPolicyYAML,
 		"clientEgressL7HTTPNamedPortPolicyYAML":    clientEgressL7HTTPNamedPortPolicyYAML,
@@ -773,6 +777,16 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 				tests.EgressGatewayExcludedCIDRs(),
 			)
 	}
+
+	// Check that pods can access nodes when referencing them by CIDR selectors
+	// (when this feature is enabled).
+	ct.NewTest("pod-to-node-cidrpolicy").
+		WithFeatureRequirements(
+			check.RequireFeatureEnabled(check.FeatureCIDRMatchNodes)).
+		WithK8SPolicy(renderedTemplates["clientEgressToCIDRNodeKNPYAML"]).
+		WithScenarios(
+			tests.PodToHost(),
+		)
 
 	// The following tests have DNS redirect policies. They should be executed last.
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -139,6 +139,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalIP, "external-ip", "1.1.1.1", "IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")
+	cmd.Flags().StringSliceVar(&params.NodeCIDRs, "node-cidr", nil, "one or more CIDRs that cover all nodes in the cluster")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
 	cmd.Flags().StringToStringVar(&params.JunitProperties, "junit-property", map[string]string{}, "Add key=value properties to the generated junit file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")


### PR DESCRIPTION
We now support selecting cluster nodes in policy by CIDR. Previously, only the `remote-node` and `host` entities could select nodes. So, add a corresponding feature and test case for this.

This required adding a function to autodetect node CIDRs.