### PR TITLE
Clean up the node feature detection logic

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1325,7 +1325,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	for _, pod := range hostNetNSPods.Items {
-		_, ok := ct.nodesWithoutCiliumMap[pod.Spec.NodeName]
+		_, ok := ct.nodesWithoutCilium[pod.Spec.NodeName]
 		p := Pod{
 			K8sClient: ct.client,
 			Pod:       pod.DeepCopy(),


### PR DESCRIPTION
- Remove nodesWithoutCilium list as it is redundant, and rename nodesWithoutCiliumMap to nodesWithoutCilium.
- Initialize both nodes and nodesWithoutCilium in getNodes to avoid listing nodes twice.
- Associate extractFeaturesFromNodes with FeatureSet instead of ConnectivityTest to decouple FeatureSet from ConnectivityTest.

Ref: #1962