### PR TITLE
install: Avoid using deprecated "tunnel" flag

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -50,7 +50,10 @@ import (
 const (
 	configNameClusterID   = "cluster-id"
 	configNameClusterName = "cluster-name"
-	configNameTunnel      = "tunnel"
+
+	configNameTunnelLegacy   = "tunnel"
+	configNameTunnelProtocol = "tunnel-protocol"
+	configNameRoutingMode    = "routing-mode"
 
 	caSuffix   = ".etcd-client-ca.crt"
 	keySuffix  = ".etcd-client.key"
@@ -826,6 +829,19 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 		}
 	}
 
+	tunnelProtocol := ""
+	if cm.Data[configNameRoutingMode] == "tunnel" {
+		// Cilium v1.14 and newer
+		tunnelProtocol = "vxlan" // default for tunnel mode
+		if proto, ok := cm.Data[configNameTunnelProtocol]; ok {
+			tunnelProtocol = proto
+		}
+	} else if proto, ok := cm.Data[configNameTunnelLegacy]; ok {
+		// Cilium v1.13 and older (some v1.14 configurations might use it too)
+		// Can be removed once we drop support for v1.14
+		tunnelProtocol = proto
+	}
+
 	ai := &accessInformation{
 		ClusterID:            clusterID,
 		ClusterName:          clusterName,
@@ -836,7 +852,7 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 		ExternalWorkloadCert: externalWorkloadCert,
 		ServiceType:          svc.Spec.Type,
 		ServiceIPs:           []string{},
-		Tunnel:               cm.Data[configNameTunnel],
+		Tunnel:               tunnelProtocol,
 	}
 
 	switch {
@@ -1780,7 +1796,7 @@ func (k *K8sClusterMesh) WriteExternalWorkloadInstallScript(ctx context.Context,
 		return err
 	}
 	if ai.Tunnel != "" && ai.Tunnel != "vxlan" {
-		return fmt.Errorf("datapath not using vxlan, please install Cilium with '--config tunnel=vxlan'")
+		return fmt.Errorf("datapath not using vxlan, please install Cilium with '--helm-set tunnelMode=vxlan'")
 	}
 
 	clusterAddr := fmt.Sprintf("%s:%d", ai.ServiceIPs[0], ai.ServicePort)

--- a/install/install.go
+++ b/install/install.go
@@ -62,6 +62,11 @@ const (
 )
 
 const (
+	routingModeNative = "native"
+	routingModeTunnel = "tunnel"
+)
+
+const (
 	encryptionUnspecified = ""
 	encryptionDisabled    = "disabled"
 	encryptionIPsec       = "ipsec"
@@ -523,7 +528,8 @@ func (k *K8sInstaller) generateConfigMap() (*corev1.ConfigMap, error) {
 			return nil, fmt.Errorf("--install-no-conntrack-iptables-rules cannot be enabled on Azure AKS")
 		}
 
-		if cm.Data["tunnel"] != "disabled" {
+		// The check for the legacy "tunnel" flag can be removed once we drop support for Cilium v1.14
+		if cm.Data["tunnel"] != "disabled" || cm.Data["routing-mode"] != "native" {
 			return nil, fmt.Errorf("--install-no-conntrack-iptables-rules requires tunneling to be disabled")
 		}
 


### PR DESCRIPTION
The tunnel option is deprecated and will be removed in Cilium v1.15. This commit fixes the remaining uses I have found where the Cilium CLI still set the old `tunnel` flag unconditionally, which will lead to issues once the flag is no longer accepted [1]. The Cilium CLI now only uses the deprecated `tunnel` flag for Cilium versions 1.13 and older.

When reading the ConfigMap (such as in the clustermesh code), we attempt to first parse the new values, before falling back on the old ones.

[1] https://github.com/cilium/cilium/pull/27841#issuecomment-1707275681