### PR TITLE
Move IPFamily to a separate "features" package

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cilium/cilium-cli/connectivity/filters"
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 const (
@@ -57,7 +58,7 @@ type Action struct {
 	dst TestPeer
 
 	// IP family used in this Action
-	ipFam IPFamily
+	ipFam features.IPFamily
 
 	// expEgress is the expected test result for egress from the source pod
 	expEgress Result
@@ -88,7 +89,7 @@ type Action struct {
 	metricsPerSource promMetricsPerSource
 }
 
-func newAction(t *Test, name string, s Scenario, src *Pod, dst TestPeer, ipFam IPFamily) *Action {
+func newAction(t *Test, name string, s Scenario, src *Pod, dst TestPeer, ipFam features.IPFamily) *Action {
 	return &Action{
 		name:             name,
 		test:             t,

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/junit"
 	"github.com/cilium/cilium-cli/k8s"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // ConnectivityTest is the root context of the connectivity test suite
@@ -610,8 +611,8 @@ func (ct *ConnectivityTest) detectPodCIDRs(ctx context.Context) error {
 
 	for _, n := range nodes.Items {
 		for _, cidr := range n.Spec.PodCIDRs {
-			f := GetIPFamily(ct.hostNetNSPodsByNode[n.Name].Pod.Status.HostIP)
-			if strings.Contains(cidr, ":") && f == IPFamilyV4 {
+			f := features.GetIPFamily(ct.hostNetNSPodsByNode[n.Name].Pod.Status.HostIP)
+			if strings.Contains(cidr, ":") && f == features.IPFamilyV4 {
 				// Skip if the host IP of the pod mismatches with pod CIDR.
 				// Cannot create a route with the gateway IP family
 				// mismatching the subnet.
@@ -872,7 +873,7 @@ func (ct *ConnectivityTest) UninstallResources(ctx context.Context, wait bool) {
 	}
 }
 
-func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam IPFamily, opts ...string) []string {
+func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam features.IPFamily, opts ...string) []string {
 	cmd := []string{"curl",
 		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}",
 		"--silent", "--fail", "--show-error",
@@ -897,7 +898,7 @@ func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam IPFamily, opts ...s
 	return cmd
 }
 
-func (ct *ConnectivityTest) CurlClientIPCommand(peer TestPeer, ipFam IPFamily, opts ...string) []string {
+func (ct *ConnectivityTest) CurlClientIPCommand(peer TestPeer, ipFam features.IPFamily, opts ...string) []string {
 	cmd := []string{"curl", "--silent", "--fail", "--show-error"}
 
 	if connectTimeout := ct.params.ConnectTimeout.Seconds(); connectTimeout > 0.0 {
@@ -915,10 +916,10 @@ func (ct *ConnectivityTest) CurlClientIPCommand(peer TestPeer, ipFam IPFamily, o
 	return cmd
 }
 
-func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam IPFamily) []string {
+func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily) []string {
 	cmd := []string{"ping", "-c", "1"}
 
-	if ipFam == IPFamilyV6 {
+	if ipFam == features.IPFamilyV6 {
 		cmd = append(cmd, "-6")
 	}
 
@@ -933,7 +934,7 @@ func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam IPFamily) []string 
 	return cmd
 }
 
-func (ct *ConnectivityTest) DigCommand(peer TestPeer, ipFam IPFamily) []string {
+func (ct *ConnectivityTest) DigCommand(peer TestPeer, ipFam features.IPFamily) []string {
 	cmd := []string{"dig", "+time=2", "kubernetes"}
 
 	cmd = append(cmd, fmt.Sprintf("@%s", peer.Address(ipFam)))

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/k8s"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // Feature is the name of a Cilium feature (e.g. l7-proxy, cni chaining mode etc)
@@ -118,15 +119,15 @@ func (fs FeatureSet) MatchRequirements(reqs ...FeatureRequirement) (bool, string
 }
 
 // IPFamilies returns the list of enabled IP families.
-func (fs FeatureSet) IPFamilies() []IPFamily {
-	var families []IPFamily
+func (fs FeatureSet) IPFamilies() []features.IPFamily {
+	var families []features.IPFamily
 
 	if match, _ := fs.MatchRequirements(RequireFeatureEnabled(FeatureIPv4)); match {
-		families = append(families, IPFamilyV4)
+		families = append(families, features.IPFamilyV4)
 	}
 
 	if match, _ := fs.MatchRequirements(RequireFeatureEnabled(FeatureIPv6)); match {
-		families = append(families, IPFamilyV6)
+		families = append(families, features.IPFamilyV6)
 	}
 
 	return families

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium-cli/utils/features"
+
 	"github.com/blang/semver/v4"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -709,7 +711,7 @@ func (t *Test) WithFinalizer(f func() error) *Test {
 // NewAction creates a new Action. s must be the Scenario the Action is created
 // for, name should be a visually-distinguishable name, src is the execution
 // Pod of the action, and dst is the network target the Action will connect to.
-func (t *Test) NewAction(s Scenario, name string, src *Pod, dst TestPeer, ipFam IPFamily) *Action {
+func (t *Test) NewAction(s Scenario, name string, src *Pod, dst TestPeer, ipFam features.IPFamily) *Action {
 	a := newAction(t, name, s, src, dst, ipFam)
 
 	// Obtain the expected result for this particular action by calling
@@ -767,8 +769,8 @@ func (t *Test) collectSysdump() {
 	}
 }
 
-func (t *Test) ForEachIPFamily(do func(IPFamily)) {
-	ipFams := []IPFamily{IPFamilyV4, IPFamilyV6}
+func (t *Test) ForEachIPFamily(do func(features.IPFamily)) {
+	ipFams := []features.IPFamily{features.IPFamilyV4, features.IPFamilyV6}
 
 	// The per-endpoint routes feature is broken with IPv6 on < v1.14 when there
 	// are any netpols installed (https://github.com/cilium/cilium/issues/23852
@@ -777,17 +779,17 @@ func (t *Test) ForEachIPFamily(do func(IPFamily)) {
 		f.Enabled && (len(t.cnps) > 0 || len(t.knps) > 0) &&
 		versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) {
 
-		ipFams = []IPFamily{IPFamilyV4}
+		ipFams = []features.IPFamily{features.IPFamilyV4}
 	}
 
 	for _, ipFam := range ipFams {
 		switch ipFam {
-		case IPFamilyV4:
+		case features.IPFamilyV4:
 			if f, ok := t.ctx.Features[FeatureIPv4]; ok && f.Enabled {
 				do(ipFam)
 			}
 
-		case IPFamilyV6:
+		case features.IPFamilyV6:
 			if f, ok := t.ctx.Features[FeatureIPv6]; ok && f.Enabled {
 				do(ipFam)
 			}

--- a/connectivity/check/wait.go
+++ b/connectivity/check/wait.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/k8s"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 const (
@@ -88,7 +89,7 @@ func WaitForPodDNS(ctx context.Context, log Logger, src, dst Pod) error {
 		// See https://coredns.io/plugins/local/ for more info.
 		target := "localhost"
 		stdout, err := src.K8sClient.ExecInPod(ctx, src.Namespace(), src.NameWithoutNamespace(),
-			"", []string{"nslookup", target, dst.Address(IPFamilyAny)})
+			"", []string{"nslookup", target, dst.Address(features.IPFamilyAny)})
 
 		if err == nil {
 			return nil
@@ -173,7 +174,7 @@ func WaitForService(ctx context.Context, log Logger, client Pod, service Service
 
 // WaitForServiceEndpoints waits until the expected number of service backends
 // are reported by the given agent.
-func WaitForServiceEndpoints(ctx context.Context, log Logger, agent Pod, service Service, backends uint, families []IPFamily) error {
+func WaitForServiceEndpoints(ctx context.Context, log Logger, agent Pod, service Service, backends uint, families []features.IPFamily) error {
 	log.Logf("⌛ [%s] Waiting for Service %s to be synchronized by Cilium pod %s",
 		agent.K8sClient.ClusterName(), service.Name(), agent.Name())
 
@@ -198,7 +199,7 @@ func WaitForServiceEndpoints(ctx context.Context, log Logger, agent Pod, service
 	}
 }
 
-func checkServiceEndpoints(ctx context.Context, agent Pod, service Service, backends uint, families []IPFamily) error {
+func checkServiceEndpoints(ctx context.Context, agent Pod, service Service, backends uint, families []features.IPFamily) error {
 	buffer, err := agent.K8sClient.ExecInPod(ctx, agent.Namespace(), agent.NameWithoutNamespace(),
 		defaults.AgentContainerName, []string{"cilium", "service", "list", "--output=json"})
 	if err != nil {
@@ -231,7 +232,7 @@ func checkServiceEndpoints(ctx context.Context, agent Pod, service Service, back
 
 		// Skip the check for a given address if the corresponding IP family is not
 		// enabled in Cilium, as the backends will never be populated.
-		if addr.Is4() && !slices.Contains(families, IPFamilyV4) || addr.Is6() && !slices.Contains(families, IPFamilyV6) {
+		if addr.Is4() && !slices.Contains(families, features.IPFamilyV4) || addr.Is6() && !slices.Contains(families, features.IPFamilyV6) {
 			continue
 		}
 

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/connectivity/manifests/template"
 	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 var (
@@ -325,8 +326,8 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 	ct.NewTest("all-ingress-deny").WithCiliumPolicy(denyAllIngressPolicyYAML).
 		WithScenarios(allIngressDenyScenarios...).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
-				a.Destination().Address(check.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
+				a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
 				return check.ResultOK, check.ResultNone
 			}
 			return check.ResultDrop, check.ResultDefaultDenyIngressDrop
@@ -338,8 +339,8 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			WithIPRoutesFromOutsideToPodCIDRs().
 			WithScenarios(tests.FromCIDRToPod()).
 			WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-				if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
-					a.Destination().Address(check.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+				if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
+					a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
 					return check.ResultOK, check.ResultNone
 				}
 				return check.ResultDrop, check.ResultDefaultDenyIngressDrop
@@ -358,8 +359,8 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			tests.PodToCIDR(tests.WithRetryAll()),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
-				a.Destination().Address(check.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
+				a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
 				return check.ResultOK, check.ResultNone
 			}
 			return check.ResultDrop, check.ResultDefaultDenyIngressDrop
@@ -544,7 +545,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.IPFamilyV4) == ct.Params().ExternalOtherIP {
+			if a.Destination().Address(features.IPFamilyV4) == ct.Params().ExternalOtherIP {
 				// Expect packets for ExternalOtherIP to be dropped.
 				return check.ResultDropCurlTimeout, check.ResultNone
 			}
@@ -559,7 +560,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.IPFamilyV4) == ct.Params().ExternalOtherIP {
+			if a.Destination().Address(features.IPFamilyV4) == ct.Params().ExternalOtherIP {
 				// Expect packets for ExternalOtherIP to be dropped.
 				return check.ResultDropCurlTimeout, check.ResultNone
 			}
@@ -707,10 +708,10 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)), // Denies all traffic to ExternalOtherIP, but allow ExternalIP
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
 				return check.ResultPolicyDenyEgressDrop, check.ResultNone
 			}
-			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
 				return check.ResultOK, check.ResultNone
 			}
 			return check.ResultDrop, check.ResultDrop
@@ -724,10 +725,10 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			tests.PodToCIDR(), // Denies all traffic to ExternalOtherIP, but allow ExternalIP
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
 				return check.ResultPolicyDenyEgressDrop, check.ResultNone
 			}
-			if a.Destination().Address(check.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
 				return check.ResultDefaultDenyEgressDrop, check.ResultNone
 			}
 			return check.ResultDrop, check.ResultDrop
@@ -885,7 +886,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.
 				// Outbound HTTP to set domain-name defaults to one.one.one.one is L7-introspected and allowed.
-				(a.Destination().Port() == 80 && a.Destination().Address(check.GetIPFamily(ct.Params().ExternalTarget)) == ct.Params().ExternalTarget ||
+				(a.Destination().Port() == 80 && a.Destination().Address(features.GetIPFamily(ct.Params().ExternalTarget)) == ct.Params().ExternalTarget ||
 					a.Destination().Port() == 8080) { // 8080 is traffic to echo Pod.
 				if a.Destination().Path() == "/" || a.Destination().Path() == "" {
 					egress = check.ResultOK
@@ -913,7 +914,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.
 				// Outbound HTTP to domain-name, default one.one.one.one, is L7-introspected and allowed.
-				(a.Destination().Port() == 80 && a.Destination().Address(check.GetIPFamily(ct.Params().ExternalTarget)) == ct.Params().ExternalTarget ||
+				(a.Destination().Port() == 80 && a.Destination().Address(features.GetIPFamily(ct.Params().ExternalTarget)) == ct.Params().ExternalTarget ||
 					a.Destination().Port() == 8080) { // named port http-8080 is traffic to echo Pod.
 				if a.Destination().Path() == "/" || a.Destination().Path() == "" {
 					egress = check.ResultOK
@@ -1046,7 +1047,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			tests.PodToWorld2(), // resolves cilium.io
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Destination().Address(check.IPFamilyAny) == "cilium.io" {
+			if a.Destination().Address(features.IPFamilyAny) == "cilium.io" {
 				if a.Destination().Path() == "/" || a.Destination().Path() == "" {
 					egress = check.ResultDNSOK
 					egress.HTTP = check.HTTP{
@@ -1061,7 +1062,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			}
 
 			extTarget := ct.Params().ExternalTarget
-			if a.Destination().Port() == 80 && a.Destination().Address(check.GetIPFamily(extTarget)) == extTarget {
+			if a.Destination().Port() == 80 && a.Destination().Address(features.GetIPFamily(extTarget)) == extTarget {
 				if a.Destination().Path() == "/" || a.Destination().Path() == "" {
 					egress = check.ResultDNSOK
 					egress.HTTP = check.HTTP{

--- a/connectivity/tests/client.go
+++ b/connectivity/tests/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // ClientToClient sends an ICMP packet from each client Pod
@@ -39,7 +40,7 @@ func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 
 			dst := dst // copy to avoid memory aliasing when using reference
 
-			t.ForEachIPFamily(func(ipFam check.IPFamily) {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("ping-%s-%d", ipFam, i), &src, &dst, ipFam).Run(func(a *check.Action) {
 					a.ExecInPod(ctx, ct.PingCommand(dst, ipFam))
 

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 type labelsContainer interface {
@@ -63,7 +64,7 @@ type retryCondition struct {
 }
 
 // CurlOptions returns curl retry option or empty slice depending on retry conditions
-func (rc *retryCondition) CurlOptions(peer check.TestPeer, ipFam check.IPFamily, pod check.Pod, params check.Parameters) []string {
+func (rc *retryCondition) CurlOptions(peer check.TestPeer, ipFam features.IPFamily, pod check.Pod, params check.Parameters) []string {
 	if params.Retry == 0 {
 		return []string{}
 	}

--- a/connectivity/tests/dummy.go
+++ b/connectivity/tests/dummy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // dummy implements a Scenario.
@@ -30,13 +31,13 @@ func (s *dummy) Name() string {
 }
 
 func (s *dummy) Run(_ context.Context, t *check.Test) {
-	t.NewAction(s, "action-1", nil, nil, check.IPFamilyAny).Run(func(a *check.Action) {
+	t.NewAction(s, "action-1", nil, nil, features.IPFamilyAny).Run(func(a *check.Action) {
 		a.Log("logging")
 		a.Debug("debugging")
 		a.Info("informing")
 	})
 
-	t.NewAction(s, "action-2", nil, nil, check.IPFamilyAny).Run(func(a *check.Action) {
+	t.NewAction(s, "action-2", nil, nil, features.IPFamilyAny).Run(func(a *check.Action) {
 		a.Log("logging")
 		a.Fatal("killing :(")
 		a.Fail("failing (this should not be printed)")

--- a/connectivity/tests/egressgateway.go
+++ b/connectivity/tests/egressgateway.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/utils/features"
 	"github.com/cilium/cilium-cli/utils/wait"
 
 	v1 "k8s.io/api/core/v1"
@@ -204,8 +205,8 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		for _, dst := range ct.HostNetNSPodsByNode() {
 			dst := dst
 
-			t.NewAction(s, fmt.Sprintf("ping-%d", i), &client, &dst, check.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.PingCommand(dst, check.IPFamilyV4))
+			t.NewAction(s, fmt.Sprintf("ping-%d", i), &client, &dst, features.IPFamilyV4).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.PingCommand(dst, features.IPFamilyV4))
 			})
 			i++
 		}
@@ -222,8 +223,8 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		}
 		kubeDNSServicePeer := check.Service{Service: kubeDNSService}
 
-		t.NewAction(s, fmt.Sprintf("dig-%d", i), &client, kubeDNSServicePeer, check.IPFamilyV4).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.DigCommand(kubeDNSServicePeer, check.IPFamilyV4))
+		t.NewAction(s, fmt.Sprintf("dig-%d", i), &client, kubeDNSServicePeer, features.IPFamilyV4).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.DigCommand(kubeDNSServicePeer, features.IPFamilyV4))
 		})
 		i++
 	}
@@ -234,8 +235,8 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		client := client
 
 		for _, externalEcho := range ct.ExternalEchoPods() {
-			t.NewAction(s, fmt.Sprintf("curl-external-echo-pod-%d", i), &client, externalEcho, check.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlClientIPCommand(externalEcho, check.IPFamilyV4))
+			t.NewAction(s, fmt.Sprintf("curl-external-echo-pod-%d", i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlClientIPCommand(externalEcho, features.IPFamilyV4))
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(egressGatewayNodeInternalIP) {
@@ -257,8 +258,8 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 				// convert the service to a ServiceExternalIP as we want to access it through its external IP
 				echo := echo.ToNodeportService(node)
 
-				t.NewAction(s, fmt.Sprintf("curl-echo-service-%d", i), &client, echo, check.IPFamilyV4).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.CurlCommand(echo, check.IPFamilyV4))
+				t.NewAction(s, fmt.Sprintf("curl-echo-service-%d", i), &client, echo, features.IPFamilyV4).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, ct.CurlCommand(echo, features.IPFamilyV4))
 				})
 				i++
 			}
@@ -278,8 +279,8 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 			client := client
 
 			for _, echo := range ct.EchoPods() {
-				t.NewAction(s, fmt.Sprintf("curl-echo-pod-%d", i), &client, echo, check.IPFamilyV4).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.CurlCommand(echo, check.IPFamilyV4))
+				t.NewAction(s, fmt.Sprintf("curl-echo-pod-%d", i), &client, echo, features.IPFamilyV4).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, ct.CurlCommand(echo, features.IPFamilyV4))
 				})
 				i++
 			}
@@ -366,8 +367,8 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 		client := client
 
 		for _, externalEcho := range ct.ExternalEchoPods() {
-			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, externalEcho, check.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlClientIPCommand(externalEcho, check.IPFamilyV4))
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlClientIPCommand(externalEcho, features.IPFamilyV4))
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(net.ParseIP(client.Pod.Status.HostIP)) {

--- a/connectivity/tests/externalworkload.go
+++ b/connectivity/tests/externalworkload.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 func PodToExternalWorkload() check.Scenario {
@@ -28,8 +29,8 @@ func (s *podToExternalWorkload) Run(ctx context.Context, t *check.Test) {
 		pod := pod // copy to avoid memory aliasing when using reference
 
 		for _, wl := range ct.ExternalWorkloads() {
-			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, wl, check.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.PingCommand(wl, check.IPFamilyV4))
+			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, wl, features.IPFamilyV4).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.PingCommand(wl, features.IPFamilyV4))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					Protocol: check.ICMP,

--- a/connectivity/tests/from-cidr.go
+++ b/connectivity/tests/from-cidr.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // FromCIDRToPod generates HTTP request from each node without Cilium to the
@@ -32,11 +33,11 @@ func (f *fromCIDRToPod) Run(ctx context.Context, t *check.Test) {
 		ep := check.HTTPEndpoint(
 			"http-endpoint",
 			// scheme://[ip:port]/path
-			pod.Scheme()+"://"+net.JoinHostPort(pod.Address(check.IPFamilyAny), strconv.FormatUint(uint64(pod.Port()), 10))+pod.Path(),
+			pod.Scheme()+"://"+net.JoinHostPort(pod.Address(features.IPFamilyAny), strconv.FormatUint(uint64(pod.Port()), 10))+pod.Path(),
 		)
 
-		t.NewAction(f, "host-netns-to-pod", &clientPod, pod, check.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, t.Context().CurlCommand(ep, check.IPFamilyAny))
+		t.NewAction(f, "host-netns-to-pod", &clientPod, pod, features.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, t.Context().CurlCommand(ep, features.IPFamilyAny))
 		})
 		i++
 	}

--- a/connectivity/tests/health.go
+++ b/connectivity/tests/health.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 func CiliumHealth() check.Scenario {
@@ -30,7 +31,7 @@ func (s *ciliumHealth) Name() string {
 func (s *ciliumHealth) Run(ctx context.Context, t *check.Test) {
 	for name, pod := range t.Context().CiliumPods() {
 		pod := pod
-		t.NewAction(s, name, &pod, nil, check.IPFamilyAny).Run(func(a *check.Action) {
+		t.NewAction(s, name, &pod, nil, features.IPFamilyAny).Run(func(a *check.Action) {
 			runHealthProbe(ctx, t.Context(), &pod)
 		})
 	}

--- a/connectivity/tests/perfpod.go
+++ b/connectivity/tests/perfpod.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 const (
@@ -52,7 +53,7 @@ func (s *netPerfPodtoPod) Run(ctx context.Context, t *check.Test) {
 			} else {
 				scenarioName = "pod-net"
 			}
-			action := t.NewAction(s, "netperf", &c, server, check.IPFamilyV4)
+			action := t.NewAction(s, "netperf", &c, server, features.IPFamilyV4)
 			action.CollectFlows = false
 			action.Run(func(a *check.Action) {
 				if crr {

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // PodToPod generates one HTTP request from each client pod
@@ -49,7 +50,7 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 			if !hasAllLabels(echo, s.destinationLabels) {
 				continue
 			}
-			t.ForEachIPFamily(func(ipFam check.IPFamily) {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
 					if s.method == "" {
 						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFam))
@@ -109,7 +110,7 @@ func (s *podToPodWithEndpoints) Run(ctx context.Context, t *check.Test) {
 				continue
 			}
 
-			t.ForEachIPFamily(func(ipFam check.IPFamily) {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				s.curlEndpoints(ctx, t, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, echo, ipFam)
 			})
 
@@ -119,7 +120,7 @@ func (s *podToPodWithEndpoints) Run(ctx context.Context, t *check.Test) {
 }
 
 func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test, name string,
-	client *check.Pod, echo check.TestPeer, ipFam check.IPFamily) {
+	client *check.Pod, echo check.TestPeer, ipFam features.IPFamily) {
 	ct := t.Context()
 	baseURL := fmt.Sprintf("%s://%s:%d", echo.Scheme(), echo.Address(ipFam), echo.Port())
 	var curlOpts []string

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // PodToService sends an HTTP request from all client Pods
@@ -52,8 +53,8 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 				continue
 			}
 
-			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, check.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(svc, check.IPFamilyAny))
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(svc, features.IPFamilyAny))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
@@ -105,8 +106,8 @@ func (s *podToIngress) Run(ctx context.Context, t *check.Test) {
 				continue
 			}
 
-			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, check.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(svc, check.IPFamilyAny))
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(svc, features.IPFamilyAny))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
@@ -223,10 +224,10 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 		}
 	}
 
-	t.ForEachIPFamily(func(ipFam check.IPFamily) {
+	t.ForEachIPFamily(func(ipFam features.IPFamily) {
 
 		for _, addr := range addrs {
-			if check.GetIPFamily(addr.Address) != ipFam {
+			if features.GetIPFamily(addr.Address) != ipFam {
 				continue
 			}
 
@@ -238,7 +239,7 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 			}
 
 			//  Skip IPv6 requests when running on <1.14.0 Cilium with CNPs
-			if check.GetIPFamily(addr.Address) == check.IPFamilyV6 &&
+			if features.GetIPFamily(addr.Address) == features.IPFamilyV6 &&
 				versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) &&
 				(len(t.CiliumNetworkPolicies()) > 0 || len(t.KubernetesNetworkPolicies()) > 0) {
 				continue
@@ -250,8 +251,8 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 
 			// Create the Action with the original svc as this will influence what the
 			// flow matcher looks for in the flow logs.
-			t.NewAction(s, name, pod, svc, check.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, t.Context().CurlCommand(ep, check.IPFamilyAny))
+			t.NewAction(s, name, pod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, t.Context().CurlCommand(ep, features.IPFamilyAny))
 
 				if validateFlows {
 					a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{

--- a/connectivity/tests/to-cidr.go
+++ b/connectivity/tests/to-cidr.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // PodToCIDR sends an HTTPS request from each client Pod
@@ -40,9 +41,9 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 		for _, src := range ct.ClientPods() {
 			src := src // copy to avoid memory aliasing when using reference
 
-			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep, check.IPFamilyAny).Run(func(a *check.Action) {
-				opts := s.rc.CurlOptions(ep, check.IPFamilyAny, src, ct.Params())
-				a.ExecInPod(ctx, ct.CurlCommand(ep, check.IPFamilyAny, opts...))
+			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep, features.IPFamilyAny).Run(func(a *check.Action) {
+				opts := s.rc.CurlOptions(ep, features.IPFamilyAny, src, ct.Params())
+				a.ExecInPod(ctx, ct.CurlCommand(ep, features.IPFamilyAny, opts...))
 
 				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
 					RSTAllowed: true,

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
 )
 
 // PodToWorld sends multiple HTTP(S) requests to ExternalTarget
@@ -47,23 +48,23 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		client := client // copy to avoid memory aliasing when using reference
 
 		// With http, over port 80.
-		httpOpts := s.rc.CurlOptions(http, check.IPFamilyAny, client, ct.Params())
-		t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &client, http, check.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(http, check.IPFamilyAny, httpOpts...))
+		httpOpts := s.rc.CurlOptions(http, features.IPFamilyAny, client, ct.Params())
+		t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &client, http, features.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(http, features.IPFamilyAny, httpOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443.
-		httpsOpts := s.rc.CurlOptions(https, check.IPFamilyAny, client, ct.Params())
-		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, check.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyAny, httpsOpts...))
+		httpsOpts := s.rc.CurlOptions(https, features.IPFamilyAny, client, ct.Params())
+		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny, httpsOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443, index.html.
-		httpsindexOpts := s.rc.CurlOptions(httpsindex, check.IPFamilyAny, client, ct.Params())
-		t.NewAction(s, fmt.Sprintf("https-to-%s-index-%d", extTarget, i), &client, httpsindex, check.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(httpsindex, check.IPFamilyAny, httpsindexOpts...))
+		httpsindexOpts := s.rc.CurlOptions(httpsindex, features.IPFamilyAny, client, ct.Params())
+		t.NewAction(s, fmt.Sprintf("https-to-%s-index-%d", extTarget, i), &client, httpsindex, features.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(httpsindex, features.IPFamilyAny, httpsindexOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
@@ -99,8 +100,8 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 		client := client // copy to avoid memory aliasing when using reference
 
 		// With https, over port 443.
-		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https, check.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyAny))
+		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 			a.ValidateMetrics(ctx, client, a.GetEgressMetricsRequirements())
 		})
@@ -153,9 +154,9 @@ func (s *podToWorldWithTLSIntercept) Run(ctx context.Context, t *check.Test) {
 		client := client // copy to avoid memory aliasing when using reference
 
 		// With https, over port 443.
-		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, check.IPFamilyAny).Run(func(a *check.Action) {
+		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
 			a.WriteDataToPod(ctx, "/tmp/test-ca.crt", caBundle)
-			a.ExecInPod(ctx, ct.CurlCommand(https, check.IPFamilyAny, s.curlOpts...))
+			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny, s.curlOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 

--- a/utils/features/utils.go
+++ b/utils/features/utils.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package check
+package features
 
 import "net"
 


### PR DESCRIPTION
Move IPFamily to a separate package so that other packages can import it without introducing a cyclic dependency with the connectivity check package.

Ref: #1962