### PR TITLE
sysdump: Specify default selectors for log collection tasks

### DIFF
--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -83,6 +83,15 @@ func initSysdumpFlags(cmd *cobra.Command, options *sysdump.Options, optionPrefix
 	cmd.Flags().StringVar(&options.ClustermeshApiserverLabelSelector,
 		optionPrefix+"clustermesh-apiserver-label-selector", sysdump.DefaultClustermeshApiserverLabelSelector,
 		"The labels used to target 'clustermesh-apiserver' pods")
+	cmd.Flags().StringVar(&options.CiliumNodeInitLabelSelector,
+		optionPrefix+"cilium-node-init-selector", sysdump.DefaultCiliumNodeInitLabelSelector,
+		"The labels used to target Cilium node init pods")
+	cmd.Flags().StringVar(&options.CiliumSPIREAgentLabelSelector,
+		optionPrefix+"cilium-spire-agent-selector", sysdump.DefaultCiliumSpireAgentLabelSelector,
+		"The labels used to target Cilium spire-agent pods")
+	cmd.Flags().StringVar(&options.CiliumSPIREServerLabelSelector,
+		optionPrefix+"cilium-spire-server-selector", sysdump.DefaultCiliumSpireServerLabelSelector,
+		"The labels used to target Cilium spire-server pods")
 	cmd.Flags().BoolVar(&options.Debug,
 		optionPrefix+"debug", sysdump.DefaultDebug,
 		"Whether to enable debug logging")

--- a/sysdump/defaults.go
+++ b/sysdump/defaults.go
@@ -19,6 +19,9 @@ const (
 	DefaultCiliumEnvoyLabelSelector          = labelPrefix + "cilium-envoy"
 	DefaultCiliumOperatorLabelSelector       = "io.cilium/app=operator"
 	DefaultClustermeshApiserverLabelSelector = labelPrefix + "clustermesh-apiserver"
+	DefaultCiliumNodeInitLabelSelector       = "app=cilium-node-init"
+	DefaultCiliumSpireAgentLabelSelector     = "app=spire-agent"
+	DefaultCiliumSpireServerLabelSelector    = "app=spire-server"
 	DefaultDebug                             = false
 	DefaultProfiling                         = true
 	DefaultHubbleLabelSelector               = labelPrefix + "hubble"


### PR DESCRIPTION
Specify default label selectors for log collection tasks to avoid collecting logs from all the pods in a given namespace.

Fixes: f88a976e ("sysdump: collect SPIRE agent and server Pod logs")
Fixes: ebaf4fbd ("sysdump: Collect node init Pod logs and DaemonSet")