### PR TITLE
clustermesh: Make cilium symlink install idempotent

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1715,7 +1715,7 @@ while [ $cilium_started = false ]; do
 
     # Copy Cilium CLI
     ${SUDO} docker cp -L cilium:/usr/bin/cilium /usr/bin/cilium-dbg
-    ${SUDO} ln -s /usr/bin/cilium-dbg /usr/bin/cilium
+    ${SUDO} ln -fs /usr/bin/cilium-dbg /usr/bin/cilium
 
     # Wait for cilium agent to become available
     for ((i = 0 ; i < 12; i++)); do


### PR DESCRIPTION
Ensure the symlink is installed even if it already exists.

Fixes: 1e059407dc39 ("clustermesh: Adapt clustermesh script to install cilium-dbg")
Signed-off-by: Joe Stringer <joe@cilium.io>
