### PR TITLE
connectivity test: Fix detectFeatures() logic

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -278,12 +278,12 @@ func (ct *ConnectivityTest) detectFeatures(ctx context.Context) error {
 		// If unsure from which source to retrieve the information from,
 		// prefer "CiliumStatus" over "ConfigMap" over "RuntimeConfig".
 		// See the corresponding functions for more information.
-		ct.Features.ExtractFromConfigMap(ct.CiliumVersion, cm)
+		features.ExtractFromConfigMap(ct.CiliumVersion, cm)
 		err = ct.extractFeaturesFromRuntimeConfig(ctx, ciliumPod, features)
 		if err != nil {
 			return err
 		}
-		ct.Features.ExtractFromNodes(ct.nodesWithoutCilium)
+		features.ExtractFromNodes(ct.nodesWithoutCilium)
 		err = ct.extractFeaturesFromCiliumStatus(ctx, ciliumPod, features)
 		if err != nil {
 			return err


### PR DESCRIPTION
f5ac9776fb21 unintentionally changed the detectFeatures logic by calling ExtractFromConfigMap() and ExtractFromNodes() on ct.Features instead of the features variable declared at the beginning of the loop [^1].

Fixes: f5ac9776fb21 ("Refactor extractFeaturesFromConfigMap()")

[^1]: https://github.com/cilium/cilium-cli/blob/f5ac9776fb217d883edc9f916cb61cb916576693/connectivity/check/features.go#L518