### PR TITLE
helm-upgrade-clustermesh: Free up some disk space

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -328,6 +328,8 @@ jobs:
 
       - name: Run the multicluster connectivity tests
         run: |
+          # Remove unused docker stuff to avoid running out of disk space.
+          docker system prune -fa
           # Setup the connectivity disruption tests. We don't really care about the result
           # here (in the sense that we don't perform any operation which might cause a
           # disruption), but we want to make sure that the command works as expected.


### PR DESCRIPTION
helm-upgrade-clustermesh recently started running out of disk space
[^1]. Run "docker system prune -fa" to make some space before running
cilium connectivity test.

[^1]: https://github.com/cilium/cilium-cli/actions/runs/6423071562/job/17440825179

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>