### PR TITLE
sysdump feature detection: Don't depend on Cilium version

### DIFF
--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -278,7 +278,8 @@ func (ct *ConnectivityTest) detectFeatures(ctx context.Context) error {
 		// If unsure from which source to retrieve the information from,
 		// prefer "CiliumStatus" over "ConfigMap" over "RuntimeConfig".
 		// See the corresponding functions for more information.
-		features.ExtractFromConfigMap(ct.CiliumVersion, cm)
+		features.ExtractFromVersionedConfigMap(ct.CiliumVersion, cm)
+		features.ExtractFromConfigMap(cm)
 		err = ct.extractFeaturesFromRuntimeConfig(ctx, ciliumPod, features)
 		if err != nil {
 			return err

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -267,12 +267,8 @@ func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion
 			}
 			c.log("ℹ️  %s ConfigMap not found in %s namespace", ciliumConfigMapName, c.Options.CiliumNamespace)
 		}
-		if c.CiliumConfigMap != nil && len(c.CiliumPods) > 0 {
-			ciliumVersion, err := c.Client.GetCiliumVersion(context.Background(), c.CiliumPods[0])
-			if err != nil {
-				return nil, fmt.Errorf("failed to get Cilium version from %s/%s: %w", c.CiliumPods[0].Namespace, c.CiliumPods[0].Name, err)
-			}
-			c.FeatureSet.ExtractFromConfigMap(*ciliumVersion, c.CiliumConfigMap)
+		if c.CiliumConfigMap != nil {
+			c.FeatureSet.ExtractFromConfigMap(c.CiliumConfigMap)
 			c.log("🔮 Detected Cilium features: %v", c.FeatureSet)
 		}
 	}


### PR DESCRIPTION
Detecting Cilium version can get arbitrary complicated. Let's not even try during sysdump feature detection since sysdump doesn't depend on any version-specific features yet.

This commit separates ExtractFromConfigMap into two functions:

- ExtractFromConfigMap to detect version-independent features.
- ExtractFromVersionedConfigMap to detect version-specific features.

Then sysdump uses ExtractFromConfigMap to extract enabled features it needs to know about without having to detect Cilium version. Problem solved, at least for now...

Fixes: #2029