### PR TITLE
connectivity: Add Control Plane Node Connectivity Tests

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -28,6 +28,7 @@ type Parameters struct {
 	ForceDeploy           bool
 	Hubble                bool
 	HubbleServer          string
+	K8sLocalHostTest      bool
 	MultiCluster          string
 	RunTests              []*regexp.Regexp
 	SkipTests             []*regexp.Regexp
@@ -61,6 +62,8 @@ type Parameters struct {
 	ExternalOtherIP       string
 	PodCIDRs              []podCIDRs
 	NodeCIDRs             []string
+	ControlPlaneCIDRs     []string
+	K8sCIDR               string
 	NodesWithoutCiliumIPs []nodesWithoutCiliumIP
 	JunitFile             string
 	JunitProperties       map[string]string

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -348,3 +348,11 @@ func canNodeRunCilium(node *corev1.Node) bool {
 	val, ok := node.ObjectMeta.Labels["cilium.io/no-schedule"]
 	return !ok || val == "false"
 }
+
+func isControlPlane(node *corev1.Node) bool {
+	if node != nil {
+		_, ok := node.Labels["node-role.kubernetes.io/control-plane"]
+		return ok
+	}
+	return false
+}

--- a/connectivity/manifests/client-egress-to-cidr-cp-host-knp.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-cp-host-knp.yaml
@@ -1,0 +1,15 @@
+# This policy allows packets to all node IPs
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: client-egress-to-cidr-cp-host
+spec:
+  podSelector:
+    matchLabels:
+      kind: client
+  egress:
+    - to:
+{{- range .ControlPlaneCIDRs }}
+        - ipBlock:
+            cidr: {{.}}
+{{- end }}

--- a/connectivity/manifests/client-egress-to-cidr-k8s.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-cidr-k8s
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toCIDR:
+      - {{ .K8sCIDR }}
+  - toEndpoints:
+    - matchExpressions:
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY

--- a/connectivity/manifests/client-egress-to-entities-host.yaml
+++ b/connectivity/manifests/client-egress-to-entities-host.yaml
@@ -1,0 +1,11 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-entities-host
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toEntities:
+    - host

--- a/connectivity/manifests/client-egress-to-entities-k8s.yaml
+++ b/connectivity/manifests/client-egress-to-entities-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-entities-k8s
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toEntities:
+    - kube-apiserver
+  - toEndpoints:
+    - matchExpressions:
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY

--- a/connectivity/tests/k8s.go
+++ b/connectivity/tests/k8s.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+// PodToK8sLocal sends a curl from all control plane client Pods
+// to all control-plane nodes.
+func PodToK8sLocal() check.Scenario {
+	return &podToK8sLocal{}
+}
+
+// podToK8sLocal implements a Scenario.
+type podToK8sLocal struct{}
+
+func (s *podToK8sLocal) Name() string {
+	return "pod-to-k8s-local"
+}
+
+func (s *podToK8sLocal) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	k8sSvc := ct.K8sService()
+	for _, pod := range ct.ControlPlaneClientPods() {
+		pod := pod // copy to avoid memory aliasing when using reference
+		t.NewAction(s, fmt.Sprintf("curl-k8s-from-pod-%s", pod.Name()), &pod, k8sSvc, features.IPFamilyAny).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.CurlCommand(k8sSvc, features.IPFamilyAny))
+			a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
+				DNSRequired: true,
+				AltDstPort:  k8sSvc.Port(),
+			}))
+
+			a.ValidateMetrics(ctx, pod, a.GetEgressMetricsRequirements())
+		})
+	}
+}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -146,6 +146,8 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster nodes state")
 	cmd.Flags().MarkHidden("include-unsafe-tests")
+	cmd.Flags().BoolVar(&params.K8sLocalHostTest, "k8s-localhost-test", false, "Include tests which test for policy enforcement for the k8s entity on its own host")
+	cmd.Flags().MarkHidden("k8s-localhost-test")
 
 	cmd.Flags().StringVar(&params.K8sVersion, "k8s-version", "", "Kubernetes server version in case auto-detection fails")
 	cmd.Flags().StringVar(&params.HelmChartDirectory, "chart-directory", "", "Helm chart directory")


### PR DESCRIPTION
The control plane nodes create unique policy selection contexts that allow us to test that label selection of host and kube-apiserver entities is correct.