### PR TITLE
gha: cleanup stale AWS-CNI iptables rules in EKS tunnel workflow

### DIFF
--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -25,6 +25,19 @@ cilium status --wait
 # Make sure the 'aws-node' DaemonSet exists but has no scheduled pods
 [[ $(kubectl -n kube-system get ds/aws-node -o jsonpath='{.status.currentNumberScheduled}') == 0 ]]
 
+# Clean up stale AWS-CNI iptables rules, which break host to pod connectivity (cilium/cilium#25804)
+CLEANUP_CMD="\
+    iptables -t nat -F AWS-SNAT-CHAIN-0 && \
+    iptables -t nat -F AWS-SNAT-CHAIN-1 && \
+    iptables -t nat -F AWS-CONNMARK-CHAIN-0 && \
+    iptables -t nat -F AWS-CONNMARK-CHAIN-1"
+kubectl get pod \
+    -n kube-system \
+    -l app.kubernetes.io/name=cilium-agent \
+    -o custom-columns=name:metadata.name --no-headers \
+    | xargs -I{} kubectl exec {} -n kube-system -c cilium-agent \
+      -- sh -c "$CLEANUP_CMD"
+
 # Port forward Relay
 cilium hubble port-forward&
 sleep 10s


### PR DESCRIPTION
Extend the eks-tunnel script to additionally flush the stale AWS-CNI iptables rules left by the aws-node DaemonSet, which break host to pod connectivity. Using the cleanup commands from the documentation [1].

[1]: https://github.com/cilium/cilium/blob/cc2051eec0ba5e57842d8a7d4b4b33f31b12509f/Documentation/installation/k8s-install-helm.rst?plain=1#L208-L211

For https://github.com/cilium/cilium-cli/pull/2035.