### PR TITLE
fix: properly propagate flags used for kubeproxyreplacement

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -266,6 +266,11 @@ cilium install
 cilium install --context kind-cluster1 --set cluster.id=1 --set cluster.name=cluster1
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				if f.Name == "set" && strings.Contains(f.Value.String(), "kubeProxyReplacement") {
+					params.UserSetKubeProxyReplacement = true
+				}
+			})
 			params.Namespace = namespace
 			// Don't log anything if it's a dry run so that the dry run output can easily be piped to other commands.
 			if params.DryRun || params.DryRunHelmValues {
@@ -344,6 +349,11 @@ cilium upgrade
 cilium upgrade --helm-set cluster.id=1 --helm-set cluster.name=cluster1
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				if f.Name == "set" && strings.Contains(f.Value.String(), "kubeProxyReplacement") {
+					params.UserSetKubeProxyReplacement = true
+				}
+			})
 			params.Namespace = namespace
 			// Don't log anything if it's a dry run so that the dry run output can easily be piped to other commands.
 			if params.DryRun || params.DryRunHelmValues {


### PR DESCRIPTION
After the switch to Helm install & upgrade mode rather than classic mode, the flags for kubeProxyReplacement, k8sServiceHost & k8sServicePort was not propagated properly.

These changes makes sure that there's no auto detection done if the `kubeProxyReplacement` flag has been set, and if it's not set, make sure to prioritze the k8sServiceHost / k8sServicePort flags over getting it from the current context.

```release-note
fix: properly propagate helm values used for kubeProxyReplacement
```