### PR TITLE
Updated deprecated service annotation

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -140,9 +140,9 @@ func (k *K8sClusterMesh) generateService() (*corev1.Service, error) {
 			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 			svc.ObjectMeta.Annotations["service.beta.kubernetes.io/azure-load-balancer-internal"] = "true"
 		case k8s.KindEKS:
-			k.Log("🔮 Auto-exposing service within AWS VPC (service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0")
+			k.Log("🔮 Auto-exposing service within AWS VPC (service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing")
 			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-			svc.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "0.0.0.0/0"
+			svc.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"] = "internet-facing"
 		default:
 			return nil, fmt.Errorf("cannot auto-detect service type, please specify using '--service-type' option")
 		}
@@ -1968,12 +1968,12 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 				},
 			}
 		case k8s.KindEKS:
-			log("🔮 Auto-exposing service within AWS VPC (service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0")
+			log("🔮 Auto-exposing service within AWS VPC (service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing")
 			helmVals["clustermesh"].(map[string]interface{})["apiserver"] = map[string]interface{}{
 				"service": map[string]interface{}{
 					"type": "LoadBalancer",
 					"annotations": map[string]interface{}{
-						"service.beta.kubernetes.io/aws-load-balancer-internal": "0.0.0.0/0",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
 					},
 				},
 			}


### PR DESCRIPTION
Updated deprecated service annotation

https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/guide/service/annotations/#:~:text=string-,service.beta.kubernetes.io/aws%2Dload%2Dbalancer%2Dinternal,-boolean
