### PR TITLE
go.mod: Let Renovate manage Go version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -186,6 +186,15 @@
         "\/\/ renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\"",
         "\/\/ renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+Version = \"(?<currentValue>.*)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^go\\.mod$"
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)"
+      ]
     }
   ]
 }

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,8 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        # renovate: datasource=golang-version depName=go
-        go-version: 1.21.3
+        go-version-file: 'go.mod'
 
     - name: Run static checks
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -45,8 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: 1.21.3
+          go-version-file: 'go.mod'
 
       - name: Set up Go for root
         run: |
@@ -241,8 +240,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: 1.21.3
+          go-version-file: 'go.mod'
 
       - name: Set up Go for root
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -84,8 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: 1.21.3
+          go-version-file: 'go.mod'
 
       - name: Set up job variables
         id: vars

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: 1.21.3
+          go-version-file: 'go.mod'
 
       - name: Generate the artifacts
         run: make release

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/cilium/cilium-cli
 
+// renovate: datasource=golang-version depName=go
 go 1.21.1
 
 // Replace directives from github.com/cilium/cilium. Keep in sync when updating Cilium!


### PR DESCRIPTION
Configure Renovate to update Go version in go.mod, and modify workflow files to use go.mod to get the Go version to reduce the number of places Renovate needs to update.

Ref: https://github.com/cilium/tetragon/pull/1579