### PR TITLE
Add aditional mutual auth tests

### DIFF
--- a/connectivity/manifests/echo-egress-mutual-authentication.yaml
+++ b/connectivity/manifests/echo-egress-mutual-authentication.yaml
@@ -1,0 +1,19 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: echo-egress-mutual-authentication
+spec:
+  description: "Allow other client to contact echo after mutual authentication"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        kind: echo
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    authentication:
+      mode: required

--- a/connectivity/manifests/echo-ingress-l7-http-mutual-auth.yaml
+++ b/connectivity/manifests/echo-ingress-l7-http-mutual-auth.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: echo-ingress-l7-http
+spec:
+  description: "Allow other client to GET on echo"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+  # Only allow 'other' client to make a GET /public requests.
+  # Allow GET /private' only if a particular HTTP header is set.
+  # Disallow L3 traffic for now, flow matcher doesn't yet support L7 drops.
+  - fromEndpoints:
+    - matchLabels:
+        other: client
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/$"
+        - method: "GET"
+          path: "/public$"
+        - method: "GET"
+          path: "/private$"
+          headers:
+          - "X-Very-Secret-Token: 42"
+    authentication:
+      mode: required


### PR DESCRIPTION
This adds two new mutual auth tests to combine them with additional features.
The first one is a test for an L7 policy with mutual auth enabled. 
The second one is a normal traffic tests but with an egress policy.