### PR TITLE
Revert "chore(deps): update dependency cilium/cilium to v1.14.3"

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -39,7 +39,7 @@ env:
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   # renovate: datasource=github-releases depName=cilium/cilium
-  cilium_version: v1.14.3
+  cilium_version: v1.14.2
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -29,7 +29,7 @@ env:
   region: us-east-2
   eksctl_version: v0.147.0
   # renovate: datasource=github-releases depName=cilium/cilium
-  cilium_version: v1.14.3
+  cilium_version: v1.14.2
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -29,7 +29,7 @@ env:
   region: us-east-2
   eksctl_version: v0.147.0
   # renovate: datasource=github-releases depName=cilium/cilium
-  cilium_version: v1.14.3
+  cilium_version: v1.14.2
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -29,7 +29,7 @@ env:
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
   # renovate: datasource=github-releases depName=cilium/cilium
-  cilium_version: v1.14.3
+  cilium_version: v1.14.2
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -28,7 +28,7 @@ concurrency:
 env:
   zone: us-west2-a
   # renovate: datasource=github-releases depName=cilium/cilium
-  cilium_version: v1.14.3
+  cilium_version: v1.14.2
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -17,7 +17,7 @@ env:
   TIMEOUT: 2m
   LOG_TIME: 30m
   # renovate: datasource=github-releases depName=cilium/cilium
-  cilium_version: v1.14.3
+  cilium_version: v1.14.2
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -28,7 +28,7 @@ concurrency:
 env:
   zone: us-west2-a
   # renovate: datasource=github-releases depName=cilium/cilium
-  cilium_version: v1.14.3
+  cilium_version: v1.14.2
   kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -7,7 +7,7 @@ import "time"
 
 const (
 	// renovate: datasource=github-releases depName=cilium/cilium
-	Version = "v1.14.3"
+	Version = "v1.14.2"
 
 	AgentContainerName      = "cilium-agent"
 	AgentServiceAccountName = "cilium"


### PR DESCRIPTION
This reverts commit 0245001fd6fd9c907780ef0b78547caf118c72eb.

It looks like the external workloads test started failing after upgrading Cilium to v1.14.3. Let's revert while we investigate. It's unclear to me why #2057 didn't fail though.

edit: it's clear to me now why #2057 didn't fail. it ran the CI with v1.14.2 because it uses the pull_request_target trigger.

Ref: #2070