### PR TITLE
Sysdump: always collect logs of cilium control-plane components

### DIFF
--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -399,15 +400,6 @@ func (k *K8sHubble) enableHubble(ctx context.Context) error {
 	return k.updateConfigMap(ctx)
 }
 
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-	return false
-}
-
 // Removes any values that are not related to hubble from configmap patch
 func (k *K8sHubble) filterConfigmapPatch(patch []byte) ([]byte, error) {
 	patchYaml := map[string]interface{}{}
@@ -421,7 +413,7 @@ func (k *K8sHubble) filterConfigmapPatch(patch []byte) ([]byte, error) {
 	if data.Kind() == reflect.Map {
 		for _, key := range data.MapKeys() {
 			keyStr := key.Interface().(string)
-			if contains(defaults.HubbleKeys, keyStr) {
+			if slices.Contains(defaults.HubbleKeys, keyStr) {
 				if data.MapIndex(key).Interface() == nil {
 					hubbleOnlyFields[keyStr] = nil
 				} else {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -91,15 +91,6 @@ func BuildImagePath(userImage, userVersion, defaultImage, defaultVersion string,
 	return image
 }
 
-func Contains(l []string, v string) bool {
-	for _, s := range l {
-		if s == v {
-			return true
-		}
-	}
-	return false
-}
-
 // IsInHelmMode returns true if cilium-cli is in "helm" mode. Otherwise, it returns false.
 func IsInHelmMode() bool {
 	return os.Getenv(CLIModeVariableName) != "classic"

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,7 +28,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium-cli/utils/features"
 )
@@ -2270,7 +2270,7 @@ func FilterPods(l *corev1.PodList, n []string) []*corev1.Pod {
 	r := make([]*corev1.Pod, 0)
 	for _, p := range l.Items {
 		p := p
-		if utils.Contains(n, p.Spec.NodeName) {
+		if slices.Contains(n, p.Spec.NodeName) {
 			r = append(r, &p)
 		}
 	}


### PR DESCRIPTION
Always collect the logs of the control-plane pods (i.e., cilium
operator, clustermesh-apiserver, hubble relay/UI, spire server) which
only run in a bound number of replicas, regardless of the specified
node filter. Indeed, they add very little overhead, but can be
extremely useful to have a full picture when troubleshooting issues.