### PR TITLE
e2e: add pod/container info in error form exec in pod.

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -453,7 +453,7 @@ func (c *Client) ExecInPod(ctx context.Context, namespace, pod, container string
 	}
 
 	if errString := result.Stderr.String(); errString != "" {
-		return bytes.Buffer{}, fmt.Errorf("command failed: %s", errString)
+		return bytes.Buffer{}, fmt.Errorf("command failed (pod=%s/%s, container=%s): %q", namespace, pod, container, errString)
 	}
 
 	return result.Stdout, nil

--- a/k8s/exec.go
+++ b/k8s/exec.go
@@ -73,7 +73,8 @@ func (c *Client) execInPodWithWriters(connCtx, killCmdCtx context.Context, p Exe
 
 func (c *Client) execInPod(ctx context.Context, p ExecParameters) (*ExecResult, error) {
 	result := &ExecResult{}
-	err := c.execInPodWithWriters(ctx, nil, p, &result.Stdout, &result.Stderr)
-
-	return result, err
+	if err := c.execInPodWithWriters(ctx, nil, p, &result.Stdout, &result.Stderr); err != nil {
+		return result, fmt.Errorf("error with exec request (pod=%s/%s, container=%s): %w", p.Namespace, p.Pod, p.Container, err)
+	}
+	return result, nil
 }


### PR DESCRIPTION
When running connectivity tests, it's up to debug logs to provide information on failure errors. This is not always the case, making it hard to understand where to start investigating errors.

This adds pod/container to the error message for calls to k8s exec to make it easier to understand where the issue occurred.

Ex use [case](https://github.com/cilium/cilium/issues/28693):

`Running test echo-ingress-l7-named-port: setting up test: applying network policies: policies were not applied on all Cilium nodes in time: Timeout occurred`

Raises the questions:
* On what Agent Pod?
* "Timeout occurred" error is ambiguous, did the k8s exec request timeout, or the passed command itself?
