### PR TITLE
fix: connectivity test client-egress-to-cidr-external-deny

### DIFF
--- a/connectivity/manifests/client-egress-to-cidr-external-deny.yaml
+++ b/connectivity/manifests/client-egress-to-cidr-external-deny.yaml
@@ -9,7 +9,7 @@ spec:
   endpointSelector:
     matchLabels:
       kind: client
-  egressDeny:
+  egress:
   - toCIDRSet:
     - cidr: {{.ExternalCIDR}}
       except:


### PR DESCRIPTION
When in an air-gapped environment, the connectivity test fails on the test `client-egress-to-cidr-external-deny` when providing some flags (--external-ip, --external-other-ip, external-cidr), for example:

```
cilium connectivity test --external-target mydomain.local --external-other-ip 10.134.1.17 --external-ip 10.134.1.17 --external-cidr 10.0.0.0/8 --curl-insecure
```

The logic of the associated CiliumNetworkPolicy seems to be reversed.

This commit fixes this issue.