### PR TITLE
Make --nodes-without-cilium work with SPIRE

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -173,4 +173,12 @@ var (
 		"operator.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=NotIn",
 		"operator.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=true",
 	}
+
+	// SpireAgentScheduleAffinity is the node affinity to prevent the SPIRE agent from being scheduled on
+	// nodes labeled with CiliumNoScheduleLabel.
+	SpireAgentScheduleAffinity = []string{
+		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=" + CiliumNoScheduleLabel,
+		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].authentication.mutual.spire.install.agent=NotIn",
+		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=true",
+	}
 )

--- a/install/helm.go
+++ b/install/helm.go
@@ -301,6 +301,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 	if len(k.params.NodesWithoutCilium) != 0 {
 		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumScheduleAffinity...)
 		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumOperatorScheduleAffinity...)
+		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.SpireAgentScheduleAffinity...)
 	}
 
 	// Store all the options passed by --config into helm extraConfig


### PR DESCRIPTION
This change sets the same affinity on the SPIRE agent as CIlium has when` --nodes-without-cilium` is used, this prevents it from being scheduled where Cilium agent is not present.