### PR TITLE
Rename GetTestOrDie to MustGetTest

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -293,9 +293,9 @@ func (ct *ConnectivityTest) GetTest(name string) (*Test, error) {
 	panic("missing test descriptor for a registered name")
 }
 
-// GetTestOrDie returns the test scope for test named "name" if found,
+// MustGetTest returns the test scope for test named "name" if found,
 // or panics otherwise.
-func (ct *ConnectivityTest) GetTestOrDie(name string) *Test {
+func (ct *ConnectivityTest) MustGetTest(name string) *Test {
 	test, err := ct.GetTest(name)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes: 89c7ff04254f ("connectivity: Add GetTestOrDie()")

Ref: https://github.com/cilium/cilium-cli/pull/2096#pullrequestreview-1721958513