### PR TITLE
connectivity test: Fix flow validation for nodeport service tests

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -516,8 +516,12 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 	ipRequest := filters.IP(srcIP, dstIP)
 	ipResponse := filters.IP(dstIP, srcIP)
 	if len(p.AltDstIP) != 0 && p.AltDstIP != dstIP {
-		ipRequest = filters.Or(filters.IP(srcIP, p.AltDstIP), ipRequest)
-		ipResponse = filters.Or(filters.IP(p.AltDstIP, srcIP), ipResponse)
+		altDstIP := p.AltDstIP
+		if altDstIP == "ANY" {
+			altDstIP = ""
+		}
+		ipRequest = filters.Or(filters.IP(srcIP, altDstIP), ipRequest)
+		ipResponse = filters.Or(filters.IP(altDstIP, srcIP), ipResponse)
 	}
 
 	var egress filters.FlowSetRequirement

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/cilium/api/v1/flow"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium-cli/utils/features"
@@ -206,7 +205,7 @@ func (s Service) Address(family features.IPFamily) string {
 		return fmt.Sprintf("%s.%s", s.Service.Name, s.Service.Namespace)
 	}
 
-	getClusterIPForIPFamily := func(family v1.IPFamily) string {
+	getClusterIPForIPFamily := func(family corev1.IPFamily) string {
 		for i, f := range s.Service.Spec.IPFamilies {
 			if f == family {
 				return s.Service.Spec.ClusterIPs[i]
@@ -218,9 +217,9 @@ func (s Service) Address(family features.IPFamily) string {
 
 	switch family {
 	case features.IPFamilyV4:
-		return getClusterIPForIPFamily(v1.IPv4Protocol)
+		return getClusterIPForIPFamily(corev1.IPv4Protocol)
 	case features.IPFamilyV6:
-		return getClusterIPForIPFamily(v1.IPv6Protocol)
+		return getClusterIPForIPFamily(corev1.IPv6Protocol)
 	}
 
 	return ""
@@ -250,10 +249,10 @@ func (s Service) FlowFilters() []*flow.FlowFilter {
 	return nil
 }
 
-func (s Service) ToNodeportService(node *v1.Node) NodeportService {
+func (s Service) ToNodeportService(addresses []corev1.NodeAddress) NodeportService {
 	return NodeportService{
-		Service: s,
-		Node:    node,
+		Service:   s,
+		Addresses: &addresses,
 	}
 }
 
@@ -261,32 +260,24 @@ func (s Service) ToNodeportService(node *v1.Node) NodeportService {
 // It implements interface TestPeer.
 type NodeportService struct {
 	Service
-	Node *v1.Node
+	Addresses *[]corev1.NodeAddress
 }
 
 // Address returns the node IP of the wrapped Service.
 func (s NodeportService) Address(family features.IPFamily) string {
-	if family == features.IPFamilyAny {
-		return s.Node.Status.Addresses[0].Address
-	}
+	for _, address := range *s.Addresses {
+		if address.Type == corev1.NodeInternalIP {
+			ip := net.ParseIP(address.Address)
 
-	for _, address := range s.Node.Status.Addresses {
-		if address.Type == v1.NodeInternalIP {
-			parsedAddress := net.ParseIP(address.Address)
+			if (family == features.IPFamilyV4 || family == features.IPFamilyAny) && ip.To4() != nil {
+				return address.Address
+			}
 
-			switch family {
-			case features.IPFamilyV4:
-				if parsedAddress.To4() != nil {
-					return address.Address
-				}
-			case features.IPFamilyV6:
-				if parsedAddress.To16() != nil {
-					return address.Address
-				}
+			if (family == features.IPFamilyV6 || family == features.IPFamilyAny) && ip.To4() == nil && ip.To16() != nil {
+				return address.Address
 			}
 		}
 	}
-
 	return ""
 }
 

--- a/connectivity/tests/egressgateway.go
+++ b/connectivity/tests/egressgateway.go
@@ -258,7 +258,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		for _, node := range ct.Nodes() {
 			for _, echo := range ct.EchoServices() {
 				// convert the service to a ServiceExternalIP as we want to access it through its external IP
-				echo := echo.ToNodeportService(node)
+				echo := echo.ToNodeportService(node.Status.Addresses)
 
 				t.NewAction(s, fmt.Sprintf("curl-echo-service-%d", i), &client, echo, features.IPFamilyV4).Run(func(a *check.Action) {
 					a.ExecInPod(ctx, ct.CurlCommand(echo, features.IPFamilyV4))


### PR DESCRIPTION
Fix `NodeportService.Address()` IPv6 check and generalize `NodeportService` by using in `[]corev1.NodeAddress` instead of `*corev1.Node` so that test cases can customize the addresses to be used. Use `NodeportService` to simplify special casing for nodeport tests.

Pass the IP family of the current node address to `t.NewAction()`, so that the address of the correct family is used in flow validation. This fixes the bug where IPv4 address is being used to validate an IPv6 flow like below:
```
[=] Test [no-policies-extra]
  [.] Action [no-policies-extra/pod-to-remote-nodeport/curl-0: cilium-test/client2-646b88fb9b-w5rck (10.244.1.113) -> cilium-test/echo-other-node (echo-other-node:8080)]
  📄 Following flows...
  📄 Validating flows for peer cilium-test/client2-646b88fb9b-w5rck
  ℹ️  SYN and(ip(src=10.244.1.113),or(tcp(dstPort=30171),tcp(dstPort=8080)),tcpflags(syn)) not found
  ❌ Aborting flow matching: context deadline exceeded
  ❌ Flow validation failed for peer cilium-test/client2-646b88fb9b-w5rck: 1 failures (first: -1, last: -1, matched: 0)

  📄 Flow logs for peer cilium-test/client2-646b88fb9b-w5rck:
  ❓ [0] Nov 10 06:46:22.847: cilium-test/client2-646b88fb9b-w5rck:50890 -> [fc00:c111::3]:30171 from-endpoint FORWARDED TRAFFIC_DIRECTION_UNKNOWN DROP_REASON_UNKNOWN (TCP Flags: SYN)
  ❓ [1] Nov 10 06:46:22.847: cilium-test/client2-646b88fb9b-w5rck:50890 -> [fc00:c111::3]:30171 to-stack FORWARDED EGRESS DROP_REASON_UNKNOWN (TCP Flags: SYN)
  ❓ [2] Nov 10 06:46:22.848: [fc00:c111::3]:30171 -> cilium-test/client2-646b88fb9b-w5rck:50890 from-host FORWARDED TRAFFIC_DIRECTION_UNKNOWN DROP_REASON_UNKNOWN (TCP Flags: SYN, ACK)
  ❓ [3] Nov 10 06:46:22.848: [fc00:c111::3]:30171 -> cilium-test/client2-646b88fb9b-w5rck:50890 to-endpoint FORWARDED EGRESS DROP_REASON_UNKNOWN (TCP Flags: SYN, ACK)
```