### PR TITLE
connectivity: Add more tests for Ingress Controller

### DIFF
--- a/connectivity/manifests/deny-ingress-backend.yaml
+++ b/connectivity/manifests/deny-ingress-backend.yaml
@@ -1,0 +1,10 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "ingress-backend-deny"
+spec:
+  endpointSelector: {}
+  egressDeny:
+    - toEndpoints:
+        - matchLabels:
+            kind: echo

--- a/connectivity/manifests/deny-ingress-entity.yaml
+++ b/connectivity/manifests/deny-ingress-entity.yaml
@@ -1,0 +1,9 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "ingress-entity-deny"
+spec:
+  endpointSelector: {}
+  egressDeny:
+    - toEntities:
+        - ingress

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -41,6 +41,12 @@ var (
 	//go:embed manifests/deny-all-entities.yaml
 	denyAllEntitiesPolicyYAML string
 
+	//go:embed manifests/deny-ingress-entity.yaml
+	denyIngressIdentityPolicyYAML string
+
+	//go:embed manifests/deny-ingress-backend.yaml
+	denyIngressBackendPolicyYAML string
+
 	//go:embed manifests/allow-cluster-entity.yaml
 	allowClusterEntityPolicyYAML string
 
@@ -1036,6 +1042,26 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 	ct.NewTest("pod-to-ingress-service-deny-all").
 		WithFeatureRequirements(features.RequireEnabled(features.IngressController)).
 		WithCiliumPolicy(denyAllIngressPolicyYAML).
+		WithScenarios(
+			tests.PodToIngress(),
+		).
+		WithExpectations(func(a *check.Action) (egress check.Result, ingress check.Result) {
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+
+	ct.NewTest("pod-to-ingress-service-deny-ingress-identity").
+		WithFeatureRequirements(features.RequireEnabled(features.IngressController)).
+		WithCiliumPolicy(denyIngressIdentityPolicyYAML).
+		WithScenarios(
+			tests.PodToIngress(),
+		).
+		WithExpectations(func(a *check.Action) (egress check.Result, ingress check.Result) {
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+
+	ct.NewTest("pod-to-ingress-service-deny-backend-service").
+		WithFeatureRequirements(features.RequireEnabled(features.IngressController)).
+		WithCiliumPolicy(denyIngressBackendPolicyYAML).
 		WithScenarios(
 			tests.PodToIngress(),
 		).


### PR DESCRIPTION
### Description

This commit is to add two more tests related to Ingress Controller:

- Deny policy on reserve:ingress identity
- Deny policy on backend service of ingress (e.g. echo-same-node)

Relates: #2015

### Testing

Testing was done locally as per below

```
$ ./cilium connectivity test --test ingress-service
...
[=] Test [pod-to-ingress-service]
..
[=] Test [pod-to-ingress-service-deny-all]
..
[=] Test [pod-to-ingress-service-deny-ingress-identity]
..
[=] Test [pod-to-ingress-service-deny-backend-service]
..
[=] Test [pod-to-ingress-service-allow-ingress-identity]
..
[=] Skipping Test [dns-only] (skipped by user)
[=] Skipping Test [to-fqdns] (skipped by user)

✅ All 5 tests (10 actions) successful, 53 tests skipped, 0 scenarios skipped.

```