### PR TITLE
connectivity: Add IPFamily() to Action

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -140,6 +140,11 @@ func (a *Action) CmdOutput() string {
 	return a.cmdOutput
 }
 
+// IPFamily returns the IPFamily used for this test action.
+func (a *Action) IPFamily() features.IPFamily {
+	return a.ipFam
+}
+
 // Run executes function f.
 //
 // This method is to be called from a Scenario implementation.


### PR DESCRIPTION
I need to be able to access this field when I'm using the connectivity package as a library.