### PR TITLE
connectivity: Add exception to policy map recreation

### DIFF
--- a/connectivity/tests/errors.go
+++ b/connectivity/tests/errors.go
@@ -34,7 +34,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version) check.Scenario {
 		RunInitFailed:       nil,
 		sizeMismatch:        {"globals/cilium_policy"},
 		emptyBPFInitArg:     nil,
-		RemovingMapMsg:      nil,
+		RemovingMapMsg:      {"globals/cilium_policy"},
 		logBufferMessage:    nil,
 		ClangErrorsMsg:      nil,
 		ClangErrorMsg:       nil,


### PR DESCRIPTION
Spotted when running upgrade tests in Cilium \[1\]. That particular map is OK to recreate.

\[1\]: https://github.com/cilium/cilium-cli/issues/1858