### PR TITLE
connectivity/check: remove stray newline in (*Action).ValidateFlows

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -958,8 +958,6 @@ func (a *Action) ValidateFlows(ctx context.Context, peer TestPeer, reqs []filter
 	} else {
 		a.Failf("Flow validation failed for peer %s: %d failures (first: %d, last: %d, matched: %d)", peer.Name(), res.Failures, res.FirstMatch, res.LastMatch, len(res.Matched))
 	}
-
-	a.Log()
 }
 
 func (a *Action) validateFlowsForPeer(ctx context.Context, reqs []filters.FlowSetRequirement) FlowRequirementResults {


### PR DESCRIPTION
Currently, a stray newline is logged everytime flow validation finished:

```
[...]
  ✅ L3/L4 Drop not found
  ✅ Flow validation successful for peer test-namespace/client2-658d8d8db-8clt6 (first: 0, last: 82, matched: 6)

  🐛 Hubble polling ended: rpc error: code = Canceled desc = context canceled
  🐛 Receiving flows from Hubble Relay gracefully closed down.
[...]
```

Remove it to unclutter the logs a bit.