### PR TITLE
connectivity: Add more tests for Ingress Controller

### DIFF
--- a/connectivity/manifests/deny-cidr.yaml
+++ b/connectivity/manifests/deny-cidr.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: cidr-deny
+spec:
+  endpointSelector: {}
+  ingressDeny:
+  - fromCIDR:
+{{ range $i := .NodesWithoutCiliumIPs }}
+    - {{$i.IP}}/{{$i.Mask}}
+{{ end }}

--- a/connectivity/manifests/deny-world-entity.yaml
+++ b/connectivity/manifests/deny-world-entity.yaml
@@ -1,0 +1,9 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "world-entity-deny"
+spec:
+  endpointSelector: {}
+  ingressDeny:
+    - fromEntities:
+        - world


### PR DESCRIPTION
This commit is to cover the cases which the traffic is sent via external node client (i.e. from node without Cilium) to Ingress service.