### PR TITLE
Set operator key correct in SpireAgentScheduleAffinity

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -182,7 +182,7 @@ var (
 	// nodes labeled with CiliumNoScheduleLabel.
 	SpireAgentScheduleAffinity = []string{
 		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=" + CiliumNoScheduleLabel,
-		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].authentication.mutual.spire.install.agent=NotIn",
+		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=NotIn",
 		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=true",
 	}
 )


### PR DESCRIPTION
In the last change due to a copy paste error the wrong key got into the spire agent affinity resulting in an install error.