### PR TITLE
connectivity: Add per node identity test

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -95,6 +95,8 @@ type Parameters struct {
 
 	ExternalTargetCANamespace string
 	ExternalTargetCAName      string
+
+	AllowedNodeLabels map[string]string
 }
 
 type podCIDRs struct {

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -347,10 +347,11 @@ func (e ExternalWorkload) FlowFilters() []*flow.FlowFilter {
 }
 
 // ICMPEndpoint returns a new ICMP endpoint.
-func ICMPEndpoint(name, host string) TestPeer {
+func ICMPEndpoint(name, host string, labels map[string]string) TestPeer {
 	return icmpEndpoint{
-		name: name,
-		host: host,
+		name:   name,
+		host:   host,
+		labels: labels,
 	}
 }
 
@@ -362,6 +363,9 @@ type icmpEndpoint struct {
 
 	// Address of the endpoint.
 	host string
+
+	// Labels of the endpoint.
+	labels map[string]string
 }
 
 // Name is the absolute name of the network endpoint.
@@ -390,13 +394,19 @@ func (ie icmpEndpoint) Port() uint32 {
 }
 
 // HasLabel checks if given label exists and value matches.
-func (ie icmpEndpoint) HasLabel(_, _ string) bool {
+func (ie icmpEndpoint) HasLabel(key, val string) bool {
+	if value, ok := ie.labels[key]; ok && value == val {
+		return true
+	}
 	return false
 }
 
 // Labels returns the copy of labels
 func (ie icmpEndpoint) Labels() map[string]string {
-	return make(map[string]string)
+	if ie.labels == nil {
+		ie.labels = make(map[string]string)
+	}
+	return ie.labels
 }
 
 func (ie icmpEndpoint) FlowFilters() []*flow.FlowFilter {

--- a/connectivity/manifests/allow-ingress-from-custom-node.yaml
+++ b/connectivity/manifests/allow-ingress-from-custom-node.yaml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-from-custom-node
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingress:
+  - fromNodes:
+    - matchLabels:
+{{- range $key, $value := .AllowedNodeLabels }}
+        {{ $key }}: {{ $value }}
+{{ end }}

--- a/connectivity/manifests/client-egress-to-custom-node.yaml
+++ b/connectivity/manifests/client-egress-to-custom-node.yaml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-entities-remote-node
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toNodes:
+    - matchLabels:
+{{- range $key, $value := .AllowedNodeLabels }}
+        {{ $key }}: {{ $value }}
+{{ end }}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -186,6 +186,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")
 	cmd.Flags().StringVar(&params.SecondaryNetworkIface, "secondary-network-iface", "", "Secondary network iface name (e.g., to test NodePort BPF on multiple networks)")
+	cmd.Flags().StringToStringVar(&params.AllowedNodeLabels, "allowed-node-labels", map[string]string{}, "Add key=value node labels to allow access from/to in connectivity tests")
 
 	hooks.AddConnectivityTestFlags(cmd.Flags())
 

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -63,6 +63,9 @@ const (
 	EnableEnvoyConfig Feature = "enable-envoy-config"
 
 	WireguardEncapsulate Feature = "wireguard-encapsulate"
+
+	// For custom label node selection
+	PerNodeIdentity Feature = "enable-per-node-identity"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -266,6 +269,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[WireguardEncapsulate] = Status{
 		Enabled: cm.Data[string(WireguardEncapsulate)] == "true",
+	}
+
+	fs[PerNodeIdentity] = Status{
+		Enabled: cm.Data["enable-per-node-identity"] == "true",
 	}
 }
 


### PR DESCRIPTION
Add per node identity tests that can be triggered by running `connectivity test --test 'pod-to-custom-node' and or `connectivity test --test 'custom-node-to-pod'`.

Nodes are allowed by specifying --allowed-node-labels flag.

This is relevant to cilium [PR](https://github.com/cilium/cilium/pull/26924)