### PR TITLE
Add DNS over TCP tests

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -22,6 +22,9 @@ cilium hubble enable
 # NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
 cilium status --wait
 
+# Enable hubble port-forwarding to get hubble flow validation for tests
+cilium hubble port-forward&
+
 # Enable cluster mesh
 if [ "$CILIUM_CLI_MODE" = "helm" ]; then
   # Explicitly specify LoadBalancer service type since the default type is NodePort in helm mode.

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -526,10 +526,13 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 	}
 
 	var egress filters.FlowSetRequirement
+	haveEgress := false
 	var http filters.FlowSetRequirement
 	haveHTTP := false
 
 	switch p.Protocol {
+	case NONE:
+		// No payload protocol requirement
 	case ICMP:
 		icmpRequest := filters.Or(filters.ICMP(8), filters.ICMPv6(128))
 		icmpResponse := filters.Or(filters.ICMP(0), filters.ICMPv6(129))
@@ -569,6 +572,7 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 				}
 			}
 		}
+		haveEgress = true
 	case TCP:
 		tcpRequest := filters.TCP(0, a.dst.Port())
 		tcpResponse := filters.TCP(a.dst.Port(), 0)
@@ -629,6 +633,7 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 				}
 			}
 		}
+		haveEgress = true
 	case UDP:
 		a.Fail("UDP egress flow matching not implemented yet")
 	default:
@@ -656,7 +661,9 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 
 		reqs = append(reqs, dns)
 	}
-	reqs = append(reqs, egress)
+	if haveEgress {
+		reqs = append(reqs, egress)
+	}
 	if haveHTTP {
 		reqs = append(reqs, http)
 	}

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -373,7 +373,13 @@ func (a *Action) printFlows(peer TestPeer) {
 	}
 
 	a.Logf("📄 Flow logs for peer %s:", peer.Name())
-	printer := hubprinter.New(hubprinter.Compact(), hubprinter.WithIPTranslation())
+	var printer *hubprinter.Printer
+	if a.test.ctx.Numeric() {
+		printer = hubprinter.New(hubprinter.Compact())
+	} else {
+		printer = hubprinter.New(hubprinter.Compact(), hubprinter.WithIPTranslation())
+	}
+
 	defer printer.Close()
 
 	r := a.flowResults[peer]

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -25,6 +25,7 @@ type Parameters struct {
 	TestNamespace         string
 	SingleNode            bool
 	PrintFlows            bool
+	Numeric               bool
 	ForceDeploy           bool
 	Hubble                bool
 	HubbleServer          string

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -271,10 +271,10 @@ func (r *FlowRequirementResults) Merge(from *FlowRequirementResults) {
 type L4Protocol int
 
 const (
-	TCP L4Protocol = iota
+	NONE L4Protocol = iota
+	TCP
 	UDP
 	ICMP
-	NONE
 )
 
 // FlowParameters defines parameters for test result flow matching

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -274,11 +274,13 @@ const (
 	TCP L4Protocol = iota
 	UDP
 	ICMP
+	NONE
 )
 
 // FlowParameters defines parameters for test result flow matching
 type FlowParameters struct {
 	// Protocol is the network protocol being tested
+	// Use NONE to skip the payload flow validation, if only DNS is required
 	Protocol L4Protocol
 
 	// DNSRequired is true if DNS flows must be seen before the test protocol

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -272,6 +272,7 @@ type L4Protocol int
 
 const (
 	NONE L4Protocol = iota
+	ANY
 	TCP
 	UDP
 	ICMP
@@ -283,8 +284,9 @@ type FlowParameters struct {
 	// Use NONE to skip the payload flow validation, if only DNS is required
 	Protocol L4Protocol
 
-	// DNSRequired is true if DNS flows must be seen before the test protocol
-	DNSRequired bool
+	// DNSProtocol is NONE if DNS flows are not required before the test protocol
+	// Valid values are ANY, UDP, TCP
+	DNSProtocol L4Protocol
 
 	// RSTAllowed is true if TCP connection may end with either RST or FIN
 	RSTAllowed bool

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -1126,6 +1126,10 @@ func (ct *ConnectivityTest) PrintFlows() bool {
 	return ct.params.PrintFlows
 }
 
+func (ct *ConnectivityTest) Numeric() bool {
+	return ct.params.Numeric
+}
+
 func (ct *ConnectivityTest) AllFlows() bool {
 	return ct.params.AllFlows
 }

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -492,6 +492,56 @@ func (he httpEndpoint) FlowFilters() []*flow.FlowFilter {
 	return nil
 }
 
+// DNSEndpoint returns a new endpoint with the given name
+func DNSEndpoint(name, dns string) TestPeer {
+	return dnsEndpoint{
+		name: name,
+		dns:  dns,
+	}
+}
+
+// dnsEndpoint is an DNS endpoint acting as a peer in a connectivity test.
+// It implements interface TestPeer.
+type dnsEndpoint struct {
+	// Name of the endpoint instance.
+	name string
+
+	// Domain Name of the endpoint
+	dns string
+}
+
+func (de dnsEndpoint) Name() string {
+	return de.name
+}
+
+func (de dnsEndpoint) Scheme() string {
+	return ""
+}
+
+func (de dnsEndpoint) Path() string {
+	return ""
+}
+
+func (de dnsEndpoint) Address(features.IPFamily) string {
+	return de.dns
+}
+
+func (de dnsEndpoint) Port() uint32 {
+	return 0
+}
+
+func (de dnsEndpoint) HasLabel(string, string) bool {
+	return false
+}
+
+func (de dnsEndpoint) Labels() map[string]string {
+	return nil
+}
+
+func (de dnsEndpoint) FlowFilters() []*flow.FlowFilter {
+	return nil
+}
+
 // EchoIPPod is a Kubernetes Pod that prints back the client IP, acting as a peer in a connectivity test.
 type EchoIPPod struct {
 	Pod

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -1127,6 +1127,16 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			return check.ResultDNSOKDropCurlTimeout, check.ResultNone
 		})
 
+	// This policy only allows port 80 to domain-name, default one.one.one.one,. DNS proxy enabled.
+	ct.NewTest("dns-tcp").WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithScenarios(
+			tests.PodDigTCPWorld(),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			return check.ResultDNSOK, check.ResultNone
+		})
+
 	if ct.Params().K8sLocalHostTest {
 		ct.NewTest("pod-to-controlplane-host").
 			WithCiliumPolicy(clientEgressToEntitiesHostPolicyYAML).

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -147,6 +147,7 @@ func (s *podToHostPort) Run(ctx context.Context, t *check.Test) {
 				a.ExecInPod(ctx, ct.CurlCommand(ep, features.IPFamilyAny))
 
 				a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
+					Protocol: check.TCP,
 					// Because the HostPort request is NATed, we might only
 					// observe flows after DNAT has been applied (e.g. by
 					// HostReachableServices),

--- a/connectivity/tests/k8s.go
+++ b/connectivity/tests/k8s.go
@@ -32,8 +32,8 @@ func (s *podToK8sLocal) Run(ctx context.Context, t *check.Test) {
 		t.NewAction(s, fmt.Sprintf("curl-k8s-from-pod-%s", pod.Name()), &pod, k8sSvc, features.IPFamilyAny).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, ct.CurlCommand(k8sSvc, features.IPFamilyAny))
 			a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
-				DNSRequired: true,
 				Protocol:    check.TCP,
+				DNSProtocol: check.ANY,
 				AltDstPort:  k8sSvc.Port(),
 			}))
 

--- a/connectivity/tests/k8s.go
+++ b/connectivity/tests/k8s.go
@@ -33,6 +33,7 @@ func (s *podToK8sLocal) Run(ctx context.Context, t *check.Test) {
 			a.ExecInPod(ctx, ct.CurlCommand(k8sSvc, features.IPFamilyAny))
 			a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 				DNSRequired: true,
+				Protocol:    check.TCP,
 				AltDstPort:  k8sSvc.Port(),
 			}))
 

--- a/connectivity/tests/pod.go
+++ b/connectivity/tests/pod.go
@@ -58,8 +58,12 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFam, "-X", s.method))
 					}
 
-					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
-					a.ValidateFlows(ctx, echo, a.GetIngressRequirements(check.FlowParameters{}))
+					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
+						Protocol: check.TCP,
+					}))
+					a.ValidateFlows(ctx, echo, a.GetIngressRequirements(check.FlowParameters{
+						Protocol: check.TCP,
+					}))
 
 					a.ValidateMetrics(ctx, echo, a.GetIngressMetricsRequirements())
 					a.ValidateMetrics(ctx, echo, a.GetEgressMetricsRequirements())
@@ -142,8 +146,12 @@ func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test
 		t.NewAction(s, epName, client, ep, ipFam).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, ct.CurlCommand(ep, ipFam, curlOpts...))
 
-			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
-			a.ValidateFlows(ctx, ep, a.GetIngressRequirements(check.FlowParameters{}))
+			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
+				Protocol: check.TCP,
+			}))
+			a.ValidateFlows(ctx, ep, a.GetIngressRequirements(check.FlowParameters{
+				Protocol: check.TCP,
+			}))
 		})
 
 		// Additionally test private endpoint access with HTTP header expected by policy.
@@ -159,8 +167,12 @@ func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test
 
 				a.ExecInPod(ctx, ct.CurlCommand(ep, ipFam, opts...))
 
-				a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
-				a.ValidateFlows(ctx, ep, a.GetIngressRequirements(check.FlowParameters{}))
+				a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
+					Protocol: check.TCP,
+				}))
+				a.ValidateFlows(ctx, ep, a.GetIngressRequirements(check.FlowParameters{
+					Protocol: check.TCP,
+				}))
 			})
 		}
 	}

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -58,6 +58,7 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
+					Protocol:    check.TCP,
 					AltDstPort:  svc.Port(),
 				}))
 
@@ -111,6 +112,7 @@ func (s *podToIngress) Run(ctx context.Context, t *check.Test) {
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
+					Protocol:    check.TCP,
 					AltDstPort:  svc.Port(),
 				}))
 			})
@@ -256,6 +258,7 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 
 				if validateFlows {
 					a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
+						Protocol: check.TCP,
 						// The fact that curl is hitting the NodePort instead of the
 						// backend Pod's port is specified here. This will cause the matcher
 						// to accept both the NodePort and the ClusterIP (container) port.

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -57,8 +57,8 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 				a.ExecInPod(ctx, ct.CurlCommand(svc, features.IPFamilyAny))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
-					DNSRequired: true,
 					Protocol:    check.TCP,
+					DNSProtocol: check.ANY,
 					AltDstPort:  svc.Port(),
 				}))
 
@@ -111,8 +111,8 @@ func (s *podToIngress) Run(ctx context.Context, t *check.Test) {
 				a.ExecInPod(ctx, ct.CurlCommand(svc, features.IPFamilyAny))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
-					DNSRequired: true,
 					Protocol:    check.TCP,
+					DNSProtocol: check.ANY,
 					AltDstPort:  svc.Port(),
 				}))
 			})

--- a/connectivity/tests/to-cidr.go
+++ b/connectivity/tests/to-cidr.go
@@ -46,6 +46,7 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 				a.ExecInPod(ctx, ct.CurlCommand(ep, features.IPFamilyAny, opts...))
 
 				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
+					Protocol:   check.TCP,
 					RSTAllowed: true,
 				}))
 			})

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -37,8 +37,8 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	httpsindex := check.HTTPEndpoint(extTarget+"-https-index", fmt.Sprintf("https://%s/index.html", extTarget))
 
 	fp := check.FlowParameters{
-		DNSRequired: true,
 		Protocol:    check.TCP,
+		DNSProtocol: check.ANY,
 		RSTAllowed:  true,
 	}
 
@@ -98,7 +98,7 @@ func (s *podDigTCPWorld) Run(ctx context.Context, t *check.Test) {
 
 	fp := check.FlowParameters{
 		Protocol:    check.NONE,
-		DNSRequired: true,
+		DNSProtocol: check.TCP,
 	}
 
 	ct := t.Context()
@@ -130,8 +130,8 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 	https := check.HTTPEndpoint("cilium-io-https", "https://cilium.io")
 
 	fp := check.FlowParameters{
-		DNSRequired: true,
 		Protocol:    check.TCP,
+		DNSProtocol: check.ANY,
 		RSTAllowed:  true,
 	}
 
@@ -178,8 +178,8 @@ func (s *podToWorldWithTLSIntercept) Run(ctx context.Context, t *check.Test) {
 	https := check.HTTPEndpoint(extTarget+"-https", "https://"+extTarget)
 
 	fp := check.FlowParameters{
-		DNSRequired: true,
 		Protocol:    check.TCP,
+		DNSProtocol: check.ANY,
 		RSTAllowed:  true,
 	}
 

--- a/connectivity/tests/world.go
+++ b/connectivity/tests/world.go
@@ -38,6 +38,7 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 
 	fp := check.FlowParameters{
 		DNSRequired: true,
+		Protocol:    check.TCP,
 		RSTAllowed:  true,
 	}
 
@@ -130,6 +131,7 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 
 	fp := check.FlowParameters{
 		DNSRequired: true,
+		Protocol:    check.TCP,
 		RSTAllowed:  true,
 	}
 
@@ -177,6 +179,7 @@ func (s *podToWorldWithTLSIntercept) Run(ctx context.Context, t *check.Test) {
 
 	fp := check.FlowParameters{
 		DNSRequired: true,
+		Protocol:    check.TCP,
 		RSTAllowed:  true,
 	}
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -112,6 +112,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 
 	cmd.Flags().BoolVar(&params.SingleNode, "single-node", false, "Limit to tests able to run on a single node")
 	cmd.Flags().BoolVar(&params.PrintFlows, "print-flows", false, "Print flow logs for each test")
+	cmd.Flags().BoolVar(&params.Numeric, "numeric", false, "Print IP addresses in flow logs instead of pod names")
 	cmd.Flags().DurationVar(&params.PostTestSleepDuration, "post-test-sleep", 0, "Wait time after each test before next test starts")
 	cmd.Flags().BoolVar(&params.ForceDeploy, "force-deploy", false, "Force re-deploying test artifacts")
 	cmd.Flags().BoolVar(&params.Hubble, "hubble", true, "Automatically use Hubble for flow validation & troubleshooting")


### PR DESCRIPTION
Add a new `dns-tcp` test to the suite that tests DNS proxy forwarding over TCP to external address used in the test suite. No payload protocol is used or tested, so this is a bare DNS test.

Plenty of other test cases cover DNS proxying for UDP, so this new test is specific to TCP.

Flow validation is extended to work on tests without payload protocol and for DNS validation on a UDP or TCP only, or both.