### PR TITLE
renovate: exclude tetragon pkg/k8s updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,6 +102,9 @@
         // type func(a Status, b Status) bool of func(a, b Status) bool {…} does not match inferred
         // type func(a Status, b Status) int for func(a E, b E) int
         "golang.org/x/exp",
+	// This package is not versioned leading to "empty" updates every week.
+	// Update it manually once newly introduces tetragon CRDs are required.
+	"github.com/cilium/tetragon/pkg/k8s",
       ],
       "matchPackagePatterns": [
         // k8s dependencies will be updated manually in lockstep.


### PR DESCRIPTION
The github.com/cilium/tetragon/pkg/k8s module is not versioned leading renovate to needlessly update the dependency on every upstream commit even if there are no code changes. Thus, exclude the module for now and bump it manually once we need a more up-to-date version, e.g. when new tetragon CRDs are required for sysdump.