### PR TITLE
install action: Ignore .git and vendor directories

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
       id: build-cli
       shell: bash
       run: |
-        CLI_PATH=$(find . -iwholename '${{ inputs.local-path }}' -type d | head -n 1)
+        CLI_PATH=$(find . -iwholename '${{ inputs.local-path }}' -type d -not -path './.git/*' -not -path './vendor/*' | head -n 1)
         echo path="${CLI_PATH}" >> $GITHUB_OUTPUT
 
     - name: Setup Go


### PR DESCRIPTION
- Ignore .git directory. There would be a directory called cilium-cli in .git/refs/tags if there is a Git tag that contains '/cilium-cli/'.
- Ignore vendor directory in case the Go module depends on a package that contains '/cilium-cli/' in the name.