### PR TITLE
clustermesh: fix pattern to match IPv4 address

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1655,7 +1655,7 @@ if [ -z "$CLUSTER_ADDR" ] ; then
 fi
 
 port='@(6553[0-5]|655[0-2][0-9]|65[0-4][0-9][0-9]|6[0-4][0-9][0-9][0-9]|[1-5][0-9][0-9][0-9][0-9]|[1-9][0-9][0-9][0-9]|[1-9][0-9][0-9]|[1-9][0-9]|[1-9])'
-byte='@(25[0-5]|2[0-4][0-9]|[1][0-9][0-9]|[1-9][0-9]|[0-9])'
+byte='@(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])'
 ipv4="$byte\.$byte\.$byte\.$byte"
 
 # Default port is for a HostPort service
@@ -1665,7 +1665,7 @@ case "$CLUSTER_ADDR" in
 	CLUSTER_IP=${CLUSTER_ADDR#\[}
 	CLUSTER_IP=${CLUSTER_IP%%\]:*}
 	;;
-    [^[]$ipv4:$port)
+    $ipv4:$port)
 	CLUSTER_PORT=${CLUSTER_ADDR##*:}
 	CLUSTER_IP=${CLUSTER_ADDR%%:*}
 	;;


### PR DESCRIPTION
Executing `cilium clustermesh vm install install-external-workload.sh` fails if the randomly generated IP (v4) contains a zero (`0`) in its first byte.

Error: `Malformed CLUSTER_ADDR: 104.198.85.126:2379`

Therefore, this commit changes the pattern that is used to detect an IPv4 address (with port).

Until now i don't understand why it's working with the prefix `[^[]` for all other cases but not if the first byte is containing a zero :man_shrugging: I just think that this part isn't necessary - and shouldn't break anything :pray: 

Detected on a cilium/cilium CI run: https://github.com/cilium/cilium/actions/runs/7067930793/job/19241908576
