### PR TITLE
connectivity test: introduce connectivity test suite timeout flag

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -95,6 +95,8 @@ type Parameters struct {
 
 	ExternalTargetCANamespace string
 	ExternalTargetCAName      string
+
+	Timeout time.Duration
 }
 
 type podCIDRs struct {

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -3,7 +3,9 @@
 
 package defaults
 
-import "time"
+import (
+	"time"
+)
 
 const (
 	// renovate: datasource=github-releases depName=cilium/cilium
@@ -135,6 +137,9 @@ const (
 	// ClustermeshMaxConnectedClusters is the default number of the maximum
 	// number of clusters that should be allowed to connect to the Clustermesh.
 	ClustermeshMaxConnectedClusters = 255
+
+	// Default timeout for Connectivity Test Suite (disabled by default)
+	ConnectivityTestSuiteTimeout = 0 * time.Minute
 )
 
 var (


### PR DESCRIPTION
Currently, the connectivity test suite command doesn't have a timeout. Its context only gets cancelled due to interrupt of SIGTERM signal.

For most connectivity test scenarios and actions, this isn't a problem as they have individual fine-grained timeouts (e.g. request timeout).

But there are test scenarios (e.g. `health ` - `Cilium Health Probe`) that might run infinitely on failiure (e.g. if a Cilium Agent Pod no longer is available).

Therefore, this commit introduces a new flag `--timeout` that provides the possibility to configure an overall timeout for the connectivity test suite. It defaults to `0` - meaning no timeout by default (current behavior).

Alternative: Introduce timeout for health probe test (I thought it's better to solve with a global timeout - because other test scenarios / actions have the same problem)

Example of an infinite health probe attempt (until GitHub action timeout) in `cilium/cilium`: https://github.com/cilium/cilium/actions/runs/7060997016/job/19221753163 (Of course it would also be possible to only solve it on the usage side - e.g. by setting a timeout in the connectivity test step. But i thought it might be worth for other use-cases too.)