### PR TITLE
connectivity: Check for unexpected packet drops

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -74,8 +74,11 @@ type Parameters struct {
 	ConnDisruptTestRestartsPath   string
 	ConnDisruptTestXfrmErrorsPath string
 	ConnDisruptDispatchInterval   time.Duration
-	FlushCT                       bool
-	SecondaryNetworkIface         string
+
+	ExpectedDropReasons []string
+
+	FlushCT               bool
+	SecondaryNetworkIface string
 
 	K8sVersion           string
 	HelmChartDirectory   string

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -259,9 +259,9 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 			// include --include-conn-disrupt-test"
 			return ct.Run(ctx)
 		}
-
-		ct.NewTest("no-missed-tail-calls").WithScenarios(tests.NoMissedTailCalls())
 	}
+
+	ct.NewTest("no-unexpected-packet-drops").WithScenarios(tests.NoUnexpectedPacketDrops())
 
 	// Run all tests without any policies in place.
 	noPoliciesScenarios := []check.Scenario{

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -261,7 +261,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 		}
 	}
 
-	ct.NewTest("no-unexpected-packet-drops").WithScenarios(tests.NoUnexpectedPacketDrops())
+	ct.NewTest("no-unexpected-packet-drops").WithScenarios(tests.NoUnexpectedPacketDrops(ct.Params().ExpectedDropReasons))
 
 	// Run all tests without any policies in place.
 	noPoliciesScenarios := []check.Scenario{

--- a/connectivity/tests/errors_test.go
+++ b/connectivity/tests/errors_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestComputeExpectedDropReasons(t *testing.T) {
+	defaultReasons := []string{"reason0", "reason1"}
+	tests := []struct {
+		inputReasons    []string
+		expectedReasons []string
+	}{
+		// Empty list of reasons.
+		{
+			inputReasons:    []string{},
+			expectedReasons: []string{},
+		},
+		// Add a reason to default list.
+		{
+			inputReasons:    []string{"+reason2"},
+			expectedReasons: []string{"reason0", "reason1", "reason2"},
+		},
+		// Remove a reason from default list.
+		{
+			inputReasons:    []string{"-reason1"},
+			expectedReasons: []string{"reason0"},
+		},
+		// Add a reason then remove it.
+		{
+			inputReasons:    []string{"+reason2", "-reason2"},
+			expectedReasons: []string{"reason0", "reason1"},
+		},
+		// Remove a reason then add it back.
+		{
+			inputReasons:    []string{"-reason1", "+reason1"},
+			expectedReasons: []string{"reason0", "reason1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("InputReasons: %v", test.inputReasons), func(t *testing.T) {
+			result := computeExpectedDropReasons(defaultReasons, test.inputReasons)
+
+			// computeExpectedDropReasons doesn't guarantee the order of the
+			// emitted string so instead we check the length and that all
+			// expected elements are listed.
+
+			for _, expReason := range test.expectedReasons {
+				if !strings.Contains(result, fmt.Sprintf("%q", expReason)) {
+					t.Errorf("Expected filter to contain %q, but got: %v", expReason, result)
+				}
+			}
+
+			// We know the expected length because all our test reasons are the same length.
+			expectedLength := len(test.expectedReasons) * 9
+			if len(test.expectedReasons) > 1 {
+				expectedLength += (len(test.expectedReasons) - 1) * 2
+			}
+			if len(result) != expectedLength {
+				t.Errorf("Expected filter of length %d, but got: %v", expectedLength, result)
+			}
+		})
+	}
+}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -194,5 +194,13 @@ var (
 	ExpectedDropReasons = []string{
 		"Policy denied",
 		"Policy denied by denylist",
+		"Unsupported L3 protocol",
+		"Stale or unroutable IP",
+		"Authentication required",
+		"Service backend not found",
+		"Unsupported protocol for NAT masquerade",
+		"Invalid source ip",
+		"Unknown L3 target address",
+		"No tunnel/encapsulation endpoint (datapath BUG!)",
 	}
 )

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -190,4 +190,9 @@ var (
 		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=NotIn",
 		"authentication.mutual.spire.install.agent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=true",
 	}
+
+	ExpectedDropReasons = []string{
+		"Policy denied",
+		"Policy denied by denylist",
+	}
 )

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -190,6 +190,10 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().DurationVar(&params.ConnDisruptDispatchInterval, "conn-disrupt-dispatch-interval", 0, "TCP packet dispatch interval")
+
+	cmd.Flags().StringSliceVar(&params.ExpectedDropReasons, "expected-drop-reasons", defaults.ExpectedDropReasons, "List of expected drop reasons")
+	cmd.Flags().MarkHidden("expected-drop-reasons")
+
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")
 	cmd.Flags().StringVar(&params.SecondaryNetworkIface, "secondary-network-iface", "", "Secondary network iface name (e.g., to test NodePort BPF on multiple networks)")


### PR DESCRIPTION
This pull requests ensures we fail the connectivity tests if we hit any unexpected packet drops. The first commit transforms the existing missed-tail-call drops check into a new check for unexpected packet drops. The second commit defines a new flag to set the list of expected packet drop reasons. The last commit adds a bunch of packet drop reasons.