### PR TITLE
Remove Cilium v1.11 from the version list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ binary releases.
 
 ## Releases
 
-| Release                                                                | Maintained | Supported Cilium Versions   |
-|------------------------------------------------------------------------|------------|-----------------------------|
-| [v0.15.17](https://github.com/cilium/cilium-cli/releases/tag/v0.15.17) | Yes        | Cilium 1.14 and newer       |
-| [v0.14.8](https://github.com/cilium/cilium-cli/releases/tag/v0.14.8)   | Yes        | Cilium 1.11, 1.12, and 1.13 |
+| Release                                                                | Maintained | Compatible Cilium Versions |
+|------------------------------------------------------------------------|------------|----------------------------|
+| [v0.15.17](https://github.com/cilium/cilium-cli/releases/tag/v0.15.17) | Yes        | Cilium 1.14 and newer      |
+| [v0.14.8](https://github.com/cilium/cilium-cli/releases/tag/v0.14.8)   | Yes        | Cilium 1.12 and 1.13       |
 
 Please see [`helm` installation mode](#helm-installation-mode) section
 regarding our plan to migrate to the new `helm` installation mode and deprecate


### PR DESCRIPTION
Cilium v1.11 has been EOLed, so let's remove it from the list.

Also change the wording from "supported" to "compatible". In general I'd like to avoid using the word "supported". It might give users a false impression that the Cilium community is on the hook to provide some form of support.