### PR TITLE
Remove classic mode tests from the main branch

### DIFF
--- a/.github/cilium-cli-test-job-chart/templates/job.yaml
+++ b/.github/cilium-cli-test-job-chart/templates/job.yaml
@@ -44,8 +44,6 @@ spec:
             value: {{ .Values.azure.client_id }}
           - name: AZURE_CLIENT_SECRET
             value: {{ .Values.azure.client_secret }}
-          - name: CILIUM_CLI_MODE
-            value: {{ .Values.cilium_cli_mode }}
       dnsPolicy: ClusterFirst
       enableServiceLinks: true
       priority: 0

--- a/.github/cilium-cli-test-job-chart/values.yaml
+++ b/.github/cilium-cli-test-job-chart/values.yaml
@@ -3,7 +3,6 @@
 # Declare variables to be passed into your templates.
 
 tag: latest
-cilium_cli_mode: ""
 cilium_version: ""
 cluster_name: test
 cluster_cidr: 10.4.0.0/14

--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -23,17 +23,13 @@ cilium hubble enable
 cilium status --wait
 
 # Enable cluster mesh
-if [ "$CILIUM_CLI_MODE" = "helm" ]; then
-  # Explicitly specify LoadBalancer service type since the default type is NodePort in helm mode.
-  # Ref: https://github.com/cilium/cilium-cli/pull/1527#discussion_r1177244379
-  #
-  # In Helm mode, externalWorkloads.enabled is set to false by default. You need to pass
-  # --enable-external-workloads flag to enable it.
-  # Ref: https://github.com/cilium/cilium/pull/25259
-  cilium clustermesh enable --service-type LoadBalancer --enable-external-workloads
-else
-  cilium clustermesh enable
-fi
+# Explicitly specify LoadBalancer service type since the default type is NodePort in helm mode.
+# Ref: https://github.com/cilium/cilium-cli/pull/1527#discussion_r1177244379
+#
+# In Helm mode, externalWorkloads.enabled is set to false by default. You need to pass
+# --enable-external-workloads flag to enable it.
+# Ref: https://github.com/cilium/cilium/pull/25259
+cilium clustermesh enable --service-type LoadBalancer --enable-external-workloads
 
 # Wait for cluster mesh status to be ready
 cilium clustermesh status --wait

--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -48,9 +48,6 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    strategy:
-      matrix:
-        mode: ["classic", "helm"]
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -93,7 +90,7 @@ jobs:
 
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
           echo "owner=${OWNER}" >> $GITHUB_OUTPUT
-          echo "name=${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}" >> $GITHUB_OUTPUT
+          echo "name=${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
 
       - name: Create AKS cluster
         run: |
@@ -135,8 +132,7 @@ jobs:
             --set job_name=cilium-cli-install \
             --set test_script_cm=cilium-cli-test-script-install \
             --set tag=${{ steps.vars.outputs.sha }} \
-            --set cilium_version=${{ env.cilium_version }} \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set cilium_version=${{ env.cilium_version }}
 
       - name: Wait for install job
         env:
@@ -169,8 +165,7 @@ jobs:
             --generate-name \
             --set job_name=cilium-cli \
             --set test_script_cm=cilium-cli-test-script \
-            --set tag=${{ steps.vars.outputs.sha }} \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set tag=${{ steps.vars.outputs.sha }}
 
       - name: Wait for test job
         env:

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -38,13 +38,10 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    strategy:
-      matrix:
-        mode: ["classic", "helm"]
     steps:
       - name: Set cluster name
         run: |
-          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}" >> $GITHUB_ENV
+          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -142,8 +139,7 @@ jobs:
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cilium_version=${{ env.cilium_version }} \
-            --set cluster_name=${{ env.clusterName }} \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set cluster_name=${{ env.clusterName }}
 
       - name: Wait for job
         env:
@@ -193,8 +189,7 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }} \
             --set job_name=cilium-cli-uninstall \
-            --set test_script_cm=cilium-cli-test-script-uninstall \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set test_script_cm=cilium-cli-test-script-uninstall
 
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli-uninstall --for=condition=complete --timeout=${{ env.timeout }} &

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -38,13 +38,10 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    strategy:
-      matrix:
-        mode: ["classic", "helm"]
     steps:
       - name: Set cluster name
         run: |
-          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}" >> $GITHUB_ENV
+          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -142,8 +139,7 @@ jobs:
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cilium_version=${{ env.cilium_version }} \
-            --set cluster_name=${{ env.clusterName }} \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set cluster_name=${{ env.clusterName }}
 
       - name: Wait for job
         env:
@@ -193,8 +189,7 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cluster_name=${{ env.clusterName }} \
             --set job_name=cilium-cli-uninstall \
-            --set test_script_cm=cilium-cli-test-script-uninstall \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set test_script_cm=cilium-cli-test-script-uninstall
 
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli-uninstall --for=condition=complete --timeout=${{ env.timeout }} &

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -39,14 +39,11 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    strategy:
-      matrix:
-        mode: ["classic", "helm"]
     steps:
       - name: Set cluster name
         run: |
-          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
-          echo "vmName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.mode }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "vmName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -158,8 +155,7 @@ jobs:
             --set job_name=cilium-cli-install \
             --set test_script_cm=cilium-cli-test-script-install \
             --set vm_name=${{ env.vmName }} \
-            --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }} \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }}
 
       - name: Wait for install job
         env:
@@ -216,8 +212,7 @@ jobs:
             --generate-name \
             --set tag=${{ steps.vars.outputs.sha }} \
             --set job_name=cilium-cli \
-            --set test_script_cm=cilium-cli-test-script \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set test_script_cm=cilium-cli-test-script
 
       - name: Wait for test job
         env:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -38,13 +38,10 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    strategy:
-      matrix:
-        mode: ["classic", "helm"]
     steps:
       - name: Set cluster name
         run: |
-          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}" >> $GITHUB_ENV
+          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -135,8 +132,7 @@ jobs:
             --set tag=${{ steps.vars.outputs.sha }} \
             --set cilium_version=${{ env.cilium_version }} \
             --set cluster_name=${{ env.clusterName }} \
-            --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }} \
-            --set cilium_cli_mode=${{ matrix.mode }} \
+            --set cluster_cidr=${{ steps.cluster.outputs.cluster_cidr }}
 
       - name: Wait for test job
         env:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -25,13 +25,7 @@ jobs:
     name: Kind Installation and Connectivity Test
     runs-on: ubuntu-22.04
     timeout-minutes: 50
-    strategy:
-      matrix:
-        mode: ["classic", "helm"]
     steps:
-      - name: Set mode
-        run: |
-          echo "CILIUM_CLI_MODE=${{ matrix.mode }}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -119,8 +113,8 @@ jobs:
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
           cilium connectivity test --debug --all-flows --test-namespace test-namespace \
             --include-unsafe-tests --include-conn-disrupt-test \
-            --collect-sysdump-on-failure --junit-file cilium-junit-${{ matrix.mode }}-1.xml \
-            --junit-property mode=${{ matrix.mode }} --junit-property type=no-tunnel \
+            --collect-sysdump-on-failure --junit-file cilium-junit-1.xml \
+            --junit-property type=no-tunnel \
             --curl-insecure \
             --external-target chart-testing-worker2 \
             --external-target-ca-namespace=external-targets \
@@ -135,16 +129,6 @@ jobs:
           cilium uninstall --wait
 
       - name: Install Cilium with IPsec Encryption
-        if: ${{ matrix.mode == 'classic' }}
-        run: |
-          cilium install \
-          --version=${{ env.cilium_version}} \
-          --encryption=ipsec \
-          --nodes-without-cilium="${NODES_WITHOUT_CILIUM}" \
-          --set kubeProxyReplacement=disabled
-
-      - name: Install Cilium with IPsec Encryption
-        if: ${{ matrix.mode == 'helm' }}
         run: |
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
@@ -170,8 +154,8 @@ jobs:
         run: |
           cilium connectivity test --debug --force-deploy --all-flows --test-namespace test-namespace \
             --include-unsafe-tests \
-            --collect-sysdump-on-failure --junit-file cilium-junit-${{ matrix.mode }}-2.xml \
-            --junit-property mode=${{ matrix.mode }} --junit-property type=ipsec \
+            --collect-sysdump-on-failure --junit-file cilium-junit-2.xml \
+            --junit-property type=ipsec \
             --curl-insecure \
             --external-target chart-testing-worker2 \
             --external-target-ca-namespace=external-targets \
@@ -197,7 +181,6 @@ jobs:
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Unlabel nodes
-        if: ${{ matrix.mode == 'helm' }}
         run: |
           IFS=',' read -ra nodes <<< "$NODES_WITHOUT_CILIUM"
           for node in "${nodes[@]}"; do
@@ -218,7 +201,6 @@ jobs:
     timeout-minutes: 50
 
     env:
-      CILIUM_CLI_MODE: helm
       kind_config_1: .github/kind-config-1.yaml
       kind_config_2: .github/kind-config-2.yaml
       # helm/kind-action will override the "name:" provided in the kind config with "chart-testing" unless these are

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -40,8 +40,6 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix:
-        mode: ["classic", "helm"]
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -49,10 +47,10 @@ jobs:
       # Note: These names currently approach the limit of 40 characters
       - name: Set mode-specific names
         run: |
-          echo "clusterNameBase=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}" >> $GITHUB_ENV
-          echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}-1" >> $GITHUB_ENV
-          echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode }}-2" >> $GITHUB_ENV
-          echo "firewallRuleName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.mode}}" >> $GITHUB_ENV
+          echo "clusterNameBase=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-1" >> $GITHUB_ENV
+          echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-2" >> $GITHUB_ENV
+          echo "firewallRuleName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Install kubectl
         run: |
@@ -190,8 +188,7 @@ jobs:
             --set job_name=cilium-cli \
             --set test_script_cm=cilium-cli-test-script \
             --set cluster_name_1=${{ env.clusterName1 }} \
-            --set cluster_name_2=${{ env.clusterName2 }} \
-            --set cilium_cli_mode=${{ matrix.mode }}
+            --set cluster_name_2=${{ env.clusterName2 }}
 
       - name: Wait for test job
         env:


### PR DESCRIPTION
Let's remove classic mode tests from the main branch. In a very unlikely event of having to fix a bug in the classic mode for Cilium v1.12 or v1.13, we can create v0.14 branch from v0.14.8 tag and patch it there.

Ref: https://github.com/cilium/cilium-cli#releases