### PR TITLE
connectivity: Bump test-connection-disruption img to v0.0.13

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -617,7 +617,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			testConnDisruptServerDeployment := newDeployment(deploymentParameters{
 				Name:           testConnDisruptServerDeploymentName,
 				Kind:           KindTestConnDisrupt,
-				Image:          "quay.io/cilium/test-connection-disruption:v0.0.5",
+				Image:          "quay.io/cilium/test-connection-disruption:v0.0.13",
 				Replicas:       3,
 				Labels:         map[string]string{"app": "test-conn-disrupt-server"},
 				Command:        []string{"tcd-server", "8000"},
@@ -669,7 +669,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			testConnDisruptClientDeployment := newDeployment(deploymentParameters{
 				Name:     testConnDisruptClientDeploymentName,
 				Kind:     KindTestConnDisrupt,
-				Image:    "quay.io/cilium/test-connection-disruption:v0.0.5",
+				Image:    "quay.io/cilium/test-connection-disruption:v0.0.13",
 				Replicas: 5,
 				Labels:   map[string]string{"app": "test-conn-disrupt-client"},
 				Port:     8000,


### PR DESCRIPTION
To include arm64 build - https://github.com/cilium/test-connection-disruption/pull/9.