### PR TITLE
Don't modify running cluster in dry-run mode

### DIFF
--- a/install/azure.go
+++ b/install/azure.go
@@ -193,7 +193,7 @@ func (k *K8sInstaller) azureSetupServicePrincipal() error {
 		}
 	}
 
-	if k.params.Azure.TenantID == "" && k.params.Azure.ClientID == "" && k.params.Azure.ClientSecret == "" {
+	if k.params.Azure.TenantID == "" && k.params.Azure.ClientID == "" && k.params.Azure.ClientSecret == "" && !k.params.IsDryRun() {
 		k.Log("🚀 Creating Azure Service Principal for Cilium Azure operator...")
 		bytes, err := k.azExec("ad", "sp", "create-for-rbac", "--scopes", "/subscriptions/"+k.params.Azure.SubscriptionID+"/resourceGroups/"+k.params.Azure.AKSNodeResourceGroup, "--role", "Contributor")
 		if err != nil {

--- a/install/install.go
+++ b/install/install.go
@@ -684,7 +684,7 @@ func (k *K8sInstaller) preinstall(ctx context.Context) error {
 		chainingMode := getChainingMode(helmValues)
 
 		// Do not stop AWS DS if we are running in chaining mode
-		if chainingMode != "aws-cni" {
+		if chainingMode != "aws-cni" && !k.params.IsDryRun() {
 			if _, err := k.client.GetDaemonSet(ctx, AwsNodeDaemonSetNamespace, AwsNodeDaemonSetName, metav1.GetOptions{}); err == nil {
 				k.Log("🔥 Patching the %q DaemonSet to evict its pods...", AwsNodeDaemonSetName)
 				patch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"nodeSelector":{"%s":"%s"}}}}}`, AwsNodeDaemonSetNodeSelectorKey, AwsNodeDaemonSetNodeSelectorValue))

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -268,7 +268,7 @@ cilium install --context kind-cluster1 --set cluster.id=1 --set cluster.name=clu
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params.Namespace = namespace
 			// Don't log anything if it's a dry run so that the dry run output can easily be piped to other commands.
-			if params.DryRun || params.DryRunHelmValues {
+			if params.IsDryRun() {
 				params.Writer = io.Discard
 			}
 			installer, err := install.NewK8sInstaller(k8sClient, params)
@@ -346,7 +346,7 @@ cilium upgrade --set cluster.id=1 --set cluster.name=cluster1
 		RunE: func(cmd *cobra.Command, args []string) error {
 			params.Namespace = namespace
 			// Don't log anything if it's a dry run so that the dry run output can easily be piped to other commands.
-			if params.DryRun || params.DryRunHelmValues {
+			if params.IsDryRun() {
 				params.Writer = io.Discard
 			}
 			installer, err := install.NewK8sInstaller(k8sClient, params)

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -524,6 +524,10 @@ type UpgradeParameters struct {
 	DryRunHelmValues bool
 }
 
+func (p *UpgradeParameters) IsDryRun() bool {
+	return p.DryRun || p.DryRunHelmValues
+}
+
 // Upgrade upgrades the existing Helm release with the given Helm chart and values
 func Upgrade(
 	ctx context.Context,
@@ -544,7 +548,7 @@ func Upgrade(
 	helmClient.ReuseValues = params.ReuseValues
 	helmClient.Wait = params.Wait
 	helmClient.Timeout = params.WaitDuration
-	helmClient.DryRun = params.DryRun || params.DryRunHelmValues
+	helmClient.DryRun = params.IsDryRun()
 
 	return helmClient.RunWithContext(ctx, defaults.HelmReleaseName, params.Chart, params.Values)
 }


### PR DESCRIPTION
In EKS mode, don't stop the AWS node DaemonSet when running in dry-run mode. In AKS mode, don't create any cloud resources.

Fixes #2161