### PR TITLE
Assign unique names to connectivity test jobs

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -44,6 +44,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: AKS BYOCNI Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: EKS (tunnel) Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: EKS Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -35,6 +35,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: External Workloads Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: GKE Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: Kind Installation and Connectivity Test
     runs-on: ubuntu-22.04
     timeout-minutes: 50
     strategy:
@@ -212,6 +213,7 @@ jobs:
           retention-days: 5
 
   helm-upgrade-clustermesh:
+    name: Kind Helm Upgrade Clustermesh
     runs-on: ubuntu-22.04
     timeout-minutes: 50
 

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: Multicluster Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45


### PR DESCRIPTION
Assign unique names to connectivity test jobs so that we can control which of these jobs are required.