### PR TITLE
kind: Set conn-disrupt-test-setup

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -107,7 +107,10 @@ jobs:
           # Setup the connectivity disruption tests. We don't really care about the result
           # here (in the sense that we don't perform any operation which might cause a
           # disruption), but we want to make sure that the command works as expected.
+          #
+          # Dispatch interval is set to 100ms, b/c otherwise (default is 0), the flow validation might time out.
           cilium connectivity test --debug --test-namespace test-namespace \
+            --conn-disrupt-dispatch-interval 100ms \
             --include-conn-disrupt-test --conn-disrupt-test-setup
 
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
@@ -317,7 +320,10 @@ jobs:
           # Setup the connectivity disruption tests. We don't really care about the result
           # here (in the sense that we don't perform any operation which might cause a
           # disruption), but we want to make sure that the command works as expected.
+          #
+          # Dispatch interval is set to 100ms, b/c otherwise (default is 0), the flow validation might time out.
           cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2 --debug \
+            --conn-disrupt-dispatch-interval 100ms \
             --include-conn-disrupt-test --conn-disrupt-test-setup
 
           cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2 --debug \


### PR DESCRIPTION
Michi reported that reverting [1] fix the Kind CI job flake, and that they were due to too many flow events generated by the test-conn-disrupt pods.

As we don't care about the sensitivity of those tests in cilium/cilium-cli, set the interval to 100ms to reduce the events count (and thus, the test runtime).

[1]: https://github.com/cilium/cilium-cli/pull/2156

Reported-by: Michi Mutsuzaki <michi@isovalent.com>