### PR TITLE
Enable no-errors-in-logs check by default, and extend it to all Cilium components

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -56,6 +56,7 @@ type Parameters struct {
 	DNSTestServerImage    string
 	IncludeUnsafeTests    bool
 	AgentPodSelector      string
+	CiliumPodSelector     string
 	NodeSelector          map[string]string
 	DeploymentAnnotations annotationsMap
 	NamespaceAnnotations  annotations

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -1232,7 +1232,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, extra Hooks) error {
 		return err
 	}
 
-	if ct.Params().IncludeUnsafeTests {
+	if versioncheck.MustCompile(">=1.14.0")(ct.CiliumVersion) || ct.Params().IncludeUnsafeTests {
 		ct.NewTest("check-log-errors").WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion))
 	}
 

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -1233,7 +1233,9 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, extra Hooks) error {
 	}
 
 	if versioncheck.MustCompile(">=1.14.0")(ct.CiliumVersion) || ct.Params().IncludeUnsafeTests {
-		ct.NewTest("check-log-errors").WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion))
+		ct.NewTest("check-log-errors").
+			WithSysdumpPolicy(check.SysdumpPolicyOnce).
+			WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion))
 	}
 
 	return ct.Run(ctx)

--- a/connectivity/tests/errors.go
+++ b/connectivity/tests/errors.go
@@ -146,14 +146,13 @@ func (n *noErrorsInLogs) checkErrorsInLogs(logs string, t *check.Test) {
 		}
 	}
 	if len(uniqueFailures) > 0 {
-		failures := make([]string, 0, len(uniqueFailures))
+		var failures strings.Builder
 		for f, c := range uniqueFailures {
-			failures = append(failures, f)
-
-			t.Logf("Found %q in logs %d times\n", f, c)
+			failures.WriteRune('\n')
+			failures.WriteString(f)
+			failures.WriteString(fmt.Sprintf(" (%d occurrences)", c))
 		}
-		failureMsgs := strings.Join(failures, "\n")
-		t.Failf("Found %d logs matching list of errors that must be investigated:\n%s", len(uniqueFailures), failureMsgs)
+		t.Failf("Found %d logs matching list of errors that must be investigated:%s", len(uniqueFailures), failures.String())
 	}
 }
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -11,6 +11,8 @@ const (
 	// renovate: datasource=github-releases depName=cilium/cilium
 	Version = "v1.15.0"
 
+	CiliumPodSelector = "app.kubernetes.io/part-of=cilium"
+
 	AgentContainerName      = "cilium-agent"
 	AgentServiceAccountName = "cilium"
 	AgentClusterRoleName    = "cilium"

--- a/go.mod
+++ b/go.mod
@@ -227,7 +227,7 @@ require (
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	k8s.io/kubectl v0.29.0 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	oras.land/oras-go v1.2.4 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -131,6 +131,7 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.HubbleServer, "hubble-server", "localhost:4245", "Address of the Hubble endpoint for flow validation")
 	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
 	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
+	cmd.Flags().StringVar(&params.CiliumPodSelector, "cilium-pod-selector", defaults.CiliumPodSelector, "Label selector matching all cilium-related pods")
 	cmd.Flags().Var(&params.NamespaceAnnotations, "namespace-annotations", "Add annotations to the connectivity test namespace, e.g. '{\"foo\":\"bar\"}'")
 	cmd.Flags().MarkHidden("namespace-annotations")
 	cmd.Flags().MarkHidden("deployment-pod-annotations")

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -929,17 +929,9 @@ func (c *Client) ListCiliumPodIPPools(ctx context.Context, opts metav1.ListOptio
 	return c.CiliumClientset.CiliumV2alpha1().CiliumPodIPPools().List(ctx, opts)
 }
 
-func (c *Client) GetLogs(ctx context.Context, namespace, name, container string, sinceTime time.Time, limitBytes int64, previous bool) (string, error) {
-	t := metav1.NewTime(sinceTime)
-	o := corev1.PodLogOptions{
-		Container:  container,
-		Follow:     false,
-		LimitBytes: &limitBytes,
-		Previous:   previous,
-		SinceTime:  &t,
-		Timestamps: true,
-	}
-	r := c.Clientset.CoreV1().Pods(namespace).GetLogs(name, &o)
+func (c *Client) GetLogs(ctx context.Context, namespace, name, container string, opts corev1.PodLogOptions) (string, error) {
+	opts.Container = container
+	r := c.Clientset.CoreV1().Pods(namespace).GetLogs(name, &opts)
 	s, err := r.Stream(ctx)
 	if err != nil {
 		return "", err

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -6,7 +6,6 @@ package sysdump
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"github.com/blang/semver/v4"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -37,7 +36,7 @@ type KubernetesClient interface {
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	GetStatefulSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.StatefulSet, error)
 	GetDeployment(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.Deployment, error)
-	GetLogs(ctx context.Context, namespace, name, container string, sinceTime time.Time, limitBytes int64, previous bool) (string, error)
+	GetLogs(ctx context.Context, namespace, name, container string, opts corev1.PodLogOptions) (string, error)
 	GetPodsTable(ctx context.Context) (*metav1.Table, error)
 	ProxyGet(ctx context.Context, namespace, name, url string) (string, error)
 	GetSecret(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Secret, error)

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -338,7 +338,7 @@ func (c *fakeClient) GetDeployment(_ context.Context, _, _ string, _ metav1.GetO
 	return nil, nil
 }
 
-func (c *fakeClient) GetLogs(_ context.Context, _, _, _ string, _ time.Time, _ int64, _ bool) (string, error) {
+func (c *fakeClient) GetLogs(_ context.Context, _, _, _ string, _ corev1.PodLogOptions) (string, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
Currently, we check for errors in Cilium agent logs only when unsafe tests are enabled. Let's promote this check to be always performed for Cilium v1.14 and subsequent (earlier versions are not compatible with the Cilium CLI v0.15 series), to ensure that we catch unexpected errors early (as unsafe tests are only enabled in a limited set of CI workflows) given that it does not perform any unsafe operation. Additionally, let's extend it to also cover the init containers in the cilium agent pods, as well as other cilium components, such as the operator and the clustermesh-apiserver.