### PR TITLE
connectivity: Ignore expected XFRM errors

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -78,6 +78,7 @@ type Parameters struct {
 	ConnDisruptDispatchInterval   time.Duration
 
 	ExpectedDropReasons []string
+	ExpectedXFRMErrors  []string
 
 	FlushCT               bool
 	SecondaryNetworkIface string

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -252,7 +252,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 
 		ct.NewTest("no-ipsec-xfrm-errors").
 			WithFeatureRequirements(features.RequireMode(features.EncryptionPod, "ipsec")).
-			WithScenarios(tests.NoIPsecXfrmErrors())
+			WithScenarios(tests.NoIPsecXfrmErrors(ct.Params().ExpectedXFRMErrors))
 
 		if ct.Params().ConnDisruptTestSetup {
 			// Exit early, as --conn-disrupt-test-setup is only needed to deploy pods which

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -203,4 +203,9 @@ var (
 		"Unknown L3 target address",
 		"No tunnel/encapsulation endpoint (datapath BUG!)",
 	}
+
+	ExpectedXFRMErrors = []string{
+		"inbound_forward_header", // XfrmFwdHdrError
+		"inbound_other",          // XfrmInError
+	}
 )

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -187,6 +187,8 @@ func newCmdConnectivityTest(hooks Hooks) *cobra.Command {
 
 	cmd.Flags().StringSliceVar(&params.ExpectedDropReasons, "expected-drop-reasons", defaults.ExpectedDropReasons, "List of expected drop reasons")
 	cmd.Flags().MarkHidden("expected-drop-reasons")
+	cmd.Flags().StringSliceVar(&params.ExpectedXFRMErrors, "expected-xfrm-errors", defaults.ExpectedXFRMErrors, "List of expected XFRM errors")
+	cmd.Flags().MarkHidden("expected-xfrm-errors")
 
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")

--- a/utils/features/utils.go
+++ b/utils/features/utils.go
@@ -40,3 +40,46 @@ func GetIPFamily(addr string) IPFamily {
 
 	return IPFamilyAny
 }
+
+// ComputeFailureExceptions computes a list of failure exceptions for various
+// tests, from a default list of exceptions and a diff given via a CLI flag.
+// The diff is given as a list of exceptions, with optional leading +/- signs.
+// A minus sign means the exception should be removed from the defaults; a plus
+// sign means the exception should be added to the defaults. If there are
+// neither minus nor plus signs, then the given exceptions are used directly
+// without considering the defaults.
+// See the unit tests for examples.
+func ComputeFailureExceptions(defaultExceptions, inputExceptions []string) []string {
+	exceptions := map[string]bool{}
+	if len(inputExceptions) > 0 {
+		// Build final list of failure exceptions based on default exceptions,
+		// added exceptions (+ prefix), and removed exceptions (- prefix).
+		addedAllDefaults := false
+		for _, exception := range inputExceptions {
+			if exception[0] == '+' || exception[0] == '-' {
+				if !addedAllDefaults {
+					for _, r := range defaultExceptions {
+						exceptions[r] = true
+					}
+					addedAllDefaults = true
+				}
+			}
+			switch exception[0] {
+			case '+':
+				exceptions[exception[1:]] = true
+			case '-':
+				exceptions[exception[1:]] = false
+			default:
+				exceptions[exception] = true
+			}
+		}
+	}
+
+	exceptionList := []string{}
+	for exception, isIn := range exceptions {
+		if isIn {
+			exceptionList = append(exceptionList, exception)
+		}
+	}
+	return exceptionList
+}

--- a/utils/features/utils_test.go
+++ b/utils/features/utils_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestComputeFailureExceptions(t *testing.T) {
+	defaultExceptions := []string{"reason0", "reason1"}
+	tests := []struct {
+		inputExceptions    []string
+		expectedExceptions []string
+	}{
+		// Empty list of reasons.
+		{
+			inputExceptions:    []string{},
+			expectedExceptions: []string{},
+		},
+		// Add a reason to default list.
+		{
+			inputExceptions:    []string{"+reason2"},
+			expectedExceptions: []string{"reason0", "reason1", "reason2"},
+		},
+		// Remove a reason from default list.
+		{
+			inputExceptions:    []string{"-reason1"},
+			expectedExceptions: []string{"reason0"},
+		},
+		// Add a reason then remove it.
+		{
+			inputExceptions:    []string{"+reason2", "-reason2"},
+			expectedExceptions: []string{"reason0", "reason1"},
+		},
+		// Remove a reason then add it back.
+		{
+			inputExceptions:    []string{"-reason1", "+reason1"},
+			expectedExceptions: []string{"reason0", "reason1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("InputExceptions: %v", test.inputExceptions), func(t *testing.T) {
+			result := ComputeFailureExceptions(defaultExceptions, test.inputExceptions)
+
+			// computeFailureExceptions doesn't guarantee the order of the
+			// returned slice so we have to sort both slices.
+			sort.Strings(result)
+			if !reflect.DeepEqual(result, test.expectedExceptions) {
+				t.Errorf("Expected exceptions to be %v, but got: %v", test.expectedExceptions, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
First commit refactors the existing logic for the `--expected-drop-reasons`. The second adds a new `--expected-xfrm-errors`.