### PR TITLE
Make cilium clustemesh status compatible with external kvstore

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1410,7 +1410,8 @@ func (k *K8sClusterMesh) determineStatusConnectivity(ctx context.Context) (*Conn
 	var expected []string
 	for name, cfg := range config.Data {
 		// Same check as https://github.com/cilium/cilium/blob/538a18800206da0d33916f5f48853a3d4454dd81/pkg/clustermesh/internal/config.go#L68
-		if strings.Contains(string(cfg), "endpoints:") {
+		// Additionally skip the configuration of the local cluster, if present
+		if name != k.clusterName && strings.Contains(string(cfg), "endpoints:") {
 			stats.Clusters[name] = &ClusterStats{}
 			expected = append(expected, name)
 		}

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1380,7 +1380,7 @@ func (k *K8sClusterMesh) statusConnectivity(ctx context.Context) (*ConnectivityS
 
 			if err != nil {
 				if err := w.Retry(err); err != nil {
-					return nil, err
+					return status, err
 				}
 				continue
 			}


### PR DESCRIPTION
The clustermesh-apiserver cannot be used in combination with Cilium running in kvstore mode when the identity allocation mode is kvstore. In this case, remote clusters shall be configured to directly connect to the local etcd cluster. Let's extend the `clustermesh status` command to additionally cover this setup, ignoring the validation of clustermesh-apiserver specific resources.

Additionally, let's improve the reporting in case `cilium clustermesh status --wait` times out, and fix an issue causing it to always report an error if the clustermesh secret also includes the configuration for the local cluster.