### PR TITLE
Drop cilium endpoint verification.

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1099,13 +1099,8 @@ func (ct *ConnectivityTest) DeleteConnDisruptTestDeployment(ctx context.Context,
 
 // validateDeployment checks if the Deployments we created have the expected Pods in them.
 func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
-	ct.Debug("Validating Deployments...")
 
-	disableEndpointCRD := false
-	if status, ok := ct.Feature(features.DisableEndpointCRD); ok && status.Enabled {
-		disableEndpointCRD = true
-		ct.Info("CiliumEndpoint CRD check disabled")
-	}
+	ct.Debug("Validating Deployments...")
 
 	srcDeployments, dstDeployments := ct.deploymentList()
 	for _, name := range srcDeployments {
@@ -1126,12 +1121,6 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			return fmt.Errorf("unable to list perf pods: %w", err)
 		}
 		for _, perfPod := range perfPods.Items {
-			// Individual endpoints will not be created for pods using node's network stack
-			if !perfPod.Spec.HostNetwork && !disableEndpointCRD {
-				if err := WaitForCiliumEndpoint(ctx, ct, ct.clients.src, ct.Params().TestNamespace, perfPod.Name); err != nil {
-					return err
-				}
-			}
 			_, hasLabel := perfPod.GetLabels()["server"]
 			if hasLabel {
 				ct.perfServerPod = append(ct.perfServerPod, Pod{
@@ -1162,12 +1151,6 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	for _, pod := range clientPods.Items {
-		if !disableEndpointCRD {
-			if err := WaitForCiliumEndpoint(ctx, ct, ct.clients.src, ct.Params().TestNamespace, pod.Name); err != nil {
-				return err
-			}
-		}
-
 		if strings.Contains(pod.Name, clientCPDeployment) {
 			ct.clientCPPods[pod.Name] = Pod{
 				K8sClient: ct.client,
@@ -1251,12 +1234,6 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			return fmt.Errorf("unable to list echo pods: %w", err)
 		}
 		for _, echoPod := range echoPods.Items {
-			if !disableEndpointCRD {
-				if err := WaitForCiliumEndpoint(ctx, ct, client, echoPod.GetNamespace(), echoPod.GetName()); err != nil {
-					return err
-				}
-			}
-
 			ct.echoPods[echoPod.Name] = Pod{
 				K8sClient: client,
 				Pod:       echoPod.DeepCopy(),

--- a/connectivity/check/wait.go
+++ b/connectivity/check/wait.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"golang.org/x/exp/slices"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/k8s"
@@ -47,29 +46,6 @@ func WaitForDeployment(ctx context.Context, log Logger, client *k8s.Client, name
 		case <-time.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for deployment %s/%s to become ready (last error: %w)",
-				namespace, name, err)
-		}
-	}
-}
-
-// WaitForCiliumEndpoint waits until the specified cilium endpoint gets created.
-func WaitForCiliumEndpoint(ctx context.Context, log Logger, client *k8s.Client, namespace, name string) error {
-	log.Logf("⌛ [%s] Waiting for CiliumEndpoint for pod %s/%s to appear...", client.ClusterName(), namespace, name)
-
-	ctx, cancel := context.WithTimeout(ctx, ShortTimeout)
-	defer cancel()
-	for {
-		_, err := client.GetCiliumEndpoint(ctx, namespace, name, metav1.GetOptions{})
-		if err == nil {
-			return nil
-		}
-
-		log.Debugf("[%s] Error retrieving CiliumEndpoint for pod %s/%s: %s", client.ClusterName(), namespace, name, err)
-
-		select {
-		case <-time.After(PollInterval):
-		case <-ctx.Done():
-			return fmt.Errorf("timeout reached waiting for CiliumEndpoint %s/%s to appear (last error: %w)",
 				namespace, name, err)
 		}
 	}

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -63,6 +63,8 @@ const (
 	EnableEnvoyConfig Feature = "enable-envoy-config"
 
 	WireguardEncapsulate Feature = "wireguard-encapsulate"
+
+	DisableEndpointCRD Feature = "disable-endpoint-crd"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -266,6 +268,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[WireguardEncapsulate] = Status{
 		Enabled: cm.Data[string(WireguardEncapsulate)] == "true",
+	}
+
+	fs[DisableEndpointCRD] = Status{
+		Enabled: cm.Data[string(DisableEndpointCRD)] == "true",
 	}
 }
 

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -63,8 +63,6 @@ const (
 	EnableEnvoyConfig Feature = "enable-envoy-config"
 
 	WireguardEncapsulate Feature = "wireguard-encapsulate"
-
-	DisableEndpointCRD Feature = "disable-endpoint-crd"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -268,10 +266,6 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[WireguardEncapsulate] = Status{
 		Enabled: cm.Data[string(WireguardEncapsulate)] == "true",
-	}
-
-	fs[DisableEndpointCRD] = Status{
-		Enabled: cm.Data[string(DisableEndpointCRD)] == "true",
 	}
 }
 


### PR DESCRIPTION
Looks like Cilium endpoint verification is no longer needed because Cilium should be already provisioned correctly in the environment before deploying the connectivity apps, and these tests already validate that the k8s deployment resource is ready before continuing.

This should also unblock connectivity tests for Customers that have `disableEndpointCRD: "true"` property configured.
