### PR TITLE
defaults: add 'Host datapath not ready' to expected drop reasons

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -202,6 +202,7 @@ var (
 		"Invalid source ip",
 		"Unknown L3 target address",
 		"No tunnel/encapsulation endpoint (datapath BUG!)",
+		"Host datapath not ready",
 	}
 
 	ExpectedXFRMErrors = []string{


### PR DESCRIPTION
This excludes the drop reason introduced in https://github.com/cilium/cilium/pull/29482. It occurs when Cilium is first installed on a node, the host firewall is enabled, a workload endpoint gets created before the host endpoint, and the workload endpoint in question tries to talk to the host.

Preventing these drops would require redesigning parts of the datapath, particularly the clustermesh bootstrap procedure. This is not feasible at the moment, and maybe it's not the right thing to do.