### PR TITLE
defaults: Ignore XfrmInStateInvalid errors if rare

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -208,5 +208,6 @@ var (
 	ExpectedXFRMErrors = []string{
 		"inbound_forward_header", // XfrmFwdHdrError
 		"inbound_other",          // XfrmInError
+		"inbound_state_invalid",  // XfrmInStateInvalid
 	}
 )


### PR DESCRIPTION
This pull request adds XfrmInStateInvalid errors to the list of XFRM errors to ignore if they are rare (less than 10 occurrences), as per https://github.com/cilium/cilium/pull/30151.