### PR TITLE
ci: unique artifact name for junit reports in kind workflow

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -339,7 +339,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: cilium-junits
+          name: cilium-junits-helm-upgrade-clustermesh
           path: cilium-junit*.xml
           retention-days: 2
 


### PR DESCRIPTION
Due to some recent changes on GitHub's side, uploading the JUnit reports on the second job to finish in the kind workflow will fail with:

    Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

Avoid this from happing by giving the artifacts unique names.

Fixes #2222