### PR TITLE
refactor: improve error messaging for version command

### DIFF
--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -45,8 +45,8 @@ func newCmdVersion() *cobra.Command {
 				return nil
 			}
 			version, err := k8sClient.GetRunningCiliumVersion(context.Background(), namespace)
-			if version == "" || err != nil {
-				fmt.Printf("cilium image (running): unknown. Unable to obtain cilium version, no cilium pods found in namespace %q\n", namespace)
+			if err != nil {
+				fmt.Printf("cilium image (running): unknown. Unable to obtain cilium version. Reason: %s\n", err.Error())
 			} else {
 				fmt.Printf("cilium image (running): %s\n", version)
 			}


### PR DESCRIPTION
Refactored the error messaging logic for obtaining the running Cilium version in the `GetRunningCiliumVersion` function. This modification enhances clarity and provides more detailed error information when encountering issues.

Current implementation:
<img width="922" alt="Screenshot 2024-01-11 at 3 46 37 PM" src="https://github.com/cilium/cilium-cli/assets/39435912/f1f92353-c2a9-4533-adfe-42efe7bd1781">
This error message is misleading since the pods are running in the specified namespace.

After this change, the correct error message is returned:
<img width="749" alt="Screenshot 2024-01-11 at 3 48 42 PM" src="https://github.com/cilium/cilium-cli/assets/39435912/6f1e0a8d-d7c3-4d8a-8299-76f5a6556715">

