### PR TITLE
Fix status exit code

### DIFF
--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -46,6 +47,10 @@ func newCmdStatus() *cobra.Command {
 				fmt.Println(string(jsonStatus))
 			} else {
 				fmt.Print(s.Format())
+			}
+
+			if err == nil && len(s.CollectionErrors) > 0 {
+				err = errors.New("status check failed")
 			}
 			return err
 		},


### PR DESCRIPTION
`cilium status` does currently return exit-code 0 in case of errors.

Adding an error here in case exists in the sub command, so it will result in correct exit-code `1`.

Fixes #2232 