### PR TITLE
Add host to pod tests to the connectivity suite

### DIFF
--- a/connectivity/manifests/allow-host-entity-egress.yaml
+++ b/connectivity/manifests/allow-host-entity-egress.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "host-cluster"
+  name: "host-cluster-egress"
 spec:
   endpointSelector:
     matchLabels: {}

--- a/connectivity/manifests/allow-host-entity-ingress.yaml
+++ b/connectivity/manifests/allow-host-entity-ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "host-cluster-ingress"
+spec:
+  endpointSelector:
+    matchLabels: {}
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node


### PR DESCRIPTION
Extend the connectivity suite to additionally validate that node to pod connectivity works as expected, both in absence of policies and if the ingress policy allows the host identity. Currently, we are only partially testing this path as part of the node-to-node encryption test, which makes it more difficult to pinpoint the cause of possible failures.