### PR TITLE
connectivity: only wait for daemonsets if needed

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1329,15 +1329,18 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	// The host-netns-non-cilium DaemonSet is created in the source cluster only, also in case of multi-cluster tests.
-	if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, hostNetNSDeploymentNameNonCilium); err != nil {
-		return err
+	if !ct.params.SingleNode || ct.params.MultiCluster != "" {
+		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, hostNetNSDeploymentNameNonCilium); err != nil {
+			return err
+		}
 	}
 
 	for _, client := range ct.clients.clients() {
-		if err := WaitForDaemonSet(ctx, ct, client, ct.Params().TestNamespace, hostNetNSDeploymentName); err != nil {
-			return err
+		if !ct.params.SingleNode || ct.params.MultiCluster != "" {
+			if err := WaitForDaemonSet(ctx, ct, client, ct.Params().TestNamespace, hostNetNSDeploymentName); err != nil {
+				return err
+			}
 		}
-
 		hostNetNSPods, err := client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindHostNetNS})
 		if err != nil {
 			return fmt.Errorf("unable to list host netns pods: %w", err)


### PR DESCRIPTION
### Summary

Fixes #2236 

### Description

The host-netns-non-cilium and host-netns daemonsets leveraged by the connectivity tests are only deployed in specific situations. Do not wait for them in other cases, as it blocks the tests.

### Notes

Only tested on my environment, not sure if maintainers would prefer a different fix. Happy to update the PR as needed, thanks!

An alternative approach would be for `WaitDaemonSet` to not retry any `not found` errors, but that might have more unintended consequences, hence I decided not to do it like this.