### PR TITLE
connectivity: add unknown ICMPv4 code as expected drop reason

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -203,6 +203,7 @@ var (
 		"Unknown L3 target address",
 		"No tunnel/encapsulation endpoint (datapath BUG!)",
 		"Host datapath not ready",
+		"Unknown ICMPv4 code",
 	}
 
 	ExpectedXFRMErrors = []string{


### PR DESCRIPTION
ICMP destination unreachable packets are dropped with "Unknown ICMPv4 code" reason when Cilium is configured with both KPR and BPF masquerade enabled, except that in the fragmentation needed case. Hence, let's add them to the default list of expected drop reasons, as they can be legitimately generated for instance when connecting to a NodePort if the corresponding backend is not yet ready, as in the clustermesh case:

172.18.0.7:35748 (ID:9) <> kube-system/clustermesh-apiserver:32379 (host) from-network FORWARDED (TCP Flags: SYN) 172.18.0.2 (host) <> 172.18.0.7 (ID:9) Unknown ICMPv4 code DROPPED (ICMPv4 DestinationUnreachable(Port))

Otherwise the no-unexpected-packet-drops test fails with:

🟥 Found unexpected packet drops:
{
  "labels": {
    "direction": "EGRESS",
    "reason": "Unknown ICMPv4 code"
  },
  "name": "cilium_drop_count_total",
  "value": 10
}