### PR TITLE
Extract and generalize the sniffer logic used by encryption tests for easier reusability

### DIFF
--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -402,6 +402,11 @@ func (a *Action) Fatalf(format string, s ...interface{}) {
 	a.test.Fatalf(format, s...)
 }
 
+// DebugEnabled returns whether debug logging is enabled.
+func (a *Action) DebugEnabled() bool {
+	return a.test.ctx.debug()
+}
+
 func timestamp() string {
 	return fmt.Sprintf("[%s] ", time.Now().Format(time.RFC3339))
 }

--- a/connectivity/tests/encryption.go
+++ b/connectivity/tests/encryption.go
@@ -144,7 +144,7 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 		// - To catch Geneve traffic we cannot use the "geneve" filter, as it shifts
 		//   offset of a filted packet which invalidates the later part of the
 		//   filter. Thus this poor UDP/6081 check.
-		tunnelFilter := "(udp and (udp[8:2] = 0x0800 or dst port 8472 or dst 6081))"
+		tunnelFilter := "(udp and (udp[8:2] = 0x0800 or dst port 8472 or dst port 6081))"
 		filter := fmt.Sprintf("(%s and host %s and host %s) or (host %s and host %s and %s)",
 			tunnelFilter,
 			clientHost.Address(features.IPFamilyV4), serverHost.Address(features.IPFamilyV4),

--- a/connectivity/tests/encryption.go
+++ b/connectivity/tests/encryption.go
@@ -5,18 +5,15 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"strings"
-	"time"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium-cli/utils/lock"
+	"github.com/cilium/cilium-cli/utils/sniff"
 )
 
 type requestType int
@@ -263,106 +260,6 @@ func (s *podToPodEncryption) Run(ctx context.Context, t *check.Test) {
 	})
 }
 
-type leakSniffer struct {
-	host     *check.Pod
-	dumpPath string
-
-	stdout lock.Buffer
-	cancel context.CancelFunc
-	exited chan error
-}
-
-func startLeakSniffer(ctx context.Context, t *check.Test, host *check.Pod,
-	iface string, filter string,
-) (*leakSniffer, error) {
-	cmdctx, cancel := context.WithCancel(ctx)
-	sniffer := &leakSniffer{
-		host:     host,
-		dumpPath: fmt.Sprintf("/tmp/%s-%s.pcap", t.Name(), host.Pod.Name),
-		cancel:   cancel,
-		exited:   make(chan error, 1),
-	}
-
-	go func() {
-		// Run tcpdump with -w instead of directly printing captured pkts. This
-		// is to avoid a race after sending ^C (triggered by cancel()) which
-		// might terminate the tcpdump process before it gets a chance to dump
-		// its captures.
-		cmd := []string{
-			"tcpdump", "-i", iface, "--immediate-mode",
-			"-w", sniffer.dumpPath, filter,
-		}
-
-		t.Debugf("Running in bg: %s", strings.Join(cmd, " "))
-		err := host.K8sClient.ExecInPodWithWriters(ctx, cmdctx,
-			host.Pod.Namespace, host.Pod.Name, "", cmd, &sniffer.stdout, io.Discard)
-		if err != nil && !errors.Is(err, context.Canceled) {
-			sniffer.exited <- err
-		}
-
-		close(sniffer.exited)
-	}()
-
-	// Wait until tcpdump is ready to capture pkts
-	wctx, wcancel := context.WithTimeout(ctx, 5*time.Second)
-	defer wcancel()
-	for {
-		select {
-		case <-wctx.Done():
-			return nil, fmt.Errorf("Failed to wait for tcpdump to be ready")
-		case err := <-sniffer.exited:
-			return nil, fmt.Errorf("Failed to execute tcpdump: %w", err)
-		case <-time.After(100 * time.Millisecond):
-			line, err := sniffer.stdout.ReadString('\n')
-			if err != nil && !errors.Is(err, io.EOF) {
-				return nil, fmt.Errorf("Failed to read kubectl exec's stdout: %w", err)
-			}
-			if strings.Contains(line, fmt.Sprintf("listening on %s", iface)) {
-				return sniffer, nil
-			}
-		}
-	}
-}
-
-func (sniffer *leakSniffer) validate(ctx context.Context, a *check.Action, assertNoLeaks, debug bool) {
-	// Wait until tcpdump has exited
-	sniffer.cancel()
-	if err := <-sniffer.exited; err != nil {
-		a.Fatalf("Failed to execute tcpdump: %w", err)
-	}
-
-	// Redirect stderr to /dev/null, as tcpdump logs to stderr, and ExecInPod
-	// will return an error if any char is written to stderr. Anyway, the count
-	// is written to stdout.
-	cmd := []string{"/bin/sh", "-c", fmt.Sprintf("tcpdump -r %s --count 2>/dev/null", sniffer.dumpPath)}
-	count, err := sniffer.host.K8sClient.ExecInPod(ctx, sniffer.host.Pod.Namespace, sniffer.host.Pod.Name, "", cmd)
-	if err != nil {
-		a.Fatalf("Failed to retrieve tcpdump pkt count: %s", err)
-	}
-
-	if !strings.Contains(count.String(), "packet") {
-		a.Fatalf("tcpdump output doesn't look correct: %s", count.String())
-	}
-
-	if !strings.HasPrefix(count.String(), "0 packets") && assertNoLeaks {
-		a.Failf("Captured unencrypted pkt (count=%s)", strings.TrimRight(count.String(), "\n\r"))
-
-		// If debug mode is enabled, dump the captured pkts
-		if debug {
-			cmd := []string{"/bin/sh", "-c", fmt.Sprintf("tcpdump -r %s 2>/dev/null", sniffer.dumpPath)}
-			out, err := sniffer.host.K8sClient.ExecInPod(ctx, sniffer.host.Pod.Namespace, sniffer.host.Pod.Name, "", cmd)
-			if err != nil {
-				a.Fatalf("Failed to retrieve tcpdump output: %s", err)
-			}
-			a.Debugf("Captured pkts:\n%s", out.String())
-		}
-	}
-
-	if strings.HasPrefix(count.String(), "0 packets") && !assertNoLeaks {
-		a.Failf("Expected to see unencrypted packets, but none found. This check might be broken")
-	}
-}
-
 func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 	client, server, clientHost *check.Pod, serverHost *check.Pod,
 	reqType requestType, ipFam features.IPFamily, assertNoLeaks, biDirCheck, wgEncap bool,
@@ -370,17 +267,17 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 	srcFilter := getFilter(ctx, t, client, clientHost, server, serverHost, ipFam, reqType, wgEncap)
 	srcIface := getInterNodeIface(ctx, t, client, clientHost, server, serverHost, ipFam, wgEncap)
 
-	srcSniffer, err := startLeakSniffer(ctx, t, clientHost, srcIface, srcFilter)
+	srcSniffer, err := sniff.Sniff(ctx, t, clientHost, srcIface, srcFilter)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var dstSniffer *leakSniffer
+	var dstSniffer *sniff.Sniffer
 	if biDirCheck {
 		dstFilter := getFilter(ctx, t, server, serverHost, client, clientHost, ipFam, reqType, wgEncap)
 		dstIface := getInterNodeIface(ctx, t, server, serverHost, client, clientHost, ipFam, wgEncap)
 
-		dstSniffer, err = startLeakSniffer(ctx, t, serverHost, dstIface, dstFilter)
+		dstSniffer, err = sniff.Sniff(ctx, t, serverHost, dstIface, dstFilter)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -391,18 +288,18 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 		// Curl the server from the client to generate some traffic
 		t.NewAction(s, fmt.Sprintf("curl-%s", ipFam), client, server, ipFam).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, t.Context().CurlCommand(server, ipFam))
-			srcSniffer.validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
+			srcSniffer.Validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
 			if dstSniffer != nil {
-				dstSniffer.validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
+				dstSniffer.Validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
 			}
 		})
 	case requestICMPEcho:
 		// Ping the server from the client to generate some traffic
 		t.NewAction(s, fmt.Sprintf("ping-%s", ipFam), client, server, ipFam).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, t.Context().PingCommand(server, ipFam))
-			srcSniffer.validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
+			srcSniffer.Validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
 			if dstSniffer != nil {
-				dstSniffer.validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
+				dstSniffer.Validate(ctx, a, assertNoLeaks, t.Context().Params().Debug)
 			}
 		})
 	}

--- a/connectivity/tests/encryption.go
+++ b/connectivity/tests/encryption.go
@@ -136,17 +136,8 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 		// - Any pkt client <-> server with a given proto. This might be useful
 		//   to catch any regression in the DP which makes the pkt to bypass
 		//   the VXLAN tunnel.
-		//
-		// Some explanations:
-		// - "udp[8:2] = 0x0800" compares the first two bytes of an UDP payload
-		//   against VXLAN commonly used flags. In addition we check against
-		//   the default Cilium's VXLAN port (8472).
-		// - To catch Geneve traffic we cannot use the "geneve" filter, as it shifts
-		//   offset of a filted packet which invalidates the later part of the
-		//   filter. Thus this poor UDP/6081 check.
-		tunnelFilter := "(udp and (udp[8:2] = 0x0800 or dst port 8472 or dst port 6081))"
 		filter := fmt.Sprintf("(%s and host %s and host %s) or (host %s and host %s and %s)",
-			tunnelFilter,
+			sniff.TunnelFilter,
 			clientHost.Address(features.IPFamilyV4), serverHost.Address(features.IPFamilyV4),
 			client.Address(ipFam), server.Address(ipFam), protoFilter)
 

--- a/utils/lock/buffer.go
+++ b/utils/lock/buffer.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lock
+
+import (
+	"bytes"
+	"sync"
+)
+
+// bytes.Buffer from the stdlib is non-thread safe, thus our custom
+// implementation. Unfortunately, we cannot use io.Pipe, as Write() blocks until
+// Read() has read all content, which makes it deadlock-prone when used with
+// ExecInPodWithWriters() running in a separate goroutine.
+type Buffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *Buffer) Read(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Read(p)
+}
+
+func (b *Buffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *Buffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+func (b *Buffer) ReadString(d byte) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.ReadString(d)
+}

--- a/utils/sniff/filters.go
+++ b/utils/sniff/filters.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package sniff
+
+// TunnelFilter is a tcpdump filter which captures encapsulated packets.
+//
+// Some explanations:
+//   - "udp[8:2] = 0x0800" compares the first two bytes of an UDP payload
+//     against VXLAN commonly used flags. In addition we check against
+//     the default Cilium's VXLAN port (8472).
+//   - To catch Geneve traffic we cannot use the "geneve" filter, as it shifts
+//     offset of a filtered packet, which invalidates a filter matching on the
+//     outer headers. Thus this poor UDP/6081 check.
+const TunnelFilter = "(udp and (udp[8:2] = 0x0800 or dst port 8472 or dst port 6081))"

--- a/utils/sniff/sniffer.go
+++ b/utils/sniff/sniffer.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package sniff
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/lock"
+)
+
+type Sniffer struct {
+	host     *check.Pod
+	dumpPath string
+
+	stdout lock.Buffer
+	cancel context.CancelFunc
+	exited chan error
+}
+
+func Sniff(ctx context.Context, t *check.Test, host *check.Pod,
+	iface string, filter string,
+) (*Sniffer, error) {
+	cmdctx, cancel := context.WithCancel(ctx)
+	sniffer := &Sniffer{
+		host:     host,
+		dumpPath: fmt.Sprintf("/tmp/%s-%s.pcap", t.Name(), host.Pod.Name),
+		cancel:   cancel,
+		exited:   make(chan error, 1),
+	}
+
+	go func() {
+		// Run tcpdump with -w instead of directly printing captured pkts. This
+		// is to avoid a race after sending ^C (triggered by cancel()) which
+		// might terminate the tcpdump process before it gets a chance to dump
+		// its captures.
+		cmd := []string{
+			"tcpdump", "-i", iface, "--immediate-mode",
+			"-w", sniffer.dumpPath, filter,
+		}
+
+		t.Debugf("Running in bg: %s", strings.Join(cmd, " "))
+		err := host.K8sClient.ExecInPodWithWriters(ctx, cmdctx,
+			host.Pod.Namespace, host.Pod.Name, "", cmd, &sniffer.stdout, io.Discard)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			sniffer.exited <- err
+		}
+
+		close(sniffer.exited)
+	}()
+
+	// Wait until tcpdump is ready to capture pkts
+	wctx, wcancel := context.WithTimeout(ctx, 5*time.Second)
+	defer wcancel()
+	for {
+		select {
+		case <-wctx.Done():
+			return nil, fmt.Errorf("Failed to wait for tcpdump to be ready")
+		case err := <-sniffer.exited:
+			return nil, fmt.Errorf("Failed to execute tcpdump: %w", err)
+		case <-time.After(100 * time.Millisecond):
+			line, err := sniffer.stdout.ReadString('\n')
+			if err != nil && !errors.Is(err, io.EOF) {
+				return nil, fmt.Errorf("Failed to read kubectl exec's stdout: %w", err)
+			}
+			if strings.Contains(line, fmt.Sprintf("listening on %s", iface)) {
+				return sniffer, nil
+			}
+		}
+	}
+}
+
+func (sniffer *Sniffer) Validate(ctx context.Context, a *check.Action, assertNoLeaks, debug bool) {
+	// Wait until tcpdump has exited
+	sniffer.cancel()
+	if err := <-sniffer.exited; err != nil {
+		a.Fatalf("Failed to execute tcpdump: %w", err)
+	}
+
+	// Redirect stderr to /dev/null, as tcpdump logs to stderr, and ExecInPod
+	// will return an error if any char is written to stderr. Anyway, the count
+	// is written to stdout.
+	cmd := []string{"/bin/sh", "-c", fmt.Sprintf("tcpdump -r %s --count 2>/dev/null", sniffer.dumpPath)}
+	count, err := sniffer.host.K8sClient.ExecInPod(ctx, sniffer.host.Pod.Namespace, sniffer.host.Pod.Name, "", cmd)
+	if err != nil {
+		a.Fatalf("Failed to retrieve tcpdump pkt count: %s", err)
+	}
+
+	if !strings.Contains(count.String(), "packet") {
+		a.Fatalf("tcpdump output doesn't look correct: %s", count.String())
+	}
+
+	if !strings.HasPrefix(count.String(), "0 packets") && assertNoLeaks {
+		a.Failf("Captured unencrypted pkt (count=%s)", strings.TrimRight(count.String(), "\n\r"))
+
+		// If debug mode is enabled, dump the captured pkts
+		if debug {
+			cmd := []string{"/bin/sh", "-c", fmt.Sprintf("tcpdump -r %s 2>/dev/null", sniffer.dumpPath)}
+			out, err := sniffer.host.K8sClient.ExecInPod(ctx, sniffer.host.Pod.Namespace, sniffer.host.Pod.Name, "", cmd)
+			if err != nil {
+				a.Fatalf("Failed to retrieve tcpdump output: %s", err)
+			}
+			a.Debugf("Captured pkts:\n%s", out.String())
+		}
+	}
+
+	if strings.HasPrefix(count.String(), "0 packets") && !assertNoLeaks {
+		a.Failf("Expected to see unencrypted packets, but none found. This check might be broken")
+	}
+}


### PR DESCRIPTION
Please review commit by commit and refer to the individual commit messages for additional details. Most of the changes in this PR are due to moving code around, and are isolated in their own commits (second, third and sixth).