### PR TITLE
Simplify executing generic checks as part of the connectivity suite

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -171,7 +171,8 @@ func (a *Action) Run(f func(*Action)) {
 	}
 
 	// Only perform flow validation if a Hubble Relay connection is available.
-	if a.test.ctx.params.Hubble && a.CollectFlows {
+	collectFlows := a.test.ctx.params.Hubble && a.CollectFlows && a.src != nil
+	if collectFlows {
 		// Channel for the flow listener to notify us when ready.
 		ready := make(chan bool, 1)
 
@@ -215,7 +216,7 @@ func (a *Action) Run(f func(*Action)) {
 	// Print flow buffer if any failures or warnings occurred.
 	// TODO(timo): printFlows is a misnomer, this function actually prints
 	// the verdict annotated over the list of flows.
-	if a.test.ctx.PrintFlows() || a.failed {
+	if collectFlows && (a.test.ctx.PrintFlows() || a.failed) {
 		a.printFlows(a.Source())
 		a.printFlows(a.Destination())
 	}

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -286,6 +286,7 @@ func (t *Test) Infof(format string, a ...interface{}) {
 }
 
 func (t *Test) failCommon() {
+	alreadyFailed := t.failed
 	t.failed = true
 	t.flush()
 	if t.ctx.params.PauseOnFail {
@@ -301,7 +302,8 @@ func (t *Test) failCommon() {
 		case <-ctx.Done():
 		}
 	}
-	if t.ctx.params.CollectSysdumpOnFailure {
+	if t.ctx.params.CollectSysdumpOnFailure &&
+		(t.sysdumpPolicy == SysdumpPolicyEach || (t.sysdumpPolicy == SysdumpPolicyOnce && !alreadyFailed)) {
 		t.collectSysdump()
 	}
 }

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -743,6 +743,14 @@ func (t *Test) NewAction(s Scenario, name string, src *Pod, dst TestPeer, ipFam 
 	return a
 }
 
+// NewGenericAction creates a new Action not associated with any execution pod
+// nor network target, but intended for generic assertions (e.g., checking the
+// absence of log errors over multiple pods). s must be the Scenario the Action
+// is created for, name should be a visually-distinguishable name.
+func (t *Test) NewGenericAction(s Scenario, name string) *Action {
+	return t.NewAction(s, name, nil, nil, features.IPFamilyAny)
+}
+
 // failedActions returns a list of failed Actions in the Test.
 func (t *Test) failedActions() []*Action {
 	var out []*Action


### PR DESCRIPTION
When developing new connectivity tests, we may be interested in creating an _action_ also in case we are not strictly running a connectivity check, but for instance checking for error logs or similar (to benefit from better progress and error reporting). Let's introduce a `NewGenericAction` method for such use-cases, as well as the possibility of tuning the sysdump collection policy, as it may be superfluous to collect one sysdump for each failure.

Please review commit by commit, and refer to the commit messages for additional details. 