### PR TITLE
bgp: routes CLI - update min. cilium version, use `cilium` binary

### DIFF
--- a/bgp/routes.go
+++ b/bgp/routes.go
@@ -87,7 +87,7 @@ func (s *Status) fetchRoutesConcurrently(ctx context.Context, args []string) (ma
 	wg.Add(len(s.ciliumPods))
 
 	// compute the command for fetching the routes from a cilium pod
-	fetchCmd := []string{"cilium-dbg", "bgp", "routes"}
+	fetchCmd := []string{"cilium", "bgp", "routes"}
 	fetchCmd = append(fetchCmd, args...)
 	fetchCmd = append(fetchCmd, "-o", "json")
 

--- a/internal/cli/cmd/bgp.go
+++ b/internal/cli/cmd/bgp.go
@@ -62,7 +62,7 @@ func newCmdBgpRoutes() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "routes <available | advertised> <afi> <safi> [vrouter <asn>] [peer|neighbor <address>]",
 		Short: "Lists BGP routes",
-		Long:  "Lists BGP routes from all nodes in the cluster - requires cilium >= v1.15.0",
+		Long:  "Lists BGP routes from all nodes in the cluster - requires cilium >= v1.14.6",
 		Example: `  Get all IPv4 unicast routes available:
     cilium bgp routes available ipv4 unicast
 


### PR DESCRIPTION
As the necessary cilium-dbg functionality for retrieving BGP routes was backported to cilium v1.14.6 (https://github.com/cilium/cilium/pull/30205), we have to use the `cilium` binary instead of `cilium-dbg` to fetch routes from cilium pods, as the rename from `cilium` to `cilium-dbg` happened in 1.15.

This also updates the minimal cilium version for this command in the command description.