### PR TITLE
Go workflow: Remove Cross-build step

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -42,18 +42,5 @@ jobs:
     - name: Build
       run: make
 
-    - name: Cross-build
-      run: |
-        # all GOOS/GOARCH combinations supported by `make local-release`
-        GOOS=linux GOARCH=386 go build ./cmd/cilium
-        GOOS=linux GOARCH=amd64 go build ./cmd/cilium
-        GOOS=linux GOARCH=arm go build ./cmd/cilium
-        GOOS=linux GOARCH=arm64 go build ./cmd/cilium
-        GOOS=darwin GOARCH=amd64 go build ./cmd/cilium
-        GOOS=darwin GOARCH=arm64 go build ./cmd/cilium
-        GOOS=windows GOARCH=386 go build ./cmd/cilium
-        GOOS=windows GOARCH=amd64 go build ./cmd/cilium
-        GOOS=windows GOARCH=arm64 go build ./cmd/cilium
-
     - name: Test
       run: make test


### PR DESCRIPTION
This step is now redundant since we've added the Release workflow [^1] that runs `make release' for each pull request.

[^1]: https://github.com/cilium/cilium-cli/blob/main/.github/workflows/release.yaml