### PR TITLE
hooks: split feature detection from setup and validation

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -45,4 +45,5 @@ func (*NopHooks) AddSysdumpFlags(*pflag.FlagSet)                                
 func (*NopHooks) AddSysdumpTasks(*sysdump.Collector) error                        { return nil }
 func (*NopHooks) AddConnectivityTestFlags(*pflag.FlagSet)                         {}
 func (*NopHooks) AddConnectivityTests(*check.ConnectivityTest) error              { return nil }
+func (*NopHooks) DetectFeatures(context.Context, *check.ConnectivityTest) error   { return nil }
 func (*NopHooks) SetupAndValidate(context.Context, *check.ConnectivityTest) error { return nil }

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -195,9 +195,15 @@ var (
 	client2Label = map[string]string{"name": "client2"}
 )
 
-func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*check.ConnectivityTest) error,
-	addExtraSetup func(context.Context, *check.ConnectivityTest) error) error {
-	if err := ct.SetupAndValidate(ctx, addExtraSetup); err != nil {
+// Hooks defines the extension hooks provided by connectivity tests.
+type Hooks interface {
+	check.SetupHooks
+	// AddConnectivityTests is an hook to register additional connectivity tests.
+	AddConnectivityTests(ct *check.ConnectivityTest) error
+}
+
+func Run(ctx context.Context, ct *check.ConnectivityTest, extra Hooks) error {
+	if err := ct.SetupAndValidate(ctx, extra); err != nil {
 		return err
 	}
 
@@ -1222,7 +1228,7 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, addExtraTests func(*ch
 	// Tests with DNS redirects to the proxy (e.g., client-egress-l7, dns-only,
 	// and to-fqdns) should always be executed last. See #367 for details.
 
-	if err := addExtraTests(ct); err != nil {
+	if err := extra.AddConnectivityTests(ct); err != nil {
 		return err
 	}
 

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -95,7 +95,7 @@ func RunE(hooks Hooks) func(cmd *cobra.Command, args []string) error {
 		// and end the goroutine without returning.
 		go func() {
 			defer func() { done <- struct{}{} }()
-			err = connectivity.Run(ctx, cc, hooks.AddConnectivityTests, hooks.SetupAndValidate)
+			err = connectivity.Run(ctx, cc, hooks)
 
 			// If Fatal() was called in the test suite, the statement below won't fire.
 			finished = true

--- a/internal/cli/cmd/hooks.go
+++ b/internal/cli/cmd/hooks.go
@@ -4,11 +4,9 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/pflag"
 
-	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity"
 	"github.com/cilium/cilium-cli/sysdump"
 )
 
@@ -20,9 +18,9 @@ type Hooks interface {
 
 // ConnectivityTestHooks to extend cilium-cli with additional connectivity tests and related flags.
 type ConnectivityTestHooks interface {
-	SetupAndValidate(ctx context.Context, ct *check.ConnectivityTest) error
+	connectivity.Hooks
+	// AddConnectivityTestFlags is an hook to register additional connectivity test flags.
 	AddConnectivityTestFlags(flags *pflag.FlagSet)
-	AddConnectivityTests(ct *check.ConnectivityTest) error
 }
 
 // SysdumpHooks to extend cilium-cli with additional sysdump tasks and related flags.


### PR DESCRIPTION
Currently, the SetupAndValidate extension hook is executed right after feature detection, but before the setup and validation of the different connectivity test pods and artifacts. While this has the advantage of nicely integrating with the logging of the detected features, it does not allow the hook function to rely on the existence of the pods created immediately afterwards. To enable both functionalities, let's split the hook into two -- one first function to detect extra features, and a second to perform the actual setup and validation of extra pods.