### PR TITLE
Remove no longer necessary step from the external workloads installation script generation process

### DIFF
--- a/internal/cli/cmd/clustermesh.go
+++ b/internal/cli/cmd/clustermesh.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium-cli/clustermesh"
-	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/utils"
 	"github.com/cilium/cilium-cli/status"
 )
@@ -316,8 +315,6 @@ func newCmdExternalWorkloadInstall() *cobra.Command {
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 15*time.Minute, "Maximum time to wait")
 	cmd.Flags().StringSliceVar(&params.ConfigOverwrites, "config", []string{}, "Cilium agent config entries (key=value)")
 	cmd.Flags().IntVar(&params.Retries, "retries", 4, "Number of Cilium agent start retries")
-
-	cmd.Flags().StringVar(&params.HelmValuesSecretName, "helm-values-secret-name", defaults.HelmValuesSecretName, "Secret name to store the auto-generated helm values file. The namespace is the same as where Cilium will be installed")
 
 	return cmd
 }


### PR DESCRIPTION
Currently, the `cilium clustermesh external-workload install` command attempts to retrieve the Cilium version from either the secret created by the CLI (when running in classic mode) or from the helm release. The retrieved version is then used to tune the one of the options passed to the Cilium container on the external workload, which at a certain point got renamed. Given that all supported Cilium stable versions do support the new flag, and considering that the retrieval logic is potentially fragile (e.g., it fails if Cilium is installed with a non-default release name), let's just drop all of this logic. Regardless, we retrieve the Cilium image from the existing DaemonSet.