### PR TITLE
connectivity: fix panic if the cilium-health test fails

### DIFF
--- a/connectivity/tests/health.go
+++ b/connectivity/tests/health.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/utils/features"
 )
 
 func CiliumHealth() check.Scenario {
@@ -33,7 +32,7 @@ func (s *ciliumHealth) Name() string {
 func (s *ciliumHealth) Run(ctx context.Context, t *check.Test) {
 	for name, pod := range t.Context().CiliumPods() {
 		pod := pod
-		t.NewAction(s, name, &pod, nil, features.IPFamilyAny).Run(func(a *check.Action) {
+		t.NewGenericAction(s, name).Run(func(a *check.Action) {
 			runHealthProbe(ctx, t, &pod)
 		})
 	}


### PR DESCRIPTION
Fix a possible panic occurring if the cilium-health test fails and flow validation is enabled, or --print-flow is given. Indeed, that action is configured with a nil destination (as the check has no strict destination target), in turn causing the panic during flow visualization. Hence, let's switch to creating a generic action (i.e., intended for generic assertions), effectively disabling flow collection and display.

Hit in https://github.com/cilium/cilium-cli/actions/runs/7708934175/job/21020724137?pr=2273