### PR TITLE
Prepare for v0.15.22 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ binary releases.
 
 | Release                                                                | Maintained | Compatible Cilium Versions |
 |------------------------------------------------------------------------|------------|----------------------------|
-| [v0.15.21](https://github.com/cilium/cilium-cli/releases/tag/v0.15.21) | Yes        | Cilium 1.14 and newer      |
-| [v0.14.8](https://github.com/cilium/cilium-cli/releases/tag/v0.14.8)   | Yes        | Cilium 1.12 and 1.13       |
+| [v0.15.22](https://github.com/cilium/cilium-cli/releases/tag/v0.15.22) | Yes        | Cilium 1.14 and newer      |
+| [v0.14.8](https://github.com/cilium/cilium-cli/releases/tag/v0.14.8)   | Yes        | Cilium 1.13                |
 
 Please see [`helm` installation mode](#helm-installation-mode) section
 regarding our plan to migrate to the new `helm` installation mode and deprecate

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ table](https://github.com/cilium/cilium-cli#releases) for the most recent suppor
 Set `RELEASE` environment variable to the new version. This variable will be
 used in the commands throughout the documenat to allow copy-pasting.
 
-    export RELEASE=v0.15.22
+    export RELEASE=v0.15.23
 
 ## Prepare the release
 


### PR DESCRIPTION
Also drop Cilium 1.12 from the Release section of README.md since it's been EOLed.