### PR TITLE
gateway: Upgrade API version

### DIFF
--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -158,25 +158,25 @@ var (
 	gatewayClass = schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
 		Resource: "gatewayclasses",
-		Version:  "v1beta1",
+		Version:  "v1",
 	}
 
 	gateway = schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
 		Resource: "gateways",
-		Version:  "v1beta1",
+		Version:  "v1",
 	}
 
 	referenceGrant = schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
 		Resource: "referencegrants",
-		Version:  "v1alpha2",
+		Version:  "v1beta1",
 	}
 
 	httpRoute = schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
 		Resource: "httproutes",
-		Version:  "v1beta1",
+		Version:  "v1",
 	}
 
 	tlsRoute = schema.GroupVersionResource{


### PR DESCRIPTION
This is to avoid the below warning

```
W0205 12:29:06.703289  146168 warnings.go:70] The v1alpha2 version of ReferenceGrant has been deprecated and will be removed in a future release of the API. Please upgrade to v1beta1.
```