### PR TITLE
cilium status: additionally check for endpoints readiness

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -445,6 +445,7 @@ type k8sClusterMeshImplementation interface {
 	ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error)
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error)
+	CiliumDbgEndpoints(ctx context.Context, namespace, pod string) ([]*models.Endpoint, error)
 	ClusterName() string
 	ListCiliumExternalWorkloads(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error)
 	GetCiliumExternalWorkload(ctx context.Context, name string, opts metav1.GetOptions) (*ciliumv2.CiliumExternalWorkload, error)

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -69,6 +69,7 @@ type k8sHubbleImplementation interface {
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	PatchDaemonSet(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.DaemonSet, error)
 	CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error)
+	CiliumDbgEndpoints(ctx context.Context, namespace, pod string) ([]*models.Endpoint, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 	GetServerVersion() (*semver.Version, error)
 	GetHelmState(ctx context.Context, namespace string, secretName string) (*helm.State, error)

--- a/install/install.go
+++ b/install/install.go
@@ -264,6 +264,7 @@ type k8sInstallerImplementation interface {
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	ContextName() (name string)
 	CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error)
+	CiliumDbgEndpoints(ctx context.Context, namespace, pod string) ([]*models.Endpoint, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 	GetRunningCiliumVersion(ctx context.Context, namespace string) (string, error)
 	GetPlatform(ctx context.Context) (*k8s.Platform, error)

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -492,6 +492,19 @@ func (c *Client) CiliumStatus(ctx context.Context, namespace, pod string) (*mode
 	return &statusResponse, nil
 }
 
+func (c *Client) CiliumDbgEndpoints(ctx context.Context, namespace, pod string) ([]*models.Endpoint, error) {
+	stdout, err := c.ExecInPod(ctx, namespace, pod, defaults.AgentContainerName, []string{"cilium", "endpoint", "list", "-o", "json"})
+	if err != nil {
+		return nil, err
+	}
+
+	var response []*models.Endpoint
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response: %w", err)
+	}
+	return response, nil
+}
+
 func (c *Client) CreateConfigMap(ctx context.Context, namespace string, config *corev1.ConfigMap, opts metav1.CreateOptions) (*corev1.ConfigMap, error) {
 	return c.Clientset.CoreV1().ConfigMaps(namespace).Create(ctx, config, opts)
 }

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -156,6 +156,10 @@ func (c *k8sStatusMockClient) CiliumStatus(_ context.Context, _, pod string) (*m
 	return s, nil
 }
 
+func (c *k8sStatusMockClient) CiliumDbgEndpoints(_ context.Context, _, _ string) ([]*models.Endpoint, error) {
+	return nil, nil
+}
+
 func (b *StatusSuite) TestMockClient(c *check.C) {
 	client := newK8sStatusMockClient()
 	c.Assert(client, check.Not(check.IsNil))


### PR DESCRIPTION
Introduce an additional step to the cilium status command to check
(and optionally wait) for endpoints readiness. This check is
particularly relevant in CI to ensure that the datapath of already
existing endpoints has been fully updated (i.e., restoration and
regeneration phases have completed) after agent restart, before
proceeding with the subsequent tests. Otherwise, we may continue
to incorrectly exercise the old datapath and miss possible issues,
especially concerning dropped connections and missed tail calls.