### PR TITLE
chore: Amend connectivity tests for OpenShift

### DIFF
--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -20,6 +20,20 @@ spec:
       - matchExpressions:
           - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
           - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+# OpenShift  runs coreDNS in openshift-dns namespace and uses port 5353
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      - port: "5353"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
   # When node-local-dns is deployed with local IP,
   # Cilium labels its ip as world.
   # This change prevents failing the connectivity

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -23,6 +23,17 @@ spec:
         protocol: UDP
       - port: "53"
         protocol: TCP
+  # OpenShift  runs coreDNS in openshift-dns namespace and uses port 5353
+  - toEndpoints:
+    - matchExpressions:
+      - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
+    toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      - port: "5353"
+        protocol: TCP
   # When node-local-dns is deployed with local IP,
   # Cilium labels its ip as world.
   # This change prevents failing the connectivity

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -30,6 +30,20 @@ spec:
     - matchExpressions:
       - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+# OpenShift  runs coreDNS in openshift-dns namespace and uses port 5353
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      - port: "5353"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
   # When node-local-dns is deployed with local IP,
   # Cilium labels its ip as world.
   # This change prevents failing the connectivity


### PR DESCRIPTION
OpenShift runs coreDNS in openshift-dns namespace and uses port 5353.
This PR adds rules to CiliumNetworkPolicies so that name resolution can succeed during the connectivity tests.