### PR TITLE
Introduce host firewall connectivity tests

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -250,6 +250,7 @@ func (ct *ConnectivityTest) NewTest(name string) *Test {
 		name:      name,
 		scenarios: make(map[Scenario][]*Action),
 		cnps:      make(map[string]*ciliumv2.CiliumNetworkPolicy),
+		ccnps:     make(map[string]*ciliumv2.CiliumClusterwideNetworkPolicy),
 		knps:      make(map[string]*networkingv1.NetworkPolicy),
 		cegps:     make(map[string]*ciliumv2.CiliumEgressGatewayPolicy),
 		verbose:   ct.verbose(),

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -1073,9 +1073,6 @@ func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily) 
 	if connectTimeout := ct.params.ConnectTimeout.Seconds(); connectTimeout > 0.0 {
 		cmd = append(cmd, "-W", strconv.FormatFloat(connectTimeout, 'f', -1, 64))
 	}
-	if requestTimeout := ct.params.RequestTimeout.Seconds(); requestTimeout > 0.0 {
-		cmd = append(cmd, "-w", strconv.FormatFloat(requestTimeout, 'f', -1, 64))
-	}
 
 	cmd = append(cmd, peer.Address(ipFam))
 	return cmd

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -199,6 +199,7 @@ func (ct *ConnectivityTest) extractFeaturesFromK8sCluster(ctx context.Context, r
 }
 
 const ciliumNetworkPolicyCRDName = "ciliumnetworkpolicies.cilium.io"
+const ciliumClusterwideNetworkPolicyCRDName = "ciliumclusterwidenetworkpolicies.cilium.io"
 
 func (ct *ConnectivityTest) extractFeaturesFromCRDs(ctx context.Context, result features.Set) error {
 	check := func(name string) (features.Status, error) {
@@ -218,7 +219,13 @@ func (ct *ConnectivityTest) extractFeaturesFromCRDs(ctx context.Context, result 
 		return err
 	}
 
+	ccnp, err := check(ciliumClusterwideNetworkPolicyCRDName)
+	if err != nil {
+		return err
+	}
+
 	result[features.CNP] = cnp
+	result[features.CCNP] = ccnp
 	return nil
 }
 

--- a/connectivity/manifests/host-firewall-egress.yaml
+++ b/connectivity/manifests/host-firewall-egress.yaml
@@ -1,0 +1,18 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-firewall-egress"
+spec:
+  nodeSelector: {}
+  egress:
+  - toEntities:
+    - health
+    - kube-apiserver
+    - remote-node
+    - world
+  - toEndpoints:
+    - matchExpressions:
+      - key: name
+        operator: NotIn
+        values:
+        - echo-other-node

--- a/connectivity/manifests/host-firewall-ingress.yaml
+++ b/connectivity/manifests/host-firewall-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-firewall-ingress"
+spec:
+  nodeSelector: {}
+  ingress:
+  - fromEntities:
+    - health
+    - kube-apiserver
+    - remote-node
+    - world
+  - fromEndpoints:
+    - matchExpressions:
+      - key: name
+        operator: NotIn
+        values:
+        - client

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -47,8 +47,9 @@ const (
 
 	SecretBackendK8s Feature = "secret-backend-k8s"
 
-	CNP Feature = "cilium-network-policy"
-	KNP Feature = "k8s-network-policy"
+	CNP  Feature = "cilium-network-policy"
+	CCNP Feature = "cilium-clusterwide-network-policy"
+	KNP  Feature = "k8s-network-policy"
 
 	// Whether or not CIDR selectors can match node IPs
 	CIDRMatchNodes Feature = "cidr-match-nodes"


### PR DESCRIPTION
Introduce two new tests covering the host firewall functionality, i.e., asserting that both ingress and egress CiliumClusterwideNetworkPolicies specifying a NodeSelector correctly block the expected traffic. The
tests are executed only when the unsafe tests are enabled, as potentially disruptive if executed against a live cluster.

The initial five commits are refactor and generalize the logic in charge of parsing, registering and creating/updating the policies used during the tests, to uniform it, reduce code duplication, and in preparation for the support for CCNPs. The sixth commit introduces the actual support for CCNPs in connectivity test. The last commit introduces the actual tests.

Please review commit by commit, and refer to the commit messages for additional details.