### PR TITLE
Increase timeouts in AKS and GKE GHA workflows

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -47,7 +47,7 @@ jobs:
     name: AKS BYOCNI Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -169,7 +169,7 @@ jobs:
 
       - name: Wait for test job
         env:
-          timeout: 30m
+          timeout: 45m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -37,7 +37,7 @@ jobs:
     name: GKE Installation and Connectivity Test
     if: ${{ github.repository == 'cilium/cilium-cli' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Set cluster name
         run: |
@@ -136,7 +136,7 @@ jobs:
 
       - name: Wait for test job
         env:
-          timeout: 30m
+          timeout: 45m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &


### PR DESCRIPTION
I've been recently hitting the timeout quite frequently on these two workflows. Let's try increasing it to see if the situation improves.