### PR TITLE
connectivity: improve reporting for no-unexpected-packet-drops check

### DIFF
--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -265,7 +265,9 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, extra Hooks) error {
 		}
 	}
 
-	ct.NewTest("no-unexpected-packet-drops").WithScenarios(tests.NoUnexpectedPacketDrops(ct.Params().ExpectedDropReasons))
+	ct.NewTest("no-unexpected-packet-drops").
+		WithScenarios(tests.NoUnexpectedPacketDrops(ct.Params().ExpectedDropReasons)).
+		WithSysdumpPolicy(check.SysdumpPolicyOnce)
 
 	// Run all tests without any policies in place.
 	noPoliciesScenarios := []check.Scenario{


### PR DESCRIPTION
Let's leverage the GenericAction construct to provide better progress and error reporting for the given test, displaying the node associated with any issue and ensuring that we continue checking for problems also after that a first one has been found. Let's also configure it to still capture a single sysdump regardless of the number of failures.