### PR TITLE
connectivity: add forbidden ICMPv6 message as expected drop reason

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -206,6 +206,7 @@ var (
 		"No tunnel/encapsulation endpoint (datapath BUG!)",
 		"Host datapath not ready",
 		"Unknown ICMPv4 code",
+		"Forbidden ICMPv6 message",
 	}
 
 	ExpectedXFRMErrors = []string{


### PR DESCRIPTION
When host firewall is enabled, we automatically drop certain ICMPv6 messages according to RFC4890 recommendations. Let's add that drop reason to the default list of expected ones, as possibly generated in legitimate cases, independently from Cilium.

As a special case, an ICMPv6 redirect message can be also triggered when Cilium is first installed on a node, the host firewall is enabled and KPR is disabled, a workload endpoint gets created before the host endpoint (e.g., the health one), and a remote node tries to talk to it. Indeed, the reply is passed to the stack, which is then unable to redirect it through the tunnel as the BPF program has not yet been loaded.

Related: https://github.com/cilium/cilium/pull/30818