### PR TITLE
Ignore Cilium endpoints not found error for the status command.

### DIFF
--- a/status/k8s.go
+++ b/status/k8s.go
@@ -172,7 +172,11 @@ func (k *K8sStatusCollector) podCount(ctx context.Context, status *Status) error
 
 	ciliumEps, err := k.client.ListCiliumEndpoints(ctx, "", metav1.ListOptions{})
 	if err != nil {
-		return err
+		// When the CEP has not been registered yet, it's impossible
+		// for any pods to be managed by Cilium.
+		if err.Error() != "the server could not find the requested resource (get ciliumendpoints.cilium.io)" {
+			return err
+		}
 	}
 	if ciliumEps != nil {
 		numberCiliumPod = len(ciliumEps.Items)

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"sync"
@@ -170,11 +171,11 @@ func (k *K8sStatusCollector) podCount(ctx context.Context, status *Status) error
 		}
 	}
 
+	// When the CEP has not been registered yet, it's impossible
+	// for any pods to be managed by Cilium. So continue, with 0 managed pods.
 	ciliumEps, err := k.client.ListCiliumEndpoints(ctx, "", metav1.ListOptions{})
 	if err != nil {
-		// When the CEP has not been registered yet, it's impossible
-		// for any pods to be managed by Cilium.
-		if err.Error() != "the server could not find the requested resource (get ciliumendpoints.cilium.io)" {
+		if err, ok := err.(*k8serrors.StatusError); ok && err.Status().Code != http.StatusNotFound {
 			return err
 		}
 	}


### PR DESCRIPTION
The fix is required for the Customers that have `disableEndpointCRD: "true"` in the Cilium configuration.

Status output example when `disableEndpointCRD: "true"`:
<img width="1235" alt="Screenshot 2024-02-20 at 11 29 00" src="https://github.com/cilium/cilium-cli/assets/69600804/3559b4f7-2726-41e7-85da-e0baaaba4002">

The logic was stolen from: https://github.com/cilium/cilium-cli/blob/main/install/install.go#L582-L587