### PR TITLE
k8s: don't drop stdout of kubectl exec

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -449,11 +449,11 @@ func (c *Client) ExecInPod(ctx context.Context, namespace, pod, container string
 		Command:   command,
 	})
 	if err != nil {
-		return bytes.Buffer{}, err
+		return result.Stdout, err
 	}
 
 	if errString := result.Stderr.String(); errString != "" {
-		return bytes.Buffer{}, fmt.Errorf("command failed (pod=%s/%s, container=%s): %q", namespace, pod, container, errString)
+		return result.Stdout, fmt.Errorf("command failed (pod=%s/%s, container=%s): %q", namespace, pod, container, errString)
 	}
 
 	return result.Stdout, nil


### PR DESCRIPTION
A non-empty stderr is interpreted as a command failure. However, calling code still assumes the output it gets is the output of the command, whereas we currently just return a pristine buffer.

Fix it by returning the buffer.

An example of why this is annoying: https://github.com/cilium/cilium/actions/runs/8043919487/job/21966754656#step:17:328 