### PR TITLE
connectivity: fix encryption validation with wireguard encap + host fw

### DIFF
--- a/connectivity/tests/encryption.go
+++ b/connectivity/tests/encryption.go
@@ -76,7 +76,7 @@ func getInterNodeIface(ctx context.Context, t *check.Test,
 
 	device := strings.TrimRight(dev.String(), "\n\r")
 
-	if tunnelEnabled {
+	if tunnelEnabled && !wgEncap {
 		// When tunneling is enabled, and the traffic is routed to the cilium IP space
 		// we want to capture on the tunnel interface.
 		if device == defaults.HostDevice {


### PR DESCRIPTION
In Cilium v1.15 and later (as well as v1.14 if the --wireguard-encapsulate flag is set), when both tunnel encapsulation and WireGuard encryption are enabled, packets are first encapsulated and then encrypted. Let's fix the connectivity check inter-node interface determination when host firewall is additionally enabled, as currently always defaulting to the tunnel interface, which is incorrect (we would flag the packets as unencrypted, even though the encapsulated packets are encrypted afterwards).