### PR TITLE
uninstall: when --wait is specified, use foreground deletion.

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -975,9 +975,10 @@ func (ct *ConnectivityTest) UninstallResources(ctx context.Context, wait bool) {
 	ct.Logf("🔥 Deleting %s namespace...", ct.params.TestNamespace)
 	ct.client.DeleteNamespace(ctx, ct.params.TestNamespace, metav1.DeleteOptions{})
 
-	// To avoid cases where test pods are stuck in terminating state because
-	// cni (cilium) pods were deleted sooner, wait until test pods are deleted
-	// before moving onto deleting cilium pods.
+	// If test Pods are not deleted prior to uninstalling Cilium then the CNI deletes
+	// may be queued by cilium-cni. This can cause error to be logged when re-installing
+	// Cilium later.
+	// Thus we wait for all cilium-test Pods to fully terminate before proceeding.
 	if wait {
 		ct.Logf("⌛ Waiting for %s namespace to be terminated...", ct.params.TestNamespace)
 		for {

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -32,6 +32,9 @@ type Parameters struct {
 
 	// UIOpenBrowser will automatically open browser if true
 	UIOpenBrowser bool
+
+	// Wait will cause Helm upgrades related to disabling Hubble to wait.
+	Wait bool
 }
 
 func (p *Parameters) Log(format string, a ...interface{}) {
@@ -74,6 +77,7 @@ func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Paramete
 		Values:      vals,
 		ResetValues: false,
 		ReuseValues: true,
+		Wait:        params.Wait,
 	}
 	_, err = helm.Upgrade(ctx, k8sClient.HelmActionConfig, upgradeParams)
 	return err

--- a/install/uninstall.go
+++ b/install/uninstall.go
@@ -48,6 +48,9 @@ func (k *K8sUninstaller) Log(format string, a ...interface{}) {
 func (k *K8sUninstaller) UninstallWithHelm(ctx context.Context, actionConfig *action.Configuration) error {
 	helmClient := action.NewUninstall(actionConfig)
 	helmClient.Wait = k.params.Wait
+	if k.params.Wait {
+		helmClient.DeletionPropagation = "foreground"
+	}
 	helmClient.Timeout = k.params.Timeout
 	if _, err := helmClient.Run(defaults.HelmReleaseName); err != nil {
 		return err


### PR DESCRIPTION
By default, the helm libraries will use background cascading delete which means the call to do helm uninstall returns following the deployment being removed.

This means that running workloads, such as hubble-relay, may continue to be in the terminating state following `cilium uninstall --wait` exiting.

We depend on this behavior in CI E2E to clean up and reuse clusters for testing Cilium in different configurations.

In flakes such as: https://github.com/cilium/cilium/issues/30993 it seems like the old Hubble Pods are bleeding into the "fresh" install. These should be harmless, however this is triggering failures of the [no-error-logs] assertion in the following connectivity tests.

This change will provide a more thorough uninstall procedure in this case.