### PR TITLE
helm: Remove Get and GetParameter

### DIFF
--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -43,7 +43,7 @@ func newCmdVersion() *cobra.Command {
 			if clientOnly {
 				return nil
 			}
-			version, err := k8sClient.GetRunningCiliumVersion(namespace)
+			version, err := k8sClient.GetRunningCiliumVersion()
 			if err != nil {
 				fmt.Printf("cilium image (running): unknown. Unable to obtain cilium version. Reason: %s\n", err.Error())
 			} else {

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -317,20 +317,3 @@ func Upgrade(
 
 	return helmClient.RunWithContext(ctx, defaults.HelmReleaseName, params.Chart, params.Values)
 }
-
-// GetParameters contains parameters for helm get operation.
-type GetParameters struct {
-	// Namespace in which the Helm release is installed.
-	Namespace string
-	// Name of the Helm release to get.
-	Name string
-}
-
-// Get returns the Helm release specified by GetParameters.
-func Get(
-	actionConfig *action.Configuration,
-	params GetParameters,
-) (*release.Release, error) {
-	helmClient := action.NewGet(actionConfig)
-	return helmClient.Run(params.Name)
-}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -50,7 +50,6 @@ import (
 	tetragonClientset "github.com/cilium/tetragon/pkg/k8s/client/clientset/versioned"
 
 	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/internal/helm"
 )
 
 type Client struct {
@@ -972,11 +971,8 @@ func (c *Client) GetCiliumVersion(ctx context.Context, p *corev1.Pod) (*semver.V
 	return &podVersion, nil
 }
 
-func (c *Client) GetRunningCiliumVersion(namespace string) (string, error) {
-	release, err := helm.Get(c.HelmActionConfig, helm.GetParameters{
-		Namespace: namespace,
-		Name:      defaults.HelmReleaseName,
-	})
+func (c *Client) GetRunningCiliumVersion() (string, error) {
+	release, err := action.NewGet(c.HelmActionConfig).Run(defaults.HelmReleaseName)
 	if err != nil {
 		return "", err
 	}

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -16,13 +16,13 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/workerpool"
+	"helm.sh/helm/v3/pkg/action"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium-cli/defaults"
-	"github.com/cilium/cilium-cli/internal/helm"
 	"github.com/cilium/cilium-cli/k8s"
 )
 
@@ -518,10 +518,7 @@ func (k *K8sStatusCollector) status(ctx context.Context) *Status {
 			if !ok {
 				return fmt.Errorf("failed to initialize Helm client")
 			}
-			release, err := helm.Get(client.HelmActionConfig, helm.GetParameters{
-				Namespace: k.params.Namespace,
-				Name:      defaults.HelmReleaseName,
-			})
+			release, err := action.NewGet(client.HelmActionConfig).Run(defaults.HelmReleaseName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Namespace is already configured in HelmActionConfig, so defining Get and GetParameter is somewhat redundant and misleading. Directly call Helm client Get() instead.