### PR TITLE
Move the CLI version string to the default package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOLANGCILINT_VERSION = $(shell golangci-lint version --format short 2>/dev/null)
 $(TARGET):
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
 		-ldflags "$(STRIP_DEBUG) \
-		-X 'github.com/cilium/cilium-cli/cli.Version=${VERSION}'" \
+		-X 'github.com/cilium/cilium-cli/defaults.CLIVersion=${VERSION}'" \
 		-o $(TARGET) \
 		./cmd/cilium
 

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -14,12 +14,6 @@ import (
 	"github.com/cilium/cilium-cli/sysdump"
 )
 
-// The following variables are set at compile time via LDFLAGS.
-var (
-	// Version is the software version.
-	Version string
-)
-
 // NewDefaultCiliumCommand returns a new "cilium" cli cobra command without any additional hooks.
 func NewDefaultCiliumCommand() *cobra.Command {
 	return NewCiliumCommand(&NopHooks{})
@@ -27,7 +21,6 @@ func NewDefaultCiliumCommand() *cobra.Command {
 
 // NewCiliumCommand returns a new "cilium" cli cobra command registering all the additional input hooks.
 func NewCiliumCommand(hooks Hooks) *cobra.Command {
-	cmd.SetVersion(Version)
 	return cmd.NewCiliumCommand(hooks)
 }
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -156,4 +156,9 @@ var (
 		"inbound_other",          // XfrmInError
 		"inbound_state_invalid",  // XfrmInStateInvalid
 	}
+
+	// The following variables are set at compile time via LDFLAGS.
+
+	// CLIVersion is the software version of the Cilium CLI.
+	CLIVersion string
 )

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -17,15 +17,7 @@ var (
 	namespace   string
 
 	k8sClient *k8s.Client
-
-	// version is the version string of the cilium-cli itself
-	version string
 )
-
-// SetVersion sets the version string for the cilium command
-func SetVersion(v string) {
-	version = v
-}
 
 func NewCiliumCommand(hooks Hooks) *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -70,7 +70,7 @@ func RunE(hooks Hooks) func(cmd *cobra.Command, args []string) error {
 		}
 
 		// Instantiate the test harness.
-		cc, err := check.NewConnectivityTest(k8sClient, params, version)
+		cc, err := check.NewConnectivityTest(k8sClient, params, defaults.CLIVersion)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -108,7 +108,7 @@ func newCmdUninstallWithHelm() *cobra.Command {
 				TestNamespace:   params.TestNamespace,
 				FlowValidation:  check.FlowValidationModeDisabled,
 				Writer:          os.Stdout,
-			}, version)
+			}, defaults.CLIVersion)
 			if err != nil {
 				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s\n", err)
 			} else {

--- a/internal/cli/cmd/sysdump.go
+++ b/internal/cli/cmd/sysdump.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/sysdump"
 )
 
@@ -36,7 +37,7 @@ func newCmdSysdump(hooks sysdump.Hooks) *cobra.Command {
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)
 			// Collect the sysdump.
-			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now(), version)
+			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now(), defaults.CLIVersion)
 			if err != nil {
 				return fmt.Errorf("failed to create sysdump collector: %w", err)
 			}

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -37,7 +37,7 @@ func newCmdVersion() *cobra.Command {
 		Short: "Display detailed version information",
 		Long:  `Displays information about the version of this software.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			fmt.Printf("cilium-cli: %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("cilium-cli: %s compiled with %v on %v/%v\n", defaults.CLIVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 			fmt.Printf("cilium image (default): %s\n", defaults.Version)
 			fmt.Printf("cilium image (stable): %s\n", getLatestStableVersion())
 			if clientOnly {


### PR DESCRIPTION
Move the CLI version string from internal/cli/cmd to default/ so that it can be exported from outside the cilium-cli repo.

Ref: cilium/design-cfps#9