### PR TITLE
Add error log check exception for leader election errors.

### DIFF
--- a/connectivity/tests/errors.go
+++ b/connectivity/tests/errors.go
@@ -28,7 +28,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version) check.Scenario {
 	// error cannot be fixed in Cilium or in the test.
 	errorLogExceptions := []string{"Error in delegate stream, restarting", failedToListCRDs, removeInexistentID}
 	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
-		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR)
+		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]string{
@@ -223,26 +223,27 @@ func (n *noErrorsInLogs) checkErrorsInLogs(id string, logs string, a *check.Acti
 
 const (
 	// Logs messages that should not be in the cilium logs
-	panicMessage        = "panic:"
-	deadLockHeader      = "POTENTIAL DEADLOCK:"                                      // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault   = "segmentation fault"                                       // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived        = "NACK received for version"                                // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed       = "JoinEP: "                                                 // from https://github.com/cilium/cilium/pull/5052
-	sizeMismatch        = "size mismatch for BPF map"                                // from https://github.com/cilium/cilium/issues/7851
-	emptyBPFInitArg     = "empty argument passed to bpf/init.sh"                     // from https://github.com/cilium/cilium/issues/10228
-	RemovingMapMsg      = "Removing map to allow for property upgrade"               // from https://github.com/cilium/cilium/pull/10626
-	logBufferMessage    = "Log buffer too small to dump verifier log"                // from https://github.com/cilium/cilium/issues/10517
-	ClangErrorsMsg      = " errors generated."                                       // from https://github.com/cilium/cilium/issues/10857
-	ClangErrorMsg       = "1 error generated."                                       // from https://github.com/cilium/cilium/issues/10857
-	symbolSubstitution  = "Skipping symbol substitution"                             //
-	uninitializedRegen  = "Uninitialized regeneration level"                         // from https://github.com/cilium/cilium/pull/10949
-	unstableStat        = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
-	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
-	removeInexistentID  = "removing identity not added to the identity manager!"     // from https://github.com/cilium/cilium/issues/16419
-	missingIptablesWait = "Missing iptables wait arg (-w):"
-	localIDRestoreFail  = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
-	routerIPMismatch    = "Mismatch of router IPs found during restoration"
-	emptyIPNodeIDAlloc  = "Attempt to allocate a node ID for an empty node IP address"
-	failedToListCRDs    = "the server could not find the requested resource" // cf. https://github.com/cilium/cilium/issues/16425
-	previouslyUsedCIDR  = "Unable to find identity of previously used CIDR"  // from https://github.com/cilium/cilium/issues/26881
+	panicMessage           = "panic:"
+	deadLockHeader         = "POTENTIAL DEADLOCK:"                                      // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault      = "segmentation fault"                                       // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived           = "NACK received for version"                                // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed          = "JoinEP: "                                                 // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch           = "size mismatch for BPF map"                                // from https://github.com/cilium/cilium/issues/7851
+	emptyBPFInitArg        = "empty argument passed to bpf/init.sh"                     // from https://github.com/cilium/cilium/issues/10228
+	RemovingMapMsg         = "Removing map to allow for property upgrade"               // from https://github.com/cilium/cilium/pull/10626
+	logBufferMessage       = "Log buffer too small to dump verifier log"                // from https://github.com/cilium/cilium/issues/10517
+	ClangErrorsMsg         = " errors generated."                                       // from https://github.com/cilium/cilium/issues/10857
+	ClangErrorMsg          = "1 error generated."                                       // from https://github.com/cilium/cilium/issues/10857
+	symbolSubstitution     = "Skipping symbol substitution"                             //
+	uninitializedRegen     = "Uninitialized regeneration level"                         // from https://github.com/cilium/cilium/pull/10949
+	unstableStat           = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
+	removeTransientRule    = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
+	removeInexistentID     = "removing identity not added to the identity manager!"     // from https://github.com/cilium/cilium/issues/16419
+	missingIptablesWait    = "Missing iptables wait arg (-w):"
+	localIDRestoreFail     = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
+	routerIPMismatch       = "Mismatch of router IPs found during restoration"
+	emptyIPNodeIDAlloc     = "Attempt to allocate a node ID for an empty node IP address"
+	failedToListCRDs       = "the server could not find the requested resource"                          // cf. https://github.com/cilium/cilium/issues/16425
+	previouslyUsedCIDR     = "Unable to find identity of previously used CIDR"                           // from https://github.com/cilium/cilium/issues/26881
+	klogLeaderElectionFail = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
 )


### PR DESCRIPTION
    Add error log check exception for leader election errors.

    The operator uses the client-go leader election sdk, which reattempts acquiring the lock, logging failures via klog [1].

    [1] https://github.com/cilium/cilium/blob/6a70af21c3b6985096fca3f8240139b548ac4760/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go#L332

    In general, such errors should be transient, if it is persistent then it wouldn't be isolated to just this api so it should be ok to ignore all such errors.

    Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>