### PR TITLE
Improve the helm values autodetection logic

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -9,7 +9,7 @@ cilium install \
   --set cluster.name="${CLUSTER_NAME}" \
   --set bpf.monitorAggregation=none \
   --datapath-mode=tunnel \
-  --set kubeProxyReplacement=strict \
+  --set kubeProxyReplacement=true \
   --set loadBalancer.l7.backend=envoy \
   --set tls.secretsBackend=k8s \
   --set ipv4NativeRoutingCIDR="${CLUSTER_CIDR}"

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -141,7 +141,7 @@ jobs:
           --nodes-without-cilium="${NODES_WITHOUT_CILIUM}" \
           --set encryption.enabled=true \
           --set encryption.type=ipsec \
-          --set kubeProxyReplacement=disabled
+          --set kubeProxyReplacement=false
 
       - name: Enable Relay
         run: |

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -147,10 +147,10 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 	}
 
 	// Kube-Proxy Replacement
-	mode = "Disabled"
+	mode = "false"
 	if kpr := st.KubeProxyReplacement; kpr != nil {
-		mode = kpr.Mode
-		if f := kpr.Features; kpr.Mode != "Disabled" && f != nil {
+		mode = strings.ToLower(kpr.Mode)
+		if f := kpr.Features; f != nil {
 			if f.ExternalIPs != nil {
 				result[features.KPRExternalIPs] = features.Status{Enabled: f.ExternalIPs.Enabled}
 			}
@@ -172,7 +172,7 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 		}
 	}
 	result[features.KPRMode] = features.Status{
-		Enabled: mode != "Disabled",
+		Enabled: mode != "false" && mode != "disabled",
 		Mode:    mode,
 	}
 

--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -286,7 +286,8 @@ func (s *outsideToNodePort) Run(ctx context.Context, t *check.Test) {
 	// With kube-proxy doing N/S LB it is not possible to see the original client
 	// IP, as iptables rules do the LB SNAT/DNAT before the packet hits any
 	// of Cilium's datapath BPF progs. So, skip the flow validation in that case.
-	_, validateFlows := t.Context().Feature(features.KPRNodePort)
+	status, ok := t.Context().Feature(features.KPRNodePort)
+	validateFlows := ok && status.Enabled
 
 	for _, svc := range t.Context().EchoServices() {
 		for _, node := range t.Context().Nodes() {

--- a/hubble/hubble.go
+++ b/hubble/hubble.go
@@ -48,7 +48,7 @@ func EnableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameter
 			fmt.Sprintf("hubble.ui.enabled=%t", params.UI),
 		},
 	}
-	vals, err := helm.MergeVals(options, nil, nil, nil)
+	vals, err := helm.MergeVals(options, nil)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Paramete
 	options := values.Options{
 		Values: []string{"hubble.relay.enabled=false", "hubble.ui.enabled=false"},
 	}
-	vals, err := helm.MergeVals(options, nil, nil, nil)
+	vals, err := helm.MergeVals(options, nil)
 	if err != nil {
 		return err
 	}

--- a/install/azure.go
+++ b/install/azure.go
@@ -9,6 +9,7 @@ import (
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/getter"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type accountInfo struct {
@@ -83,14 +84,8 @@ func (k *K8sInstaller) setAzureResourceGroupFromHelmValue() error {
 	if err != nil {
 		return err
 	}
-	azure, ok := values["azure"].(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	resourceGroupName, ok := azure["resourceGroup"].(string)
-	if !ok {
-		return nil
-	}
+
+	resourceGroupName, _, _ := unstructured.NestedString(values, "azure", "resourceGroup")
 	if resourceGroupName != "" {
 		k.params.Azure.ResourceGroupName = resourceGroupName
 	}

--- a/install/helm.go
+++ b/install/helm.go
@@ -17,7 +17,6 @@ import (
 
 func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 	helmMapOpts := map[string]string{}
-	deprecatedCfgOpts := map[string]string{}
 
 	switch {
 	// It's likely that certain helm options have changed since 1.9.0
@@ -142,11 +141,5 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.SpireAgentScheduleAffinity...)
 	}
 
-	// Store all the options passed by --config into helm extraConfig
-	extraConfigMap := map[string]interface{}{}
-	for k, v := range deprecatedCfgOpts {
-		extraConfigMap[k] = v
-	}
-
-	return helm.MergeVals(k.params.HelmOpts, helmMapOpts, nil, extraConfigMap)
+	return helm.MergeVals(k.params.HelmOpts, helmMapOpts)
 }

--- a/install/helm.go
+++ b/install/helm.go
@@ -19,10 +19,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 	helmMapOpts := map[string]string{}
 
 	switch {
-	// It's likely that certain helm options have changed since 1.9.0
-	// These were tested for the >=1.11.0. In case something breaks for versions
-	// older than 1.11.0 we will fix it afterwards.
-	case versioncheck.MustCompile(">=1.9.0")(k.chartVersion):
+	case versioncheck.MustCompile(">=1.12.0")(k.chartVersion):
 		// TODO(aanm) to keep the previous behavior unchanged we will set the number
 		// of the operator replicas to 1. Ideally this should be the default in the helm chart
 		helmMapOpts["operator.replicas"] = "1"
@@ -91,25 +88,13 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 				// Can be removed once we drop support for <1.14.0
 				helmMapOpts["tunnel"] = tunnelDisabled
 			}
-			switch {
-			case versioncheck.MustCompile(">=1.10.0")(k.chartVersion):
-				helmMapOpts["bpf.masquerade"] = "false"
-				helmMapOpts["enableIPv4Masquerade"] = "false"
-				helmMapOpts["enableIPv6Masquerade"] = "false"
-			case versioncheck.MustCompile(">=1.9.0")(k.chartVersion):
-				helmMapOpts["masquerade"] = "false"
-			}
+
+			helmMapOpts["bpf.masquerade"] = "false"
+			helmMapOpts["enableIPv4Masquerade"] = "false"
+			helmMapOpts["enableIPv6Masquerade"] = "false"
 
 		case DatapathAKSBYOCNI:
-			switch {
-			case versioncheck.MustCompile(">=1.12.0")(k.chartVersion):
-				helmMapOpts["aksbyocni.enabled"] = "true"
-			case versioncheck.MustCompile(">=1.9.0")(k.chartVersion):
-				// Manually configure the same ConfigMap options as the new
-				// `aksbyocni` mode does, so that it works transparently.
-				helmMapOpts["ipam.mode"] = ipamClusterPool
-				helmMapOpts["tunnel"] = tunnelVxlan
-			}
+			helmMapOpts["aksbyocni.enabled"] = "true"
 		}
 
 		if k.params.ClusterName != "" {
@@ -119,14 +104,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 		// TODO: remove when removing "ipv4-native-routing-cidr" flag (marked as
 		// deprecated), kept for backwards compatibility
 		if k.params.IPv4NativeRoutingCIDR != "" {
-			// NOTE: Cilium v1.11 replaced --native-routing-cidr by
-			// --ipv4-native-routing-cidr
-			switch {
-			case versioncheck.MustCompile(">=1.11.0")(k.chartVersion):
-				helmMapOpts["ipv4NativeRoutingCIDR"] = k.params.IPv4NativeRoutingCIDR
-			case versioncheck.MustCompile(">=1.9.0")(k.chartVersion):
-				helmMapOpts["nativeRoutingCIDR"] = k.params.IPv4NativeRoutingCIDR
-			}
+			helmMapOpts["ipv4NativeRoutingCIDR"] = k.params.IPv4NativeRoutingCIDR
 		}
 
 	default:

--- a/install/install.go
+++ b/install/install.go
@@ -18,6 +18,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
@@ -176,14 +177,7 @@ func (k *K8sInstaller) listVersions() error {
 }
 
 func getChainingMode(values map[string]interface{}) string {
-	cni, ok := values["cni"].(map[string]interface{})
-	if !ok {
-		return ""
-	}
-	chainingMode, ok := cni["chainingMode"].(string)
-	if !ok {
-		return ""
-	}
+	chainingMode, _, _ := unstructured.NestedString(values, "cni", "chainingMode")
 	return chainingMode
 }
 

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -23,7 +23,6 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
-	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
@@ -132,17 +131,13 @@ func ciliumCacheDir() (string, error) {
 	return res, nil
 }
 
-// MergeVals merges all values from flag options ('helmFlagOpts'),
+// MergeVals merges all values from flag options ('helmFlagOpts') and
 // auto-generated helm options based on environment ('helmMapOpts'),
-// helm values from a previous installation ('helmValues'),
-// extra options that are not defined as helm flags ('extraConfigMapOpts')
 // and returns a single map with all of these options merged.
-// Both 'helmMapOpts', 'helmValues', 'extraConfigMapOpts', can be nil.
+// 'helmMapOpts' can be nil.
 func MergeVals(
 	helmFlagOpts values.Options,
 	helmMapOpts map[string]string,
-	helmValues,
-	extraConfigMapOpts chartutil.Values,
 ) (map[string]interface{}, error) {
 
 	// Create helm values from helmMapOpts
@@ -153,9 +148,7 @@ func MergeVals(
 
 	helmOptsStr := strings.Join(helmOpts, ",")
 
-	if helmValues == nil {
-		helmValues = map[string]interface{}{}
-	}
+	helmValues := map[string]interface{}{}
 	err := strvals.ParseInto(helmOptsStr, helmValues)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing helm options %q: %w", helmOptsStr, err)
@@ -169,19 +162,7 @@ func MergeVals(
 	}
 
 	// User-defined helm options will overwrite the default cilium-cli helm options
-	userVals = mergeMaps(helmValues, userVals)
-
-	// Merge the user-defined helm options into the `--config` map. This
-	// effectively means that any --set=extraConfig.<key> will overwrite
-	// the values of --config <key>
-	extraConfig := map[string]interface{}{}
-	if len(extraConfigMapOpts) != 0 {
-		extraConfig["extraConfig"] = extraConfigMapOpts
-	}
-
-	vals := mergeMaps(extraConfig, userVals)
-
-	return vals, nil
+	return mergeMaps(helmValues, userVals), nil
 }
 
 // ParseVals takes a slice of Helm values of the form


### PR DESCRIPTION
Please review commit by commit, and refer to the individual messages for additional details.

* Remove unused fields/parameters from the `getHelmValues` logic;
* Drop support for EOL Cilium v1.11 and earlier in helm values generation;  
* Drop broken `bpf.masquerade` autodetection logic;
* Fix retrieval of the user-configured routing mode, and uniform retrieval of nested helm value;
* Improve KPR autodetection logic to not override user configuration, and not configure deprecated values;
* Fix KPR probing in connectivity tests to account for both legacy and current values.
* Replace the remaining references to deprecated KPR settings in GHA workflows.