### PR TITLE
Store namespace and k8sClient in the command context

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"context"
+
+	"github.com/cilium/cilium-cli/k8s"
+)
+
+// key is a context.Context value key type. It's unexported to avoid key collisions.
+type key int
+
+const (
+	namespaceKey key = iota
+	k8sClientKey
+)
+
+// SetNamespaceContextValue stores a namespace string as a context value and
+// returns the resulting context. You can access the namespace by calling
+// GetNamespaceContextValue.
+func SetNamespaceContextValue(ctx context.Context, namespace string) context.Context {
+	return context.WithValue(ctx, namespaceKey, namespace)
+}
+
+// SetK8sClientContextValue stores a namespace string as a context value and
+// returns the resulting context. You can access the namespace by calling
+// GetK8sClientContextValue.
+func SetK8sClientContextValue(ctx context.Context, client *k8s.Client) context.Context {
+	return context.WithValue(ctx, k8sClientKey, client)
+}
+
+// GetNamespaceContextValue retrieves the namespace from a context that was
+// stored by SetNamespaceContextValue.
+func GetNamespaceContextValue(ctx context.Context) (string, bool) {
+	namespace, ok := ctx.Value(namespaceKey).(string)
+	return namespace, ok
+}
+
+// GetK8sClientContextValue retrieves the k8s.Client from a context that was
+// stored by SetK8sClientContextValue.
+func GetK8sClientContextValue(ctx context.Context) (*k8s.Client, bool) {
+	client, ok := ctx.Value(k8sClientKey).(*k8s.Client)
+	return client, ok
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium-cli/k8s"
+)
+
+func TestNamespaceContextValues(t *testing.T) {
+	ctx := context.Background()
+	namespace := "mynamespace"
+	ctx = SetNamespaceContextValue(ctx, namespace)
+	result, ok := GetNamespaceContextValue(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, namespace, result)
+}
+
+func TestK8sClientContextValues(t *testing.T) {
+	ctx := context.Background()
+	k8sClient, err := k8s.NewClient("", "", "")
+	assert.NoError(t, err)
+	ctx = SetK8sClientContextValue(ctx, k8sClient)
+	result, ok := GetK8sClientContextValue(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, k8sClient, result)
+}

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/cilium/cilium-cli/api"
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium-cli/sysdump"
@@ -47,6 +48,9 @@ func NewCiliumCommand(hooks Hooks) *cobra.Command {
 			}
 
 			k8sClient = c
+			ctx := api.SetNamespaceContextValue(context.Background(), namespace)
+			ctx = api.SetK8sClientContextValue(ctx, k8sClient)
+			cmd.SetContext(ctx)
 			return nil
 		},
 		Run: func(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
Store namespace and k8sClient as command context values so that the connectivity package can access them from outside the cli package once it moves to cilium/cilium repo.

Ref: cilium/design-cfps#9