### PR TITLE
ingress: Update backend service for Ingress

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -366,7 +366,7 @@ func newIngress() *networkingv1.Ingress {
 									}(),
 									Backend: networkingv1.IngressBackend{
 										Service: &networkingv1.IngressServiceBackend{
-											Name: echoOtherNodeDeploymentName,
+											Name: echoSameNodeDeploymentName,
 											Port: networkingv1.ServiceBackendPort{
 												Number: 8080,
 											},


### PR DESCRIPTION
This is to use echo-same-node instead of echo-other-node, which is only available for multi-node cluster. The reason is mainly for local development, no impact on CI.