### PR TITLE
BPF Masquerade test

### DIFF
--- a/Dockerfile.echo
+++ b/Dockerfile.echo
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+ADD ./echoserver /echoserver
+
+CMD /echoserver

--- a/Makefile
+++ b/Makefile
@@ -99,4 +99,11 @@ check:
 	docker run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION) golangci-lint run
 endif
 
-.PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags
+echoserver:
+	GOOS=linux $(GO_BUILD) -o echoserver ./echoserver
+	docker build  -f Dockerfile.echo -t quay.io/cilium/echoserver:$(VERSION) .
+
+kind-image-echoserver: echoserver
+	kind load docker-image quay.io/cilium/echoserver:$(VERSION)
+
+.PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags echoserver

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -847,7 +847,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					Port:           containerPort,
 					NamedPort:      "http-8080",
 					HostPort:       8080,
-					Image:          ct.params.JSONMockImage,
+					Image:          "echoserver",
 					Labels:         map[string]string{"external": "echo"},
 					Annotations:    ct.params.DeploymentAnnotations.Match(echoExternalNodeDeploymentName),
 					NodeSelector:   map[string]string{"cilium.io/no-schedule": "true"},

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -824,6 +824,18 @@ func Run(ctx context.Context, ct *check.ConnectivityTest, extra Hooks) error {
 			)
 	}
 
+	//if ct.Params().IncludeUnsafeTests {
+	ct.NewTest("bpf-masquerade").
+		WithFeatureRequirements(
+			features.RequireEnabled(features.EnableMasquerade),
+			features.RequireEnabled(features.HostPort),
+			features.RequireEnabled(features.NodeWithoutCilium)).
+		WithScenarios(tests.BPFMasquerade()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultOK
+		})
+	//}
+
 	if versioncheck.MustCompile(">=1.14.0")(ct.CiliumVersion) {
 		ct.NewTest("egress-gateway-excluded-cidrs").
 			WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{

--- a/connectivity/tests/bpf_masq.go
+++ b/connectivity/tests/bpf_masq.go
@@ -1,0 +1,87 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
+	v1 "k8s.io/api/core/v1"
+)
+
+func BPFMasquerade() check.Scenario {
+	return &bpfMasquerade{}
+}
+
+type bpfMasquerade struct{}
+
+func (s *bpfMasquerade) Name() string {
+	return "bpf-masquerade"
+}
+
+func (s *bpfMasquerade) Run(ctx context.Context, t *check.Test) {
+	var i int
+	ct := t.Context()
+
+	for _, client := range ct.ClientPods() {
+		client := client // copy to avoid memory aliasing when using reference
+
+		for _, echo := range ct.ExternalEchoPods() {
+			echo := echo // copy to avoid memory aliasing when using reference
+			if !echo.Pod.Spec.HostNetwork {
+				continue
+			}
+
+			baseURL := fmt.Sprintf("%s://%s:%d/echo", echo.Scheme(), echo.Pod.Status.HostIP, 8080)
+			ep := check.HTTPEndpoint(echo.Name(), baseURL)
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, ep, features.IPFamilyAny).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommandWithOutput(ep, features.IPFamilyAny))
+				out := a.CmdOutput()
+				m := map[string]any{}
+				if err := json.Unmarshal([]byte(out), &m); err != nil {
+					a.Fail(err)
+					return
+				}
+
+				remote, ok := m["remote_ip"]
+				if !ok {
+					a.Failf("echo response did not contain remote addr: %s", out)
+				}
+
+				var nodeaddr string
+				node := ct.Nodes()[client.NodeName()]
+				for _, addr := range node.Status.Addresses {
+					if addr.Type == v1.NodeInternalIP {
+						ip := net.ParseIP(addr.Address)
+						if ip == nil {
+							continue
+						}
+						// todo: ipv6...
+						if ip.To4() != nil {
+							nodeaddr = addr.Address
+							break
+						}
+					}
+				}
+
+				remoteip := strings.Split(remote.(string), ":")[0]
+
+				if remoteip != nodeaddr {
+					a.Failf("request traffic should have been masqueraded: remote=%s nodeaddr=%s", remote, nodeaddr)
+				}
+				/*a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
+					// Because the HostPort request is NATed, we might only
+					// observe flows after DNAT has been applied (e.g. by
+					// HostReachableServices),
+					AltDstIP:   echo.Address(features.IPFamilyAny),
+					AltDstPort: echo.Port(),
+				}))*/
+			})
+
+			//i++
+		}
+	}
+}

--- a/echoserver/main.go
+++ b/echoserver/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	// Define the routes
+	mux.HandleFunc("/public", loggingMiddleware(publicHandler))
+	mux.HandleFunc("/", loggingMiddleware(indexHandler))
+	mux.HandleFunc("/private", loggingMiddleware(privateHandler))
+	mux.HandleFunc("/echo", loggingMiddleware(echoHandler))
+
+	// Start the HTTP server on port 8080
+	port := 8080
+	logrus.Infof("Server is running on :%d", port)
+	s := &http.Server{
+		Handler: mux,
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			logrus.Infof("conn context: %v <> %v", c.RemoteAddr(), c.LocalAddr())
+			return ctx
+		},
+		Addr: fmt.Sprintf(":%d", port),
+	}
+	err := s.ListenAndServe()
+	if err != nil {
+		log.Fatalf("Error starting server: %v", err)
+	}
+}
+
+func loggingMiddleware(fn http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logrus.WithFields(logrus.Fields{
+			"remote_addr": r.RemoteAddr,
+			"path":        r.URL.Path,
+			"headers":     r.Header,
+		}).Info("handling request")
+		fn(w, r)
+	})
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Index!\n")
+}
+
+func publicHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "This is a public route\n")
+}
+
+func privateHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "This is a private route\n")
+}
+
+func echoHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, `{"remote_ip": "%s", "time": "%s"}`, r.RemoteAddr, time.Now().Format(time.RFC3339))
+}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -44,6 +44,7 @@ var params = check.Parameters{
 		LargeSysdumpAbortTimeout: sysdump.DefaultLargeSysdumpAbortTimeout,
 		LargeSysdumpThreshold:    sysdump.DefaultLargeSysdumpThreshold,
 		Writer:                   os.Stdout,
+		CiliumTestEnabled:        true,
 	},
 }
 
@@ -52,6 +53,7 @@ var tests []string
 func RunE(hooks Hooks) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
 		params.CiliumNamespace = namespace
+		params.SysdumpOptions.CiliumTestNamespace = params.TestNamespace
 
 		for _, test := range tests {
 			if strings.HasPrefix(test, "!") {

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -59,7 +59,12 @@ const (
 	IngressController Feature = "ingress-controller"
 
 	EgressGateway Feature = "enable-ipv4-egress-gateway"
-	GatewayAPI    Feature = "enable-gateway-api"
+
+	BPFMasquerade Feature = "bpf-masquerade"
+
+	EnableMasquerade Feature = "enable-masquerade"
+
+	GatewayAPI Feature = "enable-gateway-api"
 
 	EnableEnvoyConfig Feature = "enable-envoy-config"
 
@@ -255,6 +260,14 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[EgressGateway] = Status{
 		Enabled: cm.Data["enable-ipv4-egress-gateway"] == "true",
+	}
+
+	fs[BPFMasquerade] = Status{
+		Enabled: cm.Data["enable-bpf-masquerade"] == "true",
+	}
+
+	fs[EnableMasquerade] = Status{
+		Enabled: cm.Data["enable-ipv4-masquerade"] == "true" || cm.Data["enable-ipv6-masquerade"] == "true",
 	}
 
 	fs[CIDRMatchNodes] = Status{


### PR DESCRIPTION
Adds test coverage for bpf-masquerade (as well as any other IP masquerading mode) via connectivity tests. Currently this is done via Ginkgo runtime tests in cilium/cilium.

To accommodate this, and to improve overall test debugging this also replaces the normal json-mock based echo server implementation, used by connectivity tests, with a Go based implementation.

Currently, the node based json-mock server is used for creating test servers for running various tests.
Unfortunately this has some shortcomings, namely:

* Mock image is built outside of CLI repo thus making it difficult to make changes to.
* JSON Mock is designed to provide a server that returns some static schema of data. Cilium connectivity tests don't really this functionality, (we only really need to define some extra http routes to test route based policy). Instead a more flexible implementation would make it easier to adapt to future use cases.
* JSON Mock doesn't log on the index server as it's not really part of the schema. Better logging from the servers would be useful for diagosing test l7 failures/flakes (ex. https://github.com/cilium/cilium/issues/27762) as it would let us correlate timestamped events on the server side.

This adds a new standalone server called "echoserver" which is a small Go http server with the following routes:

GET / -> Index route, used for general l4/l7 connectivity testing.
GET /private -> Private route, used for l7 network policy.
GET /public -> Private route, used for l7 network policy.
GET /echo -> Responds with a json payload the remote address (i.e. <ip>:<client_port>) and timestamp.

These routes will cover existing test cases, with the latter being used to implement a bpf masquerade connectivity test.