### PR TITLE
cleanup: Avoid using deprecated KPR values

### DIFF
--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -9,7 +9,7 @@ cilium install \
   --set cluster.name="${CLUSTER_NAME}" \
   --set bpf.monitorAggregation=none \
   --datapath-mode=tunnel \
-  --set kubeProxyReplacement=strict \
+  --set kubeProxyReplacement=true \
   --set loadBalancer.l7.backend=envoy \
   --set tls.secretsBackend=k8s \
   --set ipv4NativeRoutingCIDR="${CLUSTER_CIDR}"

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -141,7 +141,7 @@ jobs:
           --nodes-without-cilium="${NODES_WITHOUT_CILIUM}" \
           --set encryption.enabled=true \
           --set encryption.type=ipsec \
-          --set kubeProxyReplacement=disabled
+          --set kubeProxyReplacement=false
 
       - name: Enable Relay
         run: |


### PR DESCRIPTION
This commit is to make sure that we don't use KPR deprecated values (e.g. partial, probe, strict, disabled) in favour of just 'true' and 'false'.

Relates: https://github.com/cilium/cilium/pull/31286