### PR TITLE
connectivity: collect sysdump from all clusters on failure

### DIFF
--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -878,14 +878,16 @@ func (t *Test) EgressGatewayNode() string {
 }
 
 func (t *Test) collectSysdump() {
-	collector, err := sysdump.NewCollector(t.ctx.K8sClient(), t.ctx.params.SysdumpOptions, time.Now(), t.ctx.version)
-	if err != nil {
-		t.Failf("Failed to create sysdump collector: %v", err)
-		return
-	}
+	for _, client := range t.ctx.Clients() {
+		collector, err := sysdump.NewCollector(client, t.ctx.params.SysdumpOptions, time.Now(), t.ctx.version)
+		if err != nil {
+			t.Failf("Failed to create sysdump collector: %v", err)
+			return
+		}
 
-	if err = collector.Run(); err != nil {
-		t.Failf("Failed to collect sysdump: %v", err)
+		if err = collector.Run(); err != nil {
+			t.Failf("Failed to collect sysdump: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Collect a sysdump from both clusters on failures when the connectivity suite is run in multi cluster mode, and the --collect-sysdump-on-failure is set, so that it is easier to troubleshoot possible failures.