### PR TITLE
Add InitializeCommand hook

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -97,6 +97,7 @@ cilium connectivity test`,
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
+	hooks.InitializeCommand(cmd)
 	return cmd
 }
 
@@ -114,3 +115,4 @@ func (*NopHooks) AddConnectivityTestFlags(*pflag.FlagSet)                       
 func (*NopHooks) AddConnectivityTests(*check.ConnectivityTest) error              { return nil }
 func (*NopHooks) DetectFeatures(context.Context, *check.ConnectivityTest) error   { return nil }
 func (*NopHooks) SetupAndValidate(context.Context, *check.ConnectivityTest) error { return nil }
+func (*NopHooks) InitializeCommand(*cobra.Command)                                {}

--- a/cli/cmd_test.go
+++ b/cli/cmd_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+const usage = "override usage"
+
+type testHooks struct {
+	NopHooks
+}
+
+func (th *testHooks) InitializeCommand(rootCmd *cobra.Command) {
+	rootCmd.Use = usage
+}
+
+func TestInitializeCommandHook(t *testing.T) {
+	cmd := NewCiliumCommand(&testHooks{})
+	assert.Equal(t, usage, cmd.Use)
+}

--- a/cli/hooks.go
+++ b/cli/hooks.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium-cli/connectivity"
@@ -14,6 +15,9 @@ import (
 type Hooks interface {
 	ConnectivityTestHooks
 	sysdump.Hooks
+	// InitializeCommand gets called with the root command before returning it
+	// from cli.NewCiliumCommand.
+	InitializeCommand(rootCmd *cobra.Command)
 }
 
 // ConnectivityTestHooks to extend cilium-cli with additional connectivity tests and related flags.


### PR DESCRIPTION
Call InitializeCommand hook with the root command before returning from cli.NewCiliumCommand.