### PR TITLE
renovate: Don't pick up new Go patch versions in go.mod

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -81,6 +81,25 @@
       ],
     },
     {
+      // Avoid updating patch releases of golang in go.mod
+      "enabled": "false",
+      "matchFiles": [
+        "go.mod",
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      matchBaseBranches: [
+        "main",
+      ]
+    },
+    {
       "enabled": false,
       "matchPackageNames": [
         // All of these packages are maintained on a Cilium fork. Thus, we don't
@@ -191,6 +210,14 @@
         "\/\/ renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\"",
         "\/\/ renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+Version = \"(?<currentValue>.*)\""
       ]
-    }
+    },
+    {
+      "fileMatch": [
+        "^go\\.mod$"
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)"
+      ]
+    },
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium-cli
 
-go 1.22.1
+go 1.22.0
 
 // Replace directives from github.com/cilium/cilium. Keep in sync when updating Cilium!
 replace (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/cilium/cilium-cli
 
+// renovate: datasource=golang-version depName=go
 go 1.22.0
 
 // Replace directives from github.com/cilium/cilium. Keep in sync when updating Cilium!


### PR DESCRIPTION
Let's not pick up new Go patch versions in go.mod to be consistent with cilium/cilium. https://github.com/cilium/cilium/pull/28686 has more context about the rationale.