### PR TITLE
connectivity: Extend pod-to-pod encryption tests (for WG)

### DIFF
--- a/connectivity/builder/manifests/client-egress-l7-http-from-any.yaml
+++ b/connectivity/builder/manifests/client-egress-l7-http-from-any.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-l7-http-from-any
+spec:
+  description: "Allow client to GET on echo"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        kind: echo
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/$"

--- a/connectivity/builder/pod_to_pod_encryption.go
+++ b/connectivity/builder/pod_to_pod_encryption.go
@@ -4,10 +4,15 @@
 package builder
 
 import (
+	_ "embed"
+
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium-cli/utils/features"
 )
+
+//go:embed manifests/client-egress-l7-http-from-any.yaml
+var clientsEgressL7HTTPFromAnyPolicyYAML string
 
 type podToPodEncryption struct{}
 
@@ -19,4 +24,19 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithScenarios(
 			tests.PodToPodEncryption(features.RequireEnabled(features.EncryptionPod)),
 		)
+
+	newTest("pod-to-pod-with-l7-policy-encryption", ct).
+		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.L7Proxy),
+			// Once https://github.com/cilium/cilium/issues/33168 is fixed, we
+			// can enable for IPsec too.
+			features.RequireMode(features.EncryptionPod, "wireguard"),
+		).
+		WithCiliumPolicy(clientsEgressL7HTTPFromAnyPolicyYAML).
+		WithCiliumPolicy(echoIngressL7HTTPFromAnywherePolicyYAML).
+		WithScenarios(
+			tests.PodToPodEncryption(features.RequireEnabled(features.EncryptionPod)),
+		)
+
 }


### PR DESCRIPTION
CI run https://github.com/cilium/cilium/pull/32995. Only for WG (see https://github.com/cilium/cilium/issues/33168 for IPsec issues).