### PR TITLE
gha: increase Multicluster timeout

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Wait for test job
         env:
-          timeout: 30m
+          timeout: 60m
         run: |
           # Background wait for job to complete or timeout
           kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &


### PR DESCRIPTION
Recently the Multicluster workflow started to timeout pretty often.
Try to increase the timeout and see if the problem re-appears.