### PR TITLE
Revert "helm: uniform retrieval of nested helm value"

### DIFF
--- a/install/azure.go
+++ b/install/azure.go
@@ -9,7 +9,6 @@ import (
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/getter"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type accountInfo struct {
@@ -84,8 +83,14 @@ func (k *K8sInstaller) setAzureResourceGroupFromHelmValue() error {
 	if err != nil {
 		return err
 	}
-
-	resourceGroupName, _, _ := unstructured.NestedString(values, "azure", "resourceGroup")
+	azure, ok := values["azure"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	resourceGroupName, ok := azure["resourceGroup"].(string)
+	if !ok {
+		return nil
+	}
 	if resourceGroupName != "" {
 		k.params.Azure.ResourceGroupName = resourceGroupName
 	}

--- a/install/install.go
+++ b/install/install.go
@@ -18,7 +18,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
@@ -177,7 +176,14 @@ func (k *K8sInstaller) listVersions() error {
 }
 
 func getChainingMode(values map[string]interface{}) string {
-	chainingMode, _, _ := unstructured.NestedString(values, "cni", "chainingMode")
+	cni, ok := values["cni"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	chainingMode, ok := cni["chainingMode"].(string)
+	if !ok {
+		return ""
+	}
 	return chainingMode
 }
 


### PR DESCRIPTION
This reverts commit 9f61556e6be584ee67e16fb96d1a02f1376e61c4.

This commit seems to be causing no-ipsec-xfrm-errors in ci-ipsec-upgrade to fail in cilium/cilium main branch [^1].

[^1]: cilium/cilium#31386