### PR TITLE
Explicitly configure the "nodes without cilium" affinity on both initial installation and subsequent upgrades 

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -58,17 +58,12 @@ jobs:
           config: ${{ env.kind_config }}
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
-      - name: Set NODES_WITHOUT_CILIUM
-        run: |
-          # To add more elements, keep it comma-separated.
-          echo "NODES_WITHOUT_CILIUM=chart-testing-worker2,chart-testing-worker3" >> $GITHUB_ENV
-
       # Install Cilium with HostPort support and enables Prometheus for extended connectivity test.
       - name: Install Cilium
         run: |
           cilium install \
             --version=${{ env.cilium_version }} \
-            --nodes-without-cilium="${NODES_WITHOUT_CILIUM}" \
+            --nodes-without-cilium \
             --wait=false \
             --set bpf.monitorAggregation=none \
             --set cni.chainingMode=portmap \
@@ -138,7 +133,7 @@ jobs:
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
           cilium install \
           --version=${{ env.cilium_version}} \
-          --nodes-without-cilium="${NODES_WITHOUT_CILIUM}" \
+          --nodes-without-cilium \
           --set encryption.enabled=true \
           --set encryption.type=ipsec \
           --set kubeProxyReplacement=false
@@ -250,7 +245,7 @@ jobs:
             --set cni.chainingMode=portmap \
             --set cluster.id=1 \
             --set cluster.name=$CLUSTER1 \
-            --nodes-without-cilium=${{ env.CLUSTER_NAME_1 }}-worker2
+            --nodes-without-cilium
 
       - name: Create kind cluster 2
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0

--- a/cli/install.go
+++ b/cli/install.go
@@ -26,7 +26,7 @@ func addCommonInstallFlags(cmd *cobra.Command, params *install.Parameters) {
 	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use { tunnel | native | aws-eni | gke | azure | aks-byocni } (default: autodetected).")
 	cmd.Flags().BoolVar(&params.ListVersions, "list-versions", false, "List all the available versions without actually installing")
-	cmd.Flags().StringSliceVar(&params.NodesWithoutCilium, "nodes-without-cilium", []string{}, "List of node names on which Cilium will not be installed. In Helm installation mode, it's assumed that the no-schedule node labels are present and that the infrastructure has set up routing on these nodes to provide connectivity within the Cilium cluster.")
+	cmd.Flags().BoolVar(&params.NodesWithoutCilium, "nodes-without-cilium", false, "Configure the affinities to avoid scheduling Cilium components on nodes labeled with cilium.io/no-schedule. It is assumed that the infrastructure has set up routing on these nodes to provide connectivity within the Cilium cluster.")
 }
 
 // addCommonUninstallFlags adds uninstall command flags that are shared between classic and helm mode.

--- a/install/helm.go
+++ b/install/helm.go
@@ -8,7 +8,6 @@ package install
 import (
 	"fmt"
 
-	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/internal/helm"
 	"github.com/cilium/cilium-cli/k8s"
 
@@ -109,14 +108,6 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 
 	default:
 		return nil, fmt.Errorf("cilium version unsupported %s", k.chartVersion)
-	}
-
-	// Set affinity to prevent Cilium from being scheduled on nodes labeled with
-	// "cilium.io/no-schedule=true"
-	if len(k.params.NodesWithoutCilium) != 0 {
-		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumScheduleAffinity...)
-		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumOperatorScheduleAffinity...)
-		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.SpireAgentScheduleAffinity...)
 	}
 
 	return helm.MergeVals(k.params.HelmOpts, helmMapOpts)

--- a/install/install.go
+++ b/install/install.go
@@ -230,6 +230,14 @@ func (k *K8sInstaller) preinstall(ctx context.Context) error {
 		}
 	}
 
+	// Set affinity to prevent Cilium from being scheduled on nodes labeled with
+	// "cilium.io/no-schedule=true"
+	if len(k.params.NodesWithoutCilium) != 0 {
+		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumScheduleAffinity...)
+		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumOperatorScheduleAffinity...)
+		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.SpireAgentScheduleAffinity...)
+	}
+
 	return nil
 }
 

--- a/install/install.go
+++ b/install/install.go
@@ -117,8 +117,8 @@ type Parameters struct {
 	// ListVersions lists all the available versions for install without actually installing.
 	ListVersions bool
 
-	// NodesWithoutCilium lists all nodes on which Cilium is not installed.
-	NodesWithoutCilium []string
+	// NodesWithoutCilium enables the affinities to avoid scheduling Cilium components on nodes labeled with cilium.io/no-schedule
+	NodesWithoutCilium bool
 
 	// DryRun writes resources to be installed to stdout without actually installing them. For Helm
 	// installation mode only.
@@ -232,7 +232,7 @@ func (k *K8sInstaller) preinstall(ctx context.Context) error {
 
 	// Set affinity to prevent Cilium from being scheduled on nodes labeled with
 	// "cilium.io/no-schedule=true"
-	if len(k.params.NodesWithoutCilium) != 0 {
+	if k.params.NodesWithoutCilium {
 		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumScheduleAffinity...)
 		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.CiliumOperatorScheduleAffinity...)
 		k.params.HelmOpts.StringValues = append(k.params.HelmOpts.StringValues, defaults.SpireAgentScheduleAffinity...)


### PR DESCRIPTION
Explicitly configure the appropriate affinities to not schedule Cilium components on the nodes labeled as `cilium.io/no-schedule` during the preinstall phase, which is executed both during the initial installation and on subsequent upgrades. This change removes the side-effect from the getHelmValues method, which is no longer executed on upgrade after a recent refactoring. Additionally, let's convert the `--nodes-without-cilium` flag to boolean, as the values are always ignored.