### PR TITLE
connectivity: enable IPv6 ns-lb-with-l7-policy on recent 1.13 release

### DIFF
--- a/connectivity/tests/service.go
+++ b/connectivity/tests/service.go
@@ -238,9 +238,9 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 				}
 			}
 
-			//  Skip IPv6 requests when running on <1.14.0 Cilium with CNPs
+			//  Skip IPv6 requests when running on <1.13.13 Cilium with CNPs
 			if features.GetIPFamily(addr.Address) == features.IPFamilyV6 &&
-				versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) &&
+				versioncheck.MustCompile("<1.13.13")(t.Context().CiliumVersion) &&
 				(len(t.CiliumNetworkPolicies()) > 0 || len(t.KubernetesNetworkPolicies()) > 0) {
 				continue
 			}


### PR DESCRIPTION
https://github.com/cilium/cilium-cli/pull/1629 initially limited the IPv6 test to v1.14, as v1.13 was missing some functionality.

But now that v1.13 has https://github.com/cilium/cilium/pull/31161, the IPv6 path should actually work. So let's extend the test coverage.