### PR TITLE
tests: Add exceptions for error logs check

### DIFF
--- a/connectivity/tests/errors.go
+++ b/connectivity/tests/errors.go
@@ -26,7 +26,10 @@ import (
 func NoErrorsInLogs(ciliumVersion semver.Version) check.Scenario {
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	errorLogExceptions := []string{"Error in delegate stream, restarting", failedToListCRDs, removeInexistentID}
+	errorLogExceptions := []string{
+		"Error in delegate stream, restarting",
+		failedToUpdateLock, failedToReleaseLock,
+		failedToListCRDs, removeInexistentID}
 	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
 		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
@@ -243,7 +246,9 @@ const (
 	localIDRestoreFail     = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
 	routerIPMismatch       = "Mismatch of router IPs found during restoration"
 	emptyIPNodeIDAlloc     = "Attempt to allocate a node ID for an empty node IP address"
-	failedToListCRDs       = "the server could not find the requested resource"                          // cf. https://github.com/cilium/cilium/issues/16425
+	failedToListCRDs       = "the server could not find the requested resource" // cf. https://github.com/cilium/cilium/issues/16425
+	failedToUpdateLock     = "Failed to update lock:"
+	failedToReleaseLock    = "Failed to release lock:"
 	previouslyUsedCIDR     = "Unable to find identity of previously used CIDR"                           // from https://github.com/cilium/cilium/issues/26881
 	klogLeaderElectionFail = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
 )


### PR DESCRIPTION
Add "Failed to update lock:" and "Failed to release lock:" to log level error excpetions, as these errors originate from vendored code and we can not silence them otherwise. This prevents CI flake like this:

  ❌ Found 1 logs in kind-kind/kube-system/cilium-operator-799cff46cd-n2lfz (cilium-operator) matching list of errors that must be investigated:
level=error msg="Failed to update lock: Operation cannot be fulfilled on leases.coordination.k8s.io \"cilium-operator-resource-lock\": the object has been modified; please apply your changes to the latest version and try again" subsys=klog (1 occurrences)