### PR TITLE
connectivity: don't hard-code ingress service NodePorts

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -64,9 +64,7 @@ const (
 
 	EchoServerHostPort = 4000
 
-	IngressServiceName         = "ingress-service"
-	ingressServiceInsecurePort = "31000"
-	ingressServiceSecurePort   = "31001"
+	IngressServiceName = "ingress-service"
 )
 
 type deploymentParameters struct {
@@ -343,10 +341,8 @@ func newIngress() *networkingv1.Ingress {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: IngressServiceName,
 			Annotations: map[string]string{
-				"ingress.cilium.io/loadbalancer-mode":  "dedicated",
-				"ingress.cilium.io/service-type":       "NodePort",
-				"ingress.cilium.io/insecure-node-port": ingressServiceInsecurePort,
-				"ingress.cilium.io/secure-node-port":   ingressServiceSecurePort,
+				"ingress.cilium.io/loadbalancer-mode": "dedicated",
+				"ingress.cilium.io/service-type":      "NodePort",
 			},
 		},
 		Spec: networkingv1.IngressSpec{


### PR DESCRIPTION
Let's prevent possible conflicts if the given NodePorts are already allocated, as well as headaches to create multiple ingresses.