### PR TITLE
Ignore "Unsupported L2 protocol" to known drops

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -138,6 +138,7 @@ var (
 	ExpectedDropReasons = []string{
 		"Policy denied",
 		"Policy denied by denylist",
+		"Unsupported L2 protocol",
 		"Unsupported L3 protocol",
 		"Stale or unroutable IP",
 		"Authentication required",


### PR DESCRIPTION
The connectivity tests sometimes runs into "Unsupported L2 protocol" drops for issues unrelated to Cilium. Ignore those as it otherwise just adds noise.