### PR TITLE
Include Makefile.override if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,5 @@ check:
 endif
 
 .PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags
+
+-include Makefile.override


### PR DESCRIPTION
Include Makefile.override if the file exists to allow overriding Make variables without modifying Makefile. Copied from cilium/cilium#26159.