### PR TITLE
errors: add [no-error-logs] exception for issue caused by fqdn bug.

### DIFF
--- a/connectivity/tests/errors.go
+++ b/connectivity/tests/errors.go
@@ -48,7 +48,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version) check.Scenario {
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, removeInexistentID}
+		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision}
 	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
 		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
@@ -276,4 +276,12 @@ const (
 	previouslyUsedCIDR     stringMatcher = "Unable to find identity of previously used CIDR"                           // from https://github.com/cilium/cilium/issues/26881
 	klogLeaderElectionFail stringMatcher = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
 
+)
+
+var (
+	// knownBugWireguardCollision is for a known issue: https://github.com/cilium/cilium/issues/31535.
+	// In spite of this occurrence, fqdn connectivity tests still pass thus it should be ok to ignore these for a while
+	// while we fix this issue.
+	// TODO: Remove this after: #31535 has been fixed.
+	knownIssueWireguardCollision = regexMatcher{regexp.MustCompile("Cannot forward proxied DNS lookup.*:51871.*bind: address already in use")} // from: https://github.com/cilium/cilium/issues/30901
 )

--- a/connectivity/tests/errors_test.go
+++ b/connectivity/tests/errors_test.go
@@ -7,7 +7,25 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestErrorExceptionMatching(t *testing.T) {
+	s := NoErrorsInLogs(semver.MustParse("1.15.0")).(*noErrorsInLogs)
+	fails := s.findUniqueFailures(
+		`level=error msg="Cannot forward proxied DNS lookup" DNSRequestID=11649 dnsName=google.com.cluster.local. endpointID=3911 error="failed to dial connection to 10.242.1.245:53: dial udp 10.242.1.208:51871->10.242.1.245:53: bind: address already in use" identity=57932 ipAddr="10.242.1.208:51871" subsys=fqdn/dnsproxy (1 occurrences)
+		level=info msg="Cannot forward proxied DNS lookup" DNSRequestID=11649 dnsName=google.com.cluster.local. endpointID=3911 error="failed to dial connection to 10.242.1.245:53: dial udp 10.242.1.208:51871->10.242.1.245:53: bind: address already in use" identity=57932 ipAddr="10.242.1.208:51871" subsys=fqdn/dnsproxy (1 occurrences)
+level=info msg="foo"
+level=error msg="bar"
+level=error error="Failed to update lock:..."
+level=error msg="bar"
+		`)
+	assert.Equal(t, len(fails), 1)
+	assert.Contains(t, fails, "level=error msg=\"bar\"")
+	assert.Equal(t, fails["level=error msg=\"bar\""], 2)
+}
 
 func TestComputeExpectedDropReasons(t *testing.T) {
 	defaultReasons := []string{"reason0", "reason1"}


### PR DESCRIPTION
FQDN Proxy together running with Wireguard has an issue where proxied dns requests can cause a port collision. See: https://github.com/cilium/cilium/issues/31535

Despite this, the actual fqdn tests seem to be resilient to this, likely due to retries.

While we work on a fix for this issue, let's add a temporary exception here.