### PR TITLE
defaults: Move Version and HelmRepository from const to var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ STRIP_DEBUG=-w -s
 ifdef DEBUG
 	STRIP_DEBUG=
 endif
+GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) -X 'github.com/cilium/cilium-cli/defaults.CLIVersion=$(VERSION)'
 
 TEST_TIMEOUT ?= 5s
 RELEASE_UID ?= $(shell id -u)
@@ -28,8 +29,7 @@ GOLANGCILINT_VERSION = $(shell golangci-lint version --format short 2>/dev/null)
 
 $(TARGET):
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
-		-ldflags "$(STRIP_DEBUG) \
-		-X 'github.com/cilium/cilium-cli/defaults.CLIVersion=${VERSION}'" \
+		-ldflags "$(GO_BUILD_LDFLAGS)" \
 		-o $(TARGET) \
 		./cmd/cilium
 
@@ -62,7 +62,7 @@ local-release: clean
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
 			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
-				-ldflags "-w -s -X 'github.com/cilium/cilium-cli/defaults.CLIVersion=${VERSION}'" \
+				-ldflags "$(GO_BUILD_LDFLAGS)" \
 				-o release/$$OS/$$ARCH/$(TARGET)$$EXT ./cmd/cilium; \
 			tar -czf release/$(TARGET)-$$OS-$$ARCH.tar.gz -C release/$$OS/$$ARCH $(TARGET)$$EXT; \
 			(cd release && sha256sum $(TARGET)-$$OS-$$ARCH.tar.gz > $(TARGET)-$$OS-$$ARCH.tar.gz.sha256sum); \
@@ -100,3 +100,5 @@ check:
 endif
 
 .PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags
+
+-include Makefile.override

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -8,9 +8,6 @@ import (
 )
 
 const (
-	// renovate: datasource=github-releases depName=cilium/cilium
-	Version = "v1.15.2"
-
 	CiliumPodSelector = "app.kubernetes.io/part-of=cilium"
 
 	AgentContainerName   = "cilium-agent"
@@ -99,9 +96,6 @@ const (
 
 	CiliumNoScheduleLabel = "cilium.io/no-schedule"
 
-	// HelmRepository specifies Helm repository to download Cilium charts from.
-	HelmRepository = "https://helm.cilium.io"
-
 	// ClustermeshMaxConnectedClusters is the default number of the maximum
 	// number of clusters that should be allowed to connect to the Clustermesh.
 	ClustermeshMaxConnectedClusters = 255
@@ -111,6 +105,12 @@ const (
 )
 
 var (
+	// renovate: datasource=github-releases depName=cilium/cilium
+	Version = "v1.15.2"
+
+	// HelmRepository specifies Helm repository to download Cilium charts from.
+	HelmRepository = "https://helm.cilium.io"
+
 	// CiliumScheduleAffinity is the node affinity to prevent Cilium from being schedule on
 	// nodes labeled with CiliumNoScheduleLabel.
 	CiliumScheduleAffinity = []string{


### PR DESCRIPTION
Make Version and HelmRepository variables instead of consts so that they can be overridden using build tags or go build -X ldflag.