### PR TITLE
sysdump: Collect helm metadata

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -917,6 +917,32 @@ func (c *Client) GetHelmValues(_ context.Context, releaseName string, namespace 
 
 }
 
+// GetHelmMetadata is the function for cilium cli sysdump to collect the helm metadata from the release directly
+func (c *Client) GetHelmMetadata(_ context.Context, releaseName string, namespace string) (string, error) {
+	if c.RESTClientGetter == nil {
+		return "", fmt.Errorf("no RESTClientGetter for Helm Values")
+	}
+	helmDriver := ""
+	actionConfig := action.Configuration{}
+	logger := func(_ string, _ ...interface{}) {}
+	if err := actionConfig.Init(c.RESTClientGetter, namespace, helmDriver, logger); err != nil {
+		return "", err
+	}
+
+	client := action.NewGetMetadata(&actionConfig)
+	meta, err := client.Run(releaseName)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve helm meta from release %s: %w", releaseName, err)
+	}
+
+	buf := new(bytes.Buffer)
+	if err = output.EncodeYAML(buf, meta); err != nil {
+		return "", fmt.Errorf("unable to parse helm metas from release %s: %w", releaseName, err)
+	}
+	return buf.String(), nil
+
+}
+
 // CreateEphemeralContainer will create a EphemeralContainer (debug container) in the specified pod.
 // EphemeralContainers are special containers which can be added after-the-fact in running pods. They're
 // useful for debugging, either when the target container image doesn't have necessary tools, or because

--- a/sysdump/client.go
+++ b/sysdump/client.go
@@ -41,6 +41,7 @@ type KubernetesClient interface {
 	GetSecret(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Secret, error)
 	GetCiliumVersion(ctx context.Context, p *corev1.Pod) (*semver.Version, error)
 	GetVersion(ctx context.Context) (string, error)
+	GetHelmMetadata(ctx context.Context, releaseName string, namespace string) (string, error)
 	GetHelmValues(ctx context.Context, releaseName string, namespace string) (string, error)
 	ListCiliumBGPPeeringPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumBGPPeeringPolicyList, error)
 	ListCiliumCIDRGroups(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumCIDRGroupList, error)

--- a/sysdump/constants.go
+++ b/sysdump/constants.go
@@ -80,6 +80,7 @@ const (
 	cniConfigMapFileName                     = "cni-configmap-<ts>.yaml"
 	cniConfigFileName                        = "cniconf-%s-%s-<ts>.txt"
 	eniconfigsFileName                       = "aws-eniconfigs-<ts>.yaml"
+	ciliumHelmMetadataFileName               = "cilium-helm-metadata-<ts>.yaml"
 	ciliumHelmValuesFileName                 = "cilium-helm-values-<ts>.yaml"
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
 	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -1449,6 +1449,21 @@ func (c *Collector) Run() error {
 	helmTasks := []Task{
 		{
 			CreatesSubtasks: true,
+			Description:     "Collecting Helm metadata from the release",
+			Quick:           true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetHelmMetadata(ctx, c.Options.CiliumHelmReleaseName, c.Options.CiliumNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get the helm metadata from the release: %w", err)
+				}
+				if err := c.WriteString(ciliumHelmMetadataFileName, v); err != nil {
+					return fmt.Errorf("failed to write the helm metadata to the file: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			CreatesSubtasks: true,
 			Description:     "Collecting Helm values from the release",
 			Quick:           true,
 			Task: func(ctx context.Context) error {

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -348,6 +348,10 @@ func (c *fakeClient) GetVersion(_ context.Context) (string, error) {
 	panic("implement me")
 }
 
+func (c *fakeClient) GetHelmMetadata(_ context.Context, _ string, _ string) (string, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) GetHelmValues(_ context.Context, _ string, _ string) (string, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
Collect information about the release like the chart repo, chart version, revision, status, etc.

After collecting a sysdump:
```
$ unzip -l cilium-sysdump-20240321-143159.zip | grep helm-meta
      154  03-21-2024 14:32   cilium-sysdump-20240321-143159/cilium-helm-metadata-20240321-143159.yaml
$ unzip -p cilium-sysdump-20240321-143159.zip cilium-sysdump-20240321-143159/cilium-helm-metadata-20240321-143159.yaml
appVersion: 1.14.7
chart: cilium
deployedAt: "2024-03-20T16:24:27-07:00"
name: cilium
namespace: kube-system
revision: 1
status: deployed
version: 1.14.7
```