### PR TITLE
Explicitly wait for ingress service creation

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1272,16 +1272,13 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	if ct.Features[features.IngressController].Enabled {
-		ingressServices, err := ct.clients.src.ListServices(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "cilium.io/ingress=true"})
+		svcName := fmt.Sprintf("cilium-ingress-%s", IngressServiceName)
+		svc, err := WaitForServiceRetrieval(ctx, ct, ct.client, ct.params.TestNamespace, svcName)
 		if err != nil {
-			return fmt.Errorf("unable to list ingress services: %w", err)
+			return err
 		}
 
-		for _, ingressService := range ingressServices.Items {
-			ct.ingressService[ingressService.Name] = Service{
-				Service: ingressService.DeepCopy(),
-			}
-		}
+		ct.ingressService[svcName] = svc
 	}
 
 	if ct.params.MultiCluster == "" {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -875,29 +875,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-
-			ingressServiceName := fmt.Sprintf("cilium-ingress-%s", IngressServiceName)
-			ct.ingressService[ingressServiceName] = Service{
-				Service: &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: ingressServiceName,
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:     "http",
-								Protocol: corev1.ProtocolTCP,
-								Port:     80,
-							},
-							{
-								Name:     "https",
-								Protocol: corev1.ProtocolTCP,
-								Port:     443,
-							},
-						},
-					},
-				},
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Rather than just listing the services, let's explicitly wait until we successfully retrieve all expected services, so that we can provide a clear error in case something went wrong and they were not created.