### PR TITLE
ci: avoid overlapping pod and service CIDRs on AKS

### DIFF
--- a/.github/in-cluster-test-scripts/aks-byocni-install.sh
+++ b/.github/in-cluster-test-scripts/aks-byocni-install.sh
@@ -10,4 +10,5 @@ cilium install \
   --wait=false \
   --set loadBalancer.l7.backend=envoy \
   --set tls.secretsBackend=k8s \
-  --set bpf.monitorAggregation=none
+  --set bpf.monitorAggregation=none \
+  --set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16" # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)


### PR DESCRIPTION
Follow https://github.com/cilium/cilium/pull/31504, quoting its commit description:

> The default service CIDR of AKS clusters is 10.0.0.0/16 [1].
> Unfortunately, we don't set a pod cidr for clusterpool IPAM, and hence
> use cilium's default of 10.0.0.0/8, which overlaps. This can
> lead to "fun" situations in which e.g. the kube-dns service ClusterIP is
> the same as the hubble-relay pod IP, or similar shenanigans. This
> usually breaks the cluster utterly.
>
> The fix is relatively straight-forward: set a pod CIDR for cilium which
> does not overlap with defaults of AKS. We chose 192.168.0.0/16 as this
> is what is recommended in [2].
>
> [1]: https://learn.microsoft.com/en-us/azure/aks/configure-kubenet#create-an-aks-cluster-with-system-assigned-managed-identities
> [2]: https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium#option-1-assign-ip-addresses-from-an-overlay-network