### PR TITLE
renovate:: Pick up github.com/cilium/cilium prereleases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -134,6 +134,13 @@
       ]
     },
     {
+      // Allow github.com/cilium/cilium to upgrade to prerelease versions.
+      "ignoreUnstable": false,
+      "matchPackageNames": [
+        "github.com/cilium/cilium",
+      ],
+    },
+    {
       // Images that directly use docker.io/library/golang for building.
       "groupName": "golang-images",
       "matchFiles": [


### PR DESCRIPTION
Configure renovate to pick up github.com/cilium/cilium prereleases instead of upgrading it manually like I did in cilium/cilium-cli#2360.