### PR TITLE
Fix flow validation with fully-qualified DNS names

### DIFF
--- a/connectivity/builder/to_fqdns.go
+++ b/connectivity/builder/to_fqdns.go
@@ -5,6 +5,7 @@ package builder
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/connectivity/tests"
@@ -28,7 +29,7 @@ func (t toFqdns) build(ct *check.ConnectivityTest, templates map[string]string) 
 					egress = check.ResultDNSOK
 					egress.HTTP = check.HTTP{
 						Method: "GET",
-						URL:    "https://cilium.io.",
+						URL:    "https://cilium.io",
 					}
 					// Expect packets for cilium.io / 104.198.14.52 to be dropped.
 					return check.ResultDropCurlTimeout, check.ResultNone
@@ -43,7 +44,9 @@ func (t toFqdns) build(ct *check.ConnectivityTest, templates map[string]string) 
 					egress = check.ResultDNSOK
 					egress.HTTP = check.HTTP{
 						Method: "GET",
-						URL:    fmt.Sprintf("http://%s/", extTarget),
+						// Trim the trailing dot, if any, to match the behavior of the curl
+						// action and make sure that flow validation can succeed.
+						URL: fmt.Sprintf("http://%s/", strings.TrimSuffix(extTarget, ".")),
 					}
 					return egress, check.ResultNone
 				}

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -647,7 +647,12 @@ func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSet
 
 		dns := filters.FlowSetRequirement{First: filters.FlowRequirement{Filter: filters.And(ipRequest, dnsRequest), Msg: "DNS request"}}
 		if a.expEgress.DNSProxy {
-			qname := a.dst.Address(a.ipFam) + "."
+			// Make the DNS name fully qualified, if not already.
+			qname := a.dst.Address(a.ipFam)
+			if !strings.HasSuffix(qname, ".") {
+				qname = qname + "."
+			}
+
 			dns.Middle = []filters.FlowRequirement{{Filter: filters.And(ipResponse, dnsResponse), Msg: "DNS response"}}
 			dns.Last = filters.FlowRequirement{Filter: filters.And(ipResponse, dnsResponse, filters.DNS(qname, 0)), Msg: "DNS proxy"}
 			// 5 is the default rcode returned on error such as policy deny


### PR DESCRIPTION
Make sure that we don't append a trailing dot to the DNS name to be matched if already fully-qualified, and remove it from HTTP validation to match the behavior of the curl action.
