### PR TITLE
ci: fix installation on AKS

### DIFF
--- a/.github/in-cluster-test-scripts/aks-byocni-install.sh
+++ b/.github/in-cluster-test-scripts/aks-byocni-install.sh
@@ -11,4 +11,4 @@ cilium install \
   --set loadBalancer.l7.backend=envoy \
   --set tls.secretsBackend=k8s \
   --set bpf.monitorAggregation=none \
-  --set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16" # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
+  --set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)


### PR DESCRIPTION
The trailing " makes the installation fail on AKS with:

2024-03-26T19:25:46.385719258Z /root/test/in-cluster-test-script.sh: line 15: syntax error: unterminated quoted string

See e.g. https://github.com/cilium/cilium-cli/actions/runs/8440743477/job/23118350044

Fixes: 918ae165b699 ("ci: avoid overlapping pod and service CIDRs on AKS")