### PR TITLE
helm: fix KPR autodetection value

### DIFF
--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -209,7 +209,7 @@ func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context, helmValues map[s
 
 		// Use HelmOpts to set auto kube-proxy installation
 		setIfUnset("kubeProxyReplacement", func() string {
-			if !versioncheck.MustCompile(">=1.14.0")(k.chartVersion) {
+			if versioncheck.MustCompile(">=1.14.0")(k.chartVersion) {
 				return "true"
 			}
 			return "strict"


### PR DESCRIPTION
The logic to determine whether KPR should be enabled using the "true" setting or the legacy "strict" one, based on the Cilium version, appears to be inverted, apparently due to a test change which got incorrectly committed. Let's fix it.

Fixes: ad3a82c210ee ("helm: improve KPR autodetection logic")