### PR TITLE
Pin github.com/osrg/gobgp/v3 to v3.23.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -126,6 +126,10 @@
 	// This package is not versioned leading to "empty" updates every week.
 	// Update it manually once newly introduces tetragon CRDs are required.
 	"github.com/cilium/tetragon/pkg/k8s",
+        // Do not update GoBGP until https://github.com/osrg/gobgp/issues/2777
+        // is resolved and a new version is released.
+        // Ref: https://github.com/cilium/cilium/pull/31123
+        "github.com/osrg/gobgp/v3",
       ],
       "matchPackagePatterns": [
         // k8s dependencies will be updated manually in lockstep.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/gops v0.3.28
-	github.com/osrg/gobgp/v3 v3.24.0
+	github.com/osrg/gobgp/v3 v3.23.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/opencontainers/image-spec v1.1.0-rc6 h1:XDqvyKsJEbRtATzkgItUqBA7QHk58
 github.com/opencontainers/image-spec v1.1.0-rc6/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
-github.com/osrg/gobgp/v3 v3.24.0 h1:i2Sa63BzozmscUVorUme3rx5STuOOhrajV6UhKJTGmY=
-github.com/osrg/gobgp/v3 v3.24.0/go.mod h1:4fbscYpsCk14EO16nTWAdJyErO4MbAZ2zLJmsmeXu/k=
+github.com/osrg/gobgp/v3 v3.23.0 h1:2QTiSAiEuHXOqELC8Y4hBvxdqedIZfcwuUndOw4vilE=
+github.com/osrg/gobgp/v3 v3.23.0/go.mod h1:4fbscYpsCk14EO16nTWAdJyErO4MbAZ2zLJmsmeXu/k=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -932,7 +932,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
-# github.com/osrg/gobgp/v3 v3.24.0
+# github.com/osrg/gobgp/v3 v3.23.0
 ## explicit; go 1.20
 github.com/osrg/gobgp/v3/pkg/packet/bgp
 # github.com/pelletier/go-toml v1.9.5


### PR DESCRIPTION
Use the same version of github.com/osrg/gobgp/v3 as cilium/cilium.

Ref: https://github.com/cilium/cilium/pull/31123