### PR TITLE
connectivity: introduce host firewall tests

### DIFF
--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -143,6 +143,8 @@ var (
 		outsideToIngressServiceDenyWorldIdentity{},
 		outsideToIngressServiceDenyCidr{},
 		outsideToIngressServiceDenyAllIngress{},
+		hostFirewallIngress{},
+		hostFirewallEgress{},
 		dnsOnly{},
 		toFqdns{},
 		podToControlplaneHost{},

--- a/connectivity/builder/host_firewall_egress.go
+++ b/connectivity/builder/host_firewall_egress.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/host-firewall-egress.yaml
+var hostFirewallEgressPolicyYAML string
+
+type hostFirewallEgress struct{}
+
+func (t hostFirewallEgress) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("host-firewall-egress", ct).
+		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithFeatureRequirements(features.RequireEnabled(features.HostFirewall)).
+		WithCiliumClusterwidePolicy(hostFirewallEgressPolicyYAML).
+		WithScenarios(tests.HostToPod()).
+		WithExpectations(func(a *check.Action) (egress check.Result, ingress check.Result) {
+			if a.Destination().HasLabel("name", "echo-other-node") {
+				return check.ResultPolicyDenyEgressDrop, check.ResultOK
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/connectivity/builder/host_firewall_ingress.go
+++ b/connectivity/builder/host_firewall_ingress.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/host-firewall-ingress.yaml
+var hostFirewallIngressPolicyYAML string
+
+type hostFirewallIngress struct{}
+
+func (t hostFirewallIngress) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("host-firewall-ingress", ct).
+		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithFeatureRequirements(features.RequireEnabled(features.HostFirewall)).
+		WithCiliumClusterwidePolicy(hostFirewallIngressPolicyYAML).
+		WithScenarios(tests.PodToHost()).
+		WithExpectations(func(a *check.Action) (egress check.Result, ingress check.Result) {
+			if a.Source().HasLabel("name", "client") {
+				return check.ResultOK, check.ResultPolicyDenyIngressDrop
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -63,6 +63,7 @@ func NewTest(name string, verbose bool, debug bool) *Test {
 		name:        name,
 		scenarios:   make(map[Scenario][]*Action),
 		cnps:        make(map[string]*ciliumv2.CiliumNetworkPolicy),
+		ccnps:       make(map[string]*ciliumv2.CiliumClusterwideNetworkPolicy),
 		knps:        make(map[string]*networkingv1.NetworkPolicy),
 		cegps:       make(map[string]*ciliumv2.CiliumEgressGatewayPolicy),
 		verbose:     verbose,


### PR DESCRIPTION
Introduce two new tests covering the host firewall functionality, i.e., asserting that both ingress and egress CiliumClusterwideNetworkPolicies specifying a NodeSelector correctly block the expected traffic. The tests are executed only when the unsafe tests are enabled, as potentially disruptive if executed against a live cluster.

Original commit by Marco Iorio
https://github.com/cilium/cilium-cli/commit/7a928d68204172547ff2cbf0a858da0e27233737
has been accidentally dropped by the following commit during merge
https://github.com/cilium/cilium-cli/commit/486eb991b228aef825294008a1ce11a098c0c377