### PR TITLE
connectivity test: avoid segfault if no agent pods are found

### DIFF
--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -853,6 +853,9 @@ func (ct *ConnectivityTest) initCiliumPods(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("unable to list Cilium pods: %w", err)
 		}
+		if len(ciliumPods.Items) == 0 {
+			return fmt.Errorf("no cilium agent pods found in -n %s -l %s", ct.params.CiliumNamespace, ct.params.AgentPodSelector)
+		}
 		for _, ciliumPod := range ciliumPods.Items {
 			// TODO: Can Cilium pod names collide across clusters?
 			ct.ciliumPods[ciliumPod.Name] = Pod{


### PR DESCRIPTION
If the `--cilium-namespace` and `--agent-pod-selector` (default `kube-system` and `k8s-app=cilium`) don't match anything, `cilium connectivity test` segfaults.

```
# (cluster where the agent pods are labeled `app=cilium)
# ./cilium connectivity test
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102fbe948]

goroutine 24 [running]:
github.com/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).detectCiliumVersion(0x140004ace08, {0x104e88238?, 0x140002f9f40?})
        /Users/oklischat/src/cilium-cli/connectivity/check/features.go:266 +0x168
github.com/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).SetupAndValidate(0x140004ace08, {0x104e88238, 0x140002f9f40}, {0x12e860658, 0x10736f180})
        /Users/oklischat/src/cilium-cli/connectivity/check/context.go:290 +0xa4
github.com/cilium/cilium-cli/connectivity.Run({0x104e88238, 0x140002f9f40}, 0x140004ace08, {0x12e860628, 0x10736f180})
        /Users/oklischat/src/cilium-cli/connectivity/suite.go:24 +0x64
github.com/cilium/cilium-cli/cli.newCmdConnectivityTest.RunE.func1.2()
        /Users/oklischat/src/cilium-cli/cli/connectivity.go:99 +0x98
created by github.com/cilium/cilium-cli/cli.newCmdConnectivityTest.RunE.func1 in goroutine 1
        /Users/oklischat/src/cilium-cli/cli/connectivity.go:97 +0x5a4
```

This fixes that to a proper error.

```
# ./cilium connectivity test
connectivity test failed: no cilium agent pods found in -n kube-system -l k8s-app=cilium
```