### PR TITLE
connectivity: misc conn-disrupt-test improvements

### DIFF
--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -167,6 +167,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckAlpineCurlImage, "Image path to use for curl")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
+	cmd.Flags().StringVar(&params.TestConnDisruptImage, "test-conn-disrupt-image", defaults.ConnectivityTestConnDisruptImage, "Image path to use for connection disruption tests")
 
 	cmd.Flags().UintVar(&params.Retry, "retry", defaults.ConnectRetry, "Number of retries on connection failure to external targets")
 	cmd.Flags().DurationVar(&params.RetryDelay, "retry-delay", defaults.ConnectRetryDelay, "Delay between retries for external targets")

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -52,6 +52,7 @@ type Parameters struct {
 	CurlImage             string
 	PerformanceImage      string
 	JSONMockImage         string
+	TestConnDisruptImage  string
 	AgentDaemonSetName    string
 	DNSTestServerImage    string
 	IncludeUnsafeTests    bool

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -487,7 +486,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				Labels:   map[string]string{"app": "test-conn-disrupt-client"},
 				Command: []string{
 					"tcd-client",
-					"--dispatch-interval", strconv.Itoa(int(ct.params.ConnDisruptDispatchInterval.Milliseconds())),
+					"--dispatch-interval", ct.params.ConnDisruptDispatchInterval.String(),
 					fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
 				},
 				ReadinessProbe: readinessProbe,

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -430,7 +430,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			testConnDisruptServerDeployment := newDeployment(deploymentParameters{
 				Name:           testConnDisruptServerDeploymentName,
 				Kind:           KindTestConnDisrupt,
-				Image:          "quay.io/cilium/test-connection-disruption:v0.0.13",
+				Image:          ct.params.TestConnDisruptImage,
 				Replicas:       3,
 				Labels:         map[string]string{"app": "test-conn-disrupt-server"},
 				Command:        []string{"tcd-server", "8000"},
@@ -482,7 +482,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			testConnDisruptClientDeployment := newDeployment(deploymentParameters{
 				Name:     testConnDisruptClientDeploymentName,
 				Kind:     KindTestConnDisrupt,
-				Image:    "quay.io/cilium/test-connection-disruption:v0.0.13",
+				Image:    ct.params.TestConnDisruptImage,
 				Replicas: 5,
 				Labels:   map[string]string{"app": "test-conn-disrupt-client"},
 				Command: []string{

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -66,7 +66,7 @@ const (
 	// renovate: datasource=docker
 	ConnectivityDNSTestServerImage = "docker.io/coredns/coredns:1.11.1@sha256:1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1"
 	// renovate: datasource=docker
-	ConnectivityTestConnDisruptImage = "quay.io/cilium/test-connection-disruption:v0.0.13@sha256:76e6e9028bd15d103eb3a14fcf3b6e19cad7065780d7f9f27171872994285811"
+	ConnectivityTestConnDisruptImage = "quay.io/cilium/test-connection-disruption:v0.0.14@sha256:8b489a89c38ae2be4f93bdeb354a8f85a6ce204f5e104915a2d6fe99f7f5997e"
 
 	ConfigMapName = "cilium-config"
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -65,6 +65,8 @@ const (
 	ConnectivityCheckJSONMockImage = "quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603"
 	// renovate: datasource=docker
 	ConnectivityDNSTestServerImage = "docker.io/coredns/coredns:1.11.1@sha256:1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1"
+	// renovate: datasource=docker
+	ConnectivityTestConnDisruptImage = "quay.io/cilium/test-connection-disruption:v0.0.13@sha256:76e6e9028bd15d103eb3a14fcf3b6e19cad7065780d7f9f27171872994285811"
 
 	ConfigMapName = "cilium-config"
 


### PR DESCRIPTION
Please review commit by commit, and refer to the individual messages for additional details. Brief summary follows:

* Make test-conn-disrupt image configurable, to simplify testing new versions.
* Bump the test-conn-disrupt image to v0.0.14 to include https://github.com/cilium/test-connection-disruption/pull/12.
* Configure CPU requests to prevent stalling due to CPU starvation. 