### PR TITLE
ingress: Use same node service

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -362,7 +362,7 @@ func newIngress() *networkingv1.Ingress {
 									}(),
 									Backend: networkingv1.IngressBackend{
 										Service: &networkingv1.IngressServiceBackend{
-											Name: echoOtherNodeDeploymentName,
+											Name: echoSameNodeDeploymentName,
 											Port: networkingv1.ServiceBackendPort{
 												Number: 8080,
 											},


### PR DESCRIPTION
### Description

This commit is to use same node service for Ingress, so that we don't
really need to have multi-node cluster for Ingress Controller, also this
will help with hairpining case.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing was done in https://github.com/cilium/cilium/pull/31280