### PR TITLE
ci: refresh login before aks cleanup

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -204,6 +204,13 @@ jobs:
           cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
+      - name: Refresh azure credentials before cleanup
+        uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a # v2.0.0
+        with:
+          client-id: ${{ secrets.AZURE_PR_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_PR_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_PR_SUBSCRIPTION_ID }}
+
       - name: Clean up AKS
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
Since somewhat recently aks credential seems to be only valid for 5min. For instance here is an error fetched on an action failure when trying to cleanup a cluster.

```
ERROR: AADSTS700024: Client assertion is not within its valid time range. Current time: 2024-04-11T18:28:00.5441148Z, assertion valid from 2024-04-11T18:01:56.0000000Z, expiry time of assertion 2024-04-11T18:06:56.0000000Z.
```

This commit solves that by login in again right before we issue the cleanup task.