### PR TITLE
connectivity: configure endpoint selector for entity-cluster CNP

### DIFF
--- a/connectivity/builder/manifests/allow-cluster-entity.yaml
+++ b/connectivity/builder/manifests/allow-cluster-entity.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      {}
+      kind: client
   egress:
     - toEntities:
         - cluster


### PR DESCRIPTION
Restrict the entity-cluster CNP to the client pods only, to avoid affecting the test-conn-disrupt pods when deployed in a multi-cluster scenario, and lead to possible confusing during the investigation of flakes. This change does not lead to changes in coverage.