### PR TITLE
add cilium status -o text for cilium CLI

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -68,6 +68,7 @@ type k8sClusterMeshImplementation interface {
 	ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error)
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	CiliumStatus(ctx context.Context, namespace, pod string) (*models.StatusResponse, error)
+	CiliumStatusInText(ctx context.Context, namespace, pod string) (string, error)
 	CiliumDbgEndpoints(ctx context.Context, namespace, pod string) ([]*models.Endpoint, error)
 	ClusterName() string
 	ListCiliumExternalWorkloads(ctx context.Context, opts metav1.ListOptions) (*ciliumv2.CiliumExternalWorkloadList, error)

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -420,6 +420,13 @@ func (c *Client) CiliumStatus(ctx context.Context, namespace, pod string) (*mode
 
 	return &statusResponse, nil
 }
+func (c *Client) CiliumStatusInText(ctx context.Context, namespace, pod string) (string, error) {
+	result, err := c.ExecInPod(ctx, namespace, pod, defaults.AgentContainerName, []string{"cilium", "status", "--verbose"})
+	if err != nil {
+		return "", err
+	}
+	return result.String(), nil
+}
 
 func (c *Client) CiliumDbgEndpoints(ctx context.Context, namespace, pod string) ([]*models.Endpoint, error) {
 	stdout, err := c.ExecInPod(ctx, namespace, pod, defaults.AgentContainerName, []string{"cilium", "endpoint", "list", "-o", "json"})

--- a/status/status.go
+++ b/status/status.go
@@ -29,6 +29,7 @@ const (
 const (
 	OutputJSON    = "json"
 	OutputSummary = "summary"
+	OutputText    = "text"
 )
 
 // MapCount is a map to count number of occurrences of a string
@@ -67,6 +68,7 @@ type PodStateCount struct {
 type PodStateMap map[string]PodStateCount
 
 type CiliumStatusMap map[string]*models.StatusResponse
+type CiliumStatusInTextMap map[string]string
 type CiliumEndpointsMap map[string][]*models.Endpoint
 
 type ErrorCount struct {
@@ -98,6 +100,9 @@ type Status struct {
 	PodsCount PodsCount `json:"pods_count,omitempty"`
 
 	CiliumStatus CiliumStatusMap `json:"cilium_status,omitempty"`
+	// CiliumStatusInText is the output when Cilium agent run cilium status --verbose.
+	// by each Cilium agent.
+	CiliumStatusInText CiliumStatusInTextMap `json:"cilium_status_in_text,omitempty"`
 
 	// CiliumEndpoints contains the information about the endpoints managed
 	// by each Cilium agent.
@@ -120,14 +125,15 @@ type Status struct {
 
 func newStatus() *Status {
 	return &Status{
-		ImageCount:      MapMapCount{},
-		PhaseCount:      MapMapCount{},
-		PodState:        PodStateMap{},
-		PodsCount:       PodsCount{},
-		CiliumStatus:    CiliumStatusMap{},
-		CiliumEndpoints: CiliumEndpointsMap{},
-		Errors:          ErrorCountMapMap{},
-		mutex:           &sync.Mutex{},
+		ImageCount:         MapMapCount{},
+		PhaseCount:         MapMapCount{},
+		PodState:           PodStateMap{},
+		PodsCount:          PodsCount{},
+		CiliumStatus:       CiliumStatusMap{},
+		CiliumStatusInText: CiliumStatusInTextMap{},
+		CiliumEndpoints:    CiliumEndpointsMap{},
+		Errors:             ErrorCountMapMap{},
+		mutex:              &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
add cilium status -o text to get the cilium status --verbose from agent, so people can use cilium CLI to troubleshoot the issue without get into the agent container

add the -p --podname to select which pod they want to choose for cilium status --verbose.

By default -p is empty and will randomly pick one.