### PR TITLE
Connectivity test concurrent run

### DIFF
--- a/.github/external-targets/certs.yaml
+++ b/.github/external-targets/certs.yaml
@@ -2,14 +2,14 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
- name: ca-cert
+  name: ca-cert
 spec:
- secretName: ca
- isCA: true
- issuerRef:
+  secretName: ca
+  isCA: true
+  issuerRef:
     name: selfsigned-issuer
     kind: Issuer
- commonName: "cilium.io"
+  commonName: "cilium.io"
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -38,5 +38,5 @@ kind: Issuer
 metadata:
   name: ca-cert-issuer
 spec:
- ca:
-   secretName: ca
+  ca:
+    secretName: ca

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -24,6 +24,14 @@ jobs:
   installation-and-connectivity:
     name: Kind Installation and Connectivity Test
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # run connectivity tests explicitly without concurrency
+          - test-concurrency: 1
+          # run connectivity tests concurrently
+          - test-concurrency: 5
     timeout-minutes: 50
     steps:
       - name: Checkout
@@ -106,13 +114,15 @@ jobs:
           #
           # Dispatch interval is set to 100ms, b/c otherwise (default is 0), the flow validation might time out.
           cilium connectivity test --debug --test-namespace test-namespace \
+            --test-concurrency=${{ matrix.test-concurrency }} \
             --conn-disrupt-dispatch-interval 100ms \
             --include-conn-disrupt-test --conn-disrupt-test-setup
 
           # Run the connectivity test in non-default namespace (i.e. not cilium-test)
           cilium connectivity test --debug --all-flows --test-namespace test-namespace \
+            --test-concurrency=${{ matrix.test-concurrency }} \
             --include-unsafe-tests --include-conn-disrupt-test \
-            --collect-sysdump-on-failure --junit-file cilium-junit-1.xml \
+            --collect-sysdump-on-failure --junit-file cilium-junit-1-concurrency-${{ matrix.test-concurrency }}.xml \
             --junit-property type=no-tunnel \
             --curl-insecure \
             --external-target chart-testing-worker2 \
@@ -152,8 +162,9 @@ jobs:
       - name: Connectivity test
         run: |
           cilium connectivity test --debug --force-deploy --all-flows --test-namespace test-namespace \
+            --test-concurrency=${{ matrix.test-concurrency }} \
             --include-unsafe-tests \
-            --collect-sysdump-on-failure --junit-file cilium-junit-2.xml \
+            --collect-sysdump-on-failure --junit-file cilium-junit-2-concurrency-${{ matrix.test-concurrency }}.xml \
             --junit-property type=ipsec \
             --curl-insecure \
             --external-target chart-testing-worker2 \
@@ -167,7 +178,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: cilium-junits
+          name: cilium-junits-concurrency-${{ matrix.test-concurrency }}
           path: cilium-junit*.xml
           retention-days: 2
 
@@ -176,14 +187,14 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
-          cilium sysdump --output-filename cilium-sysdump-out --hubble-flows-count 10000
+          cilium sysdump --output-filename cilium-sysdump-out-concurrency-${{ matrix.test-concurrency }} --hubble-flows-count 10000
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload sysdump
         if: ${{ !success() }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: cilium-sysdumps
+          name: cilium-sysdumps-concurrency-${{ matrix.test-concurrency }}
           path: cilium-sysdump-*.zip
           retention-days: 5
 

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -25,7 +25,6 @@ jobs:
     name: Kind Installation and Connectivity Test
     runs-on: ubuntu-22.04
     strategy:
-      fail-fast: false
       matrix:
         include:
           # run connectivity tests explicitly without concurrency
@@ -201,6 +200,13 @@ jobs:
   helm-upgrade-clustermesh:
     name: Kind Helm Upgrade Clustermesh
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          # run connectivity tests explicitly without concurrency
+          - test-concurrency: 1
+          # run connectivity tests concurrently
+          - test-concurrency: 5
     timeout-minutes: 50
 
     env:
@@ -326,19 +332,21 @@ jobs:
           #
           # Dispatch interval is set to 100ms, b/c otherwise (default is 0), the flow validation might time out.
           cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2 --debug \
+            --test-concurrency=${{ matrix.test-concurrency }} \
             --conn-disrupt-dispatch-interval 100ms \
             --include-conn-disrupt-test --conn-disrupt-test-setup
 
           cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2 --debug \
+            --test-concurrency=${{ matrix.test-concurrency }} \
             --include-unsafe-tests --include-conn-disrupt-test \
-            --collect-sysdump-on-failure --junit-file cilium-junit-clustermesh-1.xml \
+            --collect-sysdump-on-failure --junit-file cilium-junit-clustermesh-1-concurrency-${{ matrix.test-concurrency }}.xml \
             --junit-property mode=clustermesh --junit-property type=ipsec
 
       - name: Upload JUnit
         if: ${{ always() }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: cilium-junits-helm-upgrade-clustermesh
+          name: cilium-junits-helm-upgrade-clustermesh-concurrency-${{ matrix.test-concurrency }}
           path: cilium-junit*.xml
           retention-days: 2
 
@@ -347,24 +355,24 @@ jobs:
         run: |
           cilium --context $CLUSTER1 status
           kubectl --context $CLUSTER1 get pods --all-namespaces -o wide
-          cilium --context $CLUSTER1 sysdump --output-filename cilium-sysdump-out-c1
+          cilium --context $CLUSTER1 sysdump --output-filename cilium-sysdump-out-c1-concurrency-${{ matrix.test-concurrency }}
           cilium --context $CLUSTER2 status
           kubectl --context $CLUSTER2 get pods --all-namespaces -o wide
-          cilium --context $CLUSTER2 sysdump --output-filename cilium-sysdump-out-c2
+          cilium --context $CLUSTER2 sysdump --output-filename cilium-sysdump-out-c2-concurrency-${{ matrix.test-concurrency }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload sysdump from cluster 1
         if: ${{ !success() }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: cilium-sysdump-out-c1.zip
-          path: cilium-sysdump-out-c1.zip
+          name: cilium-sysdump-out-c1-concurrency-${{ matrix.test-concurrency }}.zip
+          path: cilium-sysdump-out-c1-concurrency-${{ matrix.test-concurrency }}.zip
           retention-days: 5
 
       - name: Upload sysdump from cluster 2
         if: ${{ !success() }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: cilium-sysdump-out-c2.zip
-          path: cilium-sysdump-out-c2.zip
+          name: cilium-sysdump-out-c2-concurrency-${{ matrix.test-concurrency }}.zip
+          path: cilium-sysdump-out-c2-concurrency-${{ matrix.test-concurrency }}.zip
           retention-days: 5

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -38,6 +38,7 @@ func newCmdConnectivity(hooks api.Hooks) *cobra.Command {
 
 var params = check.Parameters{
 	ExternalDeploymentPort: 8080,
+	EchoServerHostPort:     4000,
 	Writer:                 os.Stdout,
 	SysdumpOptions: sysdump.Options{
 		LargeSysdumpAbortTimeout: sysdump.DefaultLargeSysdumpAbortTimeout,
@@ -234,6 +235,7 @@ func newConnectivityTests(params check.Parameters) ([]*check.ConnectivityTest, e
 		params := params
 		params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
 		params.ExternalDeploymentPort += i
+		params.EchoServerHostPort += i
 		cc, err := check.NewConnectivityTest(k8sClient, params, defaults.CLIVersion)
 		if err != nil {
 			return nil, err

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -86,7 +86,7 @@ func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 			connTests[0].Logf("Cancellation request (%s) received, cancelling tests...", context.Cause(ctx))
 		}()
 
-		return connectivity.Run(ctx, params, connTests, hooks)
+		return connectivity.Run(ctx, connTests, hooks)
 	}
 }
 

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -197,6 +197,9 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 
 	cmd.Flags().DurationVar(&params.Timeout, "timeout", defaults.ConnectivityTestSuiteTimeout, "Maximum time to allow the connectivity test suite to take")
 
+	cmd.Flags().IntVar(&params.TestConcurrency, "test-concurrency", 1, "Count of namespaces to perform the connectivity tests in parallel (value <= 0 will be treated as 1)")
+	_ = cmd.Flags().MarkHidden("test-concurrency")
+
 	hooks.AddConnectivityTestFlags(cmd.Flags())
 
 	registerCommonFlags(cmd.Flags())

--- a/cli/connectivity_test.go
+++ b/cli/connectivity_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+)
+
+func TestNewConnectivityTests(t *testing.T) {
+	testCases := []struct {
+		params                 check.Parameters
+		expectedCount          int
+		expectedTestNamespaces []string
+	}{
+		{
+			params: check.Parameters{
+				FlowValidation: check.FlowValidationModeDisabled,
+				TestNamespace:  "cilium-test",
+			},
+			expectedCount:          1,
+			expectedTestNamespaces: []string{"cilium-test"},
+		},
+		{
+			params: check.Parameters{
+				FlowValidation:  check.FlowValidationModeDisabled,
+				TestNamespace:   "cilium-test",
+				TestConcurrency: -1,
+			},
+			expectedCount:          1,
+			expectedTestNamespaces: []string{"cilium-test"},
+		},
+		{
+			params: check.Parameters{
+				FlowValidation:  check.FlowValidationModeDisabled,
+				TestNamespace:   "cilium-test",
+				TestConcurrency: 3,
+			},
+			expectedCount:          3,
+			expectedTestNamespaces: []string{"cilium-test-1", "cilium-test-2", "cilium-test-3"},
+		},
+	}
+	for _, tt := range testCases {
+		// function to test
+		actual, err := newConnectivityTests(tt.params)
+
+		require.NoError(t, err)
+		require.Equal(t, tt.expectedCount, len(actual))
+		for i, n := range tt.expectedTestNamespaces {
+			require.Equal(t, n, actual[i].Params().TestNamespace)
+		}
+	}
+}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -44,35 +44,36 @@ type Parameters struct {
 	SkipIPCacheCheck      bool
 	// Perf is not user-facing parameter, but it's used to run perf subcommand
 	// using connectivity test suite.
-	Perf                  bool
-	PerfReportDir         string
-	PerfDuration          time.Duration
-	PerfHostNet           bool
-	PerfPodNet            bool
-	PerfSamples           int
-	CurlImage             string
-	PerformanceImage      string
-	JSONMockImage         string
-	TestConnDisruptImage  string
-	AgentDaemonSetName    string
-	DNSTestServerImage    string
-	IncludeUnsafeTests    bool
-	AgentPodSelector      string
-	CiliumPodSelector     string
-	NodeSelector          map[string]string
-	DeploymentAnnotations annotationsMap
-	NamespaceAnnotations  annotations
-	ExternalTarget        string
-	ExternalCIDR          string
-	ExternalIP            string
-	ExternalOtherIP       string
-	PodCIDRs              []podCIDRs
-	NodeCIDRs             []string
-	ControlPlaneCIDRs     []string
-	K8sCIDR               string
-	NodesWithoutCiliumIPs []nodesWithoutCiliumIP
-	JunitFile             string
-	JunitProperties       map[string]string
+	Perf                   bool
+	PerfReportDir          string
+	PerfDuration           time.Duration
+	PerfHostNet            bool
+	PerfPodNet             bool
+	PerfSamples            int
+	CurlImage              string
+	PerformanceImage       string
+	JSONMockImage          string
+	TestConnDisruptImage   string
+	AgentDaemonSetName     string
+	DNSTestServerImage     string
+	IncludeUnsafeTests     bool
+	AgentPodSelector       string
+	CiliumPodSelector      string
+	NodeSelector           map[string]string
+	DeploymentAnnotations  annotationsMap
+	NamespaceAnnotations   annotations
+	ExternalTarget         string
+	ExternalCIDR           string
+	ExternalIP             string
+	ExternalDeploymentPort int
+	ExternalOtherIP        string
+	PodCIDRs               []podCIDRs
+	NodeCIDRs              []string
+	ControlPlaneCIDRs      []string
+	K8sCIDR                string
+	NodesWithoutCiliumIPs  []nodesWithoutCiliumIP
+	JunitFile              string
+	JunitProperties        map[string]string
 
 	IncludeConnDisruptTest        bool
 	ConnDisruptTestSetup          bool

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -67,6 +67,7 @@ type Parameters struct {
 	ExternalIP             string
 	ExternalDeploymentPort int
 	ExternalOtherIP        string
+	EchoServerHostPort     int
 	PodCIDRs               []podCIDRs
 	NodeCIDRs              []string
 	ControlPlaneCIDRs      []string

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -23,6 +23,7 @@ type Parameters struct {
 	AssumeCiliumVersion   string
 	CiliumNamespace       string
 	TestNamespace         string
+	TestConcurrency       int
 	SingleNode            bool
 	PrintFlows            bool
 	ForceDeploy           bool

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -37,9 +37,6 @@ import (
 // and holds all resources belonging to it. It implements interface
 // ConnectivityTest and is instantiated once at the start of the program,
 type ConnectivityTest struct {
-	// ConnectivityTest instance unique identifier
-	id int
-
 	// Client connected to a Kubernetes cluster.
 	client       *k8s.Client
 	hubbleClient observer.ObserverClient

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -37,6 +37,9 @@ import (
 // and holds all resources belonging to it. It implements interface
 // ConnectivityTest and is instantiated once at the start of the program,
 type ConnectivityTest struct {
+	// ConnectivityTest instance unique identifier
+	id int
+
 	// Client connected to a Kubernetes cluster.
 	client       *k8s.Client
 	hubbleClient observer.ObserverClient
@@ -355,6 +358,10 @@ func (ct *ConnectivityTest) Run(ctx context.Context) error {
 		return err
 	}
 
+	if len(ct.tests) == 0 {
+		return nil
+	}
+
 	ct.Debug("Registered connectivity tests:")
 	for _, t := range ct.tests {
 		ct.Debugf("  %s", t)
@@ -422,6 +429,14 @@ func (ct *ConnectivityTest) Run(ctx context.Context) error {
 
 	// Report the test results.
 	return ct.report()
+}
+
+// Cleanup cleans test related fields.
+// So, ConnectivityTest instance can be re-used.
+func (ct *ConnectivityTest) Cleanup() {
+	ct.testNames = make(map[string]struct{})
+	ct.tests = make([]*Test, 0)
+	ct.lastFlowTimestamps = make(map[string]time.Time)
 }
 
 // skip marks the Test as skipped.

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -62,8 +62,6 @@ const (
 	testConnDisruptServerDeploymentName = "test-conn-disrupt-server"
 	testConnDisruptServiceName          = "test-conn-disrupt"
 	KindTestConnDisrupt                 = "test-conn-disrupt"
-
-	EchoServerHostPort = 4000
 )
 
 type deploymentParameters struct {
@@ -562,7 +560,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 
 	hostPort := 0
 	if ct.Features[features.HostPort].Enabled {
-		hostPort = EchoServerHostPort
+		hostPort = ct.Params().EchoServerHostPort
 	}
 	dnsConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -64,7 +64,7 @@ func (ct *ConnectivityTest) Headerf(format string, a ...interface{}) {
 	fmt.Fprintf(ct.params.Writer, "\n"+format+"\n", a...)
 }
 
-// Timestamps logs the current timestamp.
+// Timestamp logs the current timestamp.
 func (ct *ConnectivityTest) Timestamp() {
 	if ct.timestamp() {
 		fmt.Fprint(ct.params.Writer, timestamp())

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -19,14 +19,14 @@ type Hooks interface {
 	AddConnectivityTests(ct *check.ConnectivityTest) error
 }
 
-func Run(ctx context.Context, params check.Parameters, connTests []*check.ConnectivityTest, extra Hooks) error {
+func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) error {
 	if err := setupConnectivityTests(ctx, connTests, extra); err != nil {
 		return err
 	}
 
 	connTests[0].Infof("Cilium version: %v", connTests[0].CiliumVersion)
 
-	suiteBuilders, err := builder.GetTestSuites(params)
+	suiteBuilders, err := builder.GetTestSuites(connTests[0].Params())
 	if err != nil {
 		return err
 	}

--- a/connectivity/tests/host.go
+++ b/connectivity/tests/host.go
@@ -141,7 +141,7 @@ func (s *podToHostPort) Run(ctx context.Context, t *check.Test) {
 		for _, echo := range ct.EchoPods() {
 			echo := echo // copy to avoid memory aliasing when using reference
 
-			baseURL := fmt.Sprintf("%s://%s:%d%s", echo.Scheme(), echo.Pod.Status.HostIP, check.EchoServerHostPort, echo.Path())
+			baseURL := fmt.Sprintf("%s://%s:%d%s", echo.Scheme(), echo.Pod.Status.HostIP, ct.Params().EchoServerHostPort, echo.Path())
 			ep := check.HTTPEndpoint(echo.Name(), baseURL)
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, ep, features.IPFamilyAny).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ct.CurlCommand(ep, features.IPFamilyAny))

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/gops v0.3.28
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/osrg/gobgp/v3 v3.23.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/gops v0.3.28
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/osrg/gobgp/v3 v3.23.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.8.0

--- a/utils/runner/multierror.go
+++ b/utils/runner/multierror.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runner
+
+import (
+	"errors"
+	"sync"
+)
+
+// MultiError can be used to run multiple goroutines that
+// might return an error, wait for all the goroutines and
+// return joined errors as a single one.
+type MultiError struct {
+	wg   sync.WaitGroup
+	lock sync.Mutex
+	err  error
+}
+
+// Go runs a function in a separate goroutine.
+func (m *MultiError) Go(fn func() error) {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		if err := fn(); err != nil {
+			m.lock.Lock()
+			m.err = errors.Join(m.err, err)
+			m.lock.Unlock()
+		}
+	}()
+}
+
+// Wait waits for all the goroutines to finish and returns
+// joined errors as a single one.
+func (m *MultiError) Wait() error {
+	m.wg.Wait()
+	return m.err
+}

--- a/utils/runner/multierror_test.go
+++ b/utils/runner/multierror_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runner
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiError_no_errors(t *testing.T) {
+	m := MultiError{}
+
+	check := make([]int, 10)
+	for i := 0; i < 10; i++ {
+		id := i
+		m.Go(func() error {
+			check[id] = 1
+			return nil
+		})
+	}
+
+	require.NoError(t, m.Wait())
+	for i := 0; i < 10; i++ {
+		require.Equal(t, 1, check[i])
+	}
+}
+
+func TestMultiError_with_errors(t *testing.T) {
+	m := MultiError{}
+
+	expectedErrs := []error{
+		errors.New("error-1"),
+		errors.New("error-2"),
+		errors.New("error-3"),
+		errors.New("error-4"),
+		errors.New("error-5"),
+	}
+	for i := range expectedErrs {
+		id := i
+		m.Go(func() error {
+			return expectedErrs[id]
+		})
+	}
+
+	actualErr := m.Wait()
+	actualErrStr := actualErr.Error()
+	require.Error(t, actualErr)
+	for i := range expectedErrs {
+		require.True(t, errors.Is(actualErr, expectedErrs[i]))
+		require.True(t, strings.Contains(actualErrStr, expectedErrs[i].Error()))
+	}
+}


### PR DESCRIPTION
This PR introduces connectivity test concurrent run.

The new `test-concurrency` input param can be used to specify a count of K8S test namespaces.
So, most connectivity tests will run concurrently across test namespaces.

The new parameter is marked `hidden` because of the following reasons:
1. test and stabilisation internally (e.g.: in CI)
2. report output must be improved to avoid mess (especially for the `debug` and `verbose` modes). I want to address this in a separate PR.

Command run example: `cilium connectivity test --test-concurrency=5`

Local test in a 4 node kind cluster result:
- ~17 minutes with [`--test-concurrency=1`](https://github.com/cilium/cilium-cli/actions/runs/9057864520/job/24882553506?pr=2496)
- ~5 minutes with [`--test-concurrency=5`](https://github.com/cilium/cilium-cli/actions/runs/9057864520/job/24882553700?pr=2496)