### PR TITLE
Move the test namespace deletion logic to the install package

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -15,7 +15,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/hubble"
 	"github.com/cilium/cilium-cli/install"
@@ -105,18 +104,8 @@ func newCmdUninstallWithHelm() *cobra.Command {
 			params.HelmReleaseName = helmReleaseName
 			ctx := context.Background()
 
-			cc, err := check.NewConnectivityTest(k8sClient, check.Parameters{
-				CiliumNamespace: namespace,
-				TestNamespace:   params.TestNamespace,
-				FlowValidation:  check.FlowValidationModeDisabled,
-				Writer:          os.Stdout,
-			}, defaults.CLIVersion)
-			if err != nil {
-				fmt.Printf("⚠ ️ Failed to initialize connectivity test uninstaller: %s\n", err)
-			} else {
-				cc.UninstallResources(ctx, params.Wait)
-			}
 			uninstaller := install.NewK8sUninstaller(k8sClient, params)
+			uninstaller.DeleteTestNamespace(ctx)
 			var hubbleParams = hubble.Parameters{
 				Writer:          os.Stdout,
 				Wait:            true,

--- a/install/install.go
+++ b/install/install.go
@@ -66,6 +66,9 @@ type k8sInstallerImplementation interface {
 	GetEndpoints(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Endpoints, error)
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	ContextName() (name string)
+	GetNamespace(ctx context.Context, namespace string, options metav1.GetOptions) (*corev1.Namespace, error)
+	DeleteNamespace(ctx context.Context, namespace string, opts metav1.DeleteOptions) error
+	DeletePodCollection(ctx context.Context, namespace string, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 }
 
 type K8sInstaller struct {


### PR DESCRIPTION
Move UninstallResources() to the install package. UninstallResources() is only called from K8sUninstaller, and the logic to delete the test namespace doesn't depend on anything from the connectivity package. Also rename the function to DeleteTestNamespace() to be a bit more descriptive.