### PR TITLE
k8s: remove unused filter functionality from k8sclient.CiliumLogs

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -75,7 +74,7 @@ type k8sClusterMeshImplementation interface {
 	CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2.CiliumExternalWorkload, opts metav1.CreateOptions) (*ciliumv2.CiliumExternalWorkload, error)
 	DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
-	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, filter *regexp.Regexp) (string, error)
+	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time) (string, error)
 }
 
 type K8sClusterMesh struct {

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -657,7 +657,7 @@ func (t *Test) deletePolicies(ctx context.Context) error {
 // filter is applied on each line of output.
 func (t *Test) CiliumLogs(ctx context.Context) {
 	for _, pod := range t.Context().ciliumPods {
-		log, err := pod.K8sClient.CiliumLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, t.startTime, nil)
+		log, err := pod.K8sClient.CiliumLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, t.startTime)
 		if err != nil {
 			t.Fatalf("Error reading Cilium logs: %s", err)
 		}

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -6,7 +6,6 @@ package status
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -144,7 +143,7 @@ func (c *k8sStatusMockClient) ListCiliumEndpoints(_ context.Context, _ string, o
 	return c.ciliumEndpointList[options.LabelSelector], nil
 }
 
-func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _ string, _ time.Time, _ *regexp.Regexp) (string, error) {
+func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _ string, _ time.Time) (string, error) {
 	return "[error] a sample cilium-agent error message", nil
 }
 


### PR DESCRIPTION
Currently, the logic to retrieve all logs from Cilium Pods is implemented using `bufio.Scanner`. This might result in errors for long  loglines - hiding the actual error.

```
Error reading Cilium logs: error reading cilium-agent logs for kube-system/cilium-c2sx7: bufio.Scanner: token too long
```

AFAIU, the only reason to use the `bufio.Scanner` is the support for filtering the logs by a given regular expression. But this functionality is not used.

Therefore, this commit removes the filter functionality and the usage of `bufio.Scanner`.