### PR TITLE
sysdump: Check --namespace flag for cilium-operator

### DIFF
--- a/cli/sysdump.go
+++ b/cli/sysdump.go
@@ -34,6 +34,9 @@ func newCmdSysdump(hooks sysdump.Hooks) *cobra.Command {
 			if sysdumpOptions.CiliumNamespace == "" && cmd.Flags().Changed("namespace") {
 				sysdumpOptions.CiliumNamespace = namespace
 			}
+			if sysdumpOptions.CiliumOperatorNamespace == "" && cmd.Flags().Changed("namespace") {
+				sysdumpOptions.CiliumOperatorNamespace = namespace
+			}
 			// Honor --helm-release-name global flag in case it is set and --cilium-helm-release-name is not set
 			if sysdumpOptions.CiliumHelmReleaseName == "" && cmd.Flags().Changed("helm-release-name") {
 				sysdumpOptions.CiliumHelmReleaseName = helmReleaseName

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -2816,7 +2816,7 @@ func InitSysdumpFlags(cmd *cobra.Command, options *Options, optionPrefix string,
 		"The namespace Cilium is running in. If not provided then the --namespace global flag is used (if provided)")
 	cmd.Flags().StringVar(&options.CiliumOperatorNamespace,
 		optionPrefix+"cilium-operator-namespace", "",
-		"The namespace Cilium operator is running in")
+		"The namespace Cilium operator is running in. If not provided then the --namespace global flag is used (if provided)")
 	cmd.Flags().StringVar(&options.CiliumSPIRENamespace,
 		optionPrefix+"cilium-spire-namespace", "",
 		"The namespace Cilium SPIRE installation is running in")


### PR DESCRIPTION
Use --namespace flag for cilium-operator if --cilium-operator-namespace flag is not specified. Otherwise sysdump doesn't execute Cilium-related tasks [^1].

[^1]: https://github.com/cilium/cilium-cli/blob/c29afa4bbe93f90531b7611847f7703db603a27c/sysdump/sysdump.go#L1362

Fixes: aad7a72065fa ("Support operator running in a different namespace")