### PR TITLE
uninstall: Delete test namespaces by prefix

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -30,7 +30,7 @@ func addCommonInstallFlags(cmd *cobra.Command, params *install.Parameters) {
 
 // addCommonUninstallFlags adds uninstall command flags that are shared between classic and helm mode.
 func addCommonUninstallFlags(cmd *cobra.Command, params *install.UninstallParameters) {
-	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to uninstall Cilium tests from")
+	cmd.Flags().StringVar(&params.TestNamespacePrefix, "test-namespace", defaults.ConnectivityCheckNamespace, "Prefix of namespaces to uninstall Cilium tests from")
 	cmd.Flags().BoolVar(&params.Wait, "wait", false, "Wait for uninstallation to have completed")
 }
 
@@ -105,7 +105,7 @@ func newCmdUninstallWithHelm() *cobra.Command {
 			ctx := context.Background()
 
 			uninstaller := install.NewK8sUninstaller(k8sClient, params)
-			uninstaller.DeleteTestNamespace(ctx)
+			uninstaller.DeleteTestNamespacesByPrefix(ctx)
 			var hubbleParams = hubble.Parameters{
 				Writer:          os.Stdout,
 				Wait:            true,

--- a/install/install.go
+++ b/install/install.go
@@ -67,6 +67,7 @@ type k8sInstallerImplementation interface {
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	ContextName() (name string)
 	GetNamespace(ctx context.Context, namespace string, options metav1.GetOptions) (*corev1.Namespace, error)
+	ListNamespaces(ctx context.Context, options metav1.ListOptions) (*corev1.NamespaceList, error)
 	DeleteNamespace(ctx context.Context, namespace string, opts metav1.DeleteOptions) error
 	DeletePodCollection(ctx context.Context, namespace string, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 }


### PR DESCRIPTION
This commit changes the behavior of --test-namespace flag. Instead of only deleting the namespace that matches --test-namespace flag exactly, delete all the namespaces with the prefix specified in --test-namespace flag. This is in preparation to support running connectivity tests in parallel using multiple namespaces (#2496).