### PR TITLE
RELEASE.md: make sure to push correct release branch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,12 @@ used in the commands throughout the documenat to allow copy-pasting.
 
     export RELEASE=v0.16.8
 
-## Prepare the release
+## Update local checkout
+
+Update your local checkout to the latest state:
+
+    git checkout main
+    git pull origin main
 
 ### Update the README.md
 
@@ -35,7 +40,7 @@ it can be copy-pasted when preparing the next release.
     git checkout -b pr/prepare-$RELEASE
     git add README.md RELEASE.md
     git commit -s -m "Prepare for $RELEASE release"
-    git push origin HEAD
+    git push origin pr/prepare-$RELEASE
 
 Then open a pull request against `main` branch. Wait for the PR to be reviewed and merged.
 


### PR DESCRIPTION
In case the creation of the release preparation branch fails, the current instructions would push whatever branch was checked out before. Avoid this by explicity specifiying the pr/prepare-$RELEASE branch to be pushed. Also make sure to check out and sync the main branch before modifying README.md and creating the release branch.