### PR TITLE
golangci: remove deprecated go version properties

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,19 +36,13 @@ linters-settings:
       Copyright Authors of {{ PROJECT }}
   goimports:
     local-prefixes: github.com/cilium/cilium-cli
-  gosimple:
-    go: "1.21"
   govet:
     enable-all: true
     disable:
       - fieldalignment
       - shadow
-  staticcheck:
-    go: "1.21"
   stylecheck:
     checks: ["ST1019"]
-  unused:
-    go: "1.21"
 
 issues:
   # This also warns about credential name variables which are false positives.


### PR DESCRIPTION
Currently, the Go version for some linters is configured via separate properties. This has been deprecated in favor of the global config property `run.go` and results in the following warning.

    % golangci-lint
    WARN [config_reader] The configuration option `linters.staticcheck.go` is deprecated, please use global `run.go`.
    WARN [config_reader] The configuration option `linters.gosimple.go` is deprecated, please use global `run.go`.
    ...

In addition, the new property `run.go` defaults to the Go version defined in the `go.mod` file.

Therefore, remove the deprecated properties completely and depend on the fallback mechanism (`go.mod`).