### PR TITLE
Improve ClusterMesh status reporting to include KVStoreMesh information and troubleshooting tips

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -37,6 +37,7 @@ const (
 	HubbleGenerateCertsCronJobName = "hubble-generate-certs"
 
 	ClusterMeshDeploymentName             = "clustermesh-apiserver"
+	ClusterMeshBinaryName                 = "/usr/bin/clustermesh-apiserver"
 	ClusterMeshContainerName              = "apiserver"
 	ClusterMeshPodSelector                = "k8s-app=clustermesh-apiserver"
 	ClusterMeshMetricsPortName            = "apiserv-metrics"
@@ -46,6 +47,7 @@ const (
 	ClusterMeshEtcdMetricsPortName        = "etcd-metrics"
 	ClusterMeshServiceName                = "clustermesh-apiserver"
 	ClusterMeshSecretName                 = "cilium-clustermesh" // Secret which contains the clustermesh configuration
+	ClusterMeshKVStoreMeshSecretName      = "cilium-kvstoremesh" // Secret which contains the kvstoremesh configuration
 	ClusterMeshServerSecretName           = "clustermesh-apiserver-server-cert"
 	ClusterMeshAdminSecretName            = "clustermesh-apiserver-admin-cert"
 	ClusterMeshClientSecretName           = "clustermesh-apiserver-client-cert"

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -385,6 +386,30 @@ func (c *Client) CiliumStatus(ctx context.Context, namespace, pod string) (*mode
 	}
 
 	return &statusResponse, nil
+}
+
+// KVStoreMeshStatusNotImplemented is a sentinel error to signal that the status command is not implemented.
+var ErrKVStoreMeshStatusNotImplemented = errors.New("kvstoremesh-dbg status is not available")
+
+func (c *Client) KVStoreMeshStatus(ctx context.Context, namespace, pod string) ([]*models.RemoteCluster, error) {
+	stdout, stderr, err := c.ExecInPodWithStderr(ctx, namespace, pod, defaults.ClusterMeshKVStoreMeshContainerName,
+		[]string{defaults.ClusterMeshBinaryName, "kvstoremesh-dbg", "status", "-o", "json"})
+	if err != nil {
+		// Try to figure out if the status command is not yet supported in this version
+		stderrStr := stderr.String()
+		if strings.Contains(stderrStr, "Usage:") || strings.Contains(stderrStr, "unknown command") {
+			return nil, ErrKVStoreMeshStatusNotImplemented
+		}
+
+		return nil, err
+	}
+
+	statusResponse := make([]*models.RemoteCluster, 0)
+	if err := json.Unmarshal(stdout.Bytes(), &statusResponse); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response of kvstoremesh-dbg status: %w", err)
+	}
+
+	return statusResponse, nil
 }
 
 func (c *Client) CiliumDbgEndpoints(ctx context.Context, namespace, pod string) ([]*models.Endpoint, error) {

--- a/status/k8s_test.go
+++ b/status/k8s_test.go
@@ -5,6 +5,7 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -153,6 +154,10 @@ func (c *k8sStatusMockClient) CiliumStatus(_ context.Context, _, pod string) (*m
 		return nil, fmt.Errorf("pod %s not found", pod)
 	}
 	return s, nil
+}
+
+func (c *k8sStatusMockClient) KVStoreMeshStatus(_ context.Context, _, _ string) ([]*models.RemoteCluster, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (c *k8sStatusMockClient) CiliumDbgEndpoints(_ context.Context, _, _ string) ([]*models.Endpoint, error) {


### PR DESCRIPTION
* Additionally retrieve and output KVStoreMesh status, when enabled;
* Output troubleshooting tips associated with the most common errors;

Please review commit by commit, and refer to the respective messages for additional information.

Fixes: https://github.com/cilium/cilium/issues/29161