### PR TITLE
clustermesh: reset remote clusters configuration upon disconnection

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1403,6 +1403,8 @@ func EnableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameter
 func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Parameters) error {
 	helmStrValues := []string{
 		"clustermesh.useAPIServer=false",
+		"clustermesh.config.enabled=false",
+		"clustermesh.config.clusters=null",
 		"externalWorkloads.enabled=false",
 	}
 	vals, err := helm.ParseVals(helmStrValues)


### PR DESCRIPTION
cilium/cilium#28763 decoupled the helm settings to enable the clustermesh-apiserver and provide the list of clusters to connect to. Let's reflect this change to the 'cilium clustermesh disable' command as well, explicitly disabling and resetting the remote clusters configs when invoked, to correctly disconnect from possible leftover clusters.

Fixes: cilium/cilium#32300