### PR TITLE
Add support for IPv6 in connectivity tests

### DIFF
--- a/connectivity/builder/manifests/client-egress-to-cidr-external-deny.yaml
+++ b/connectivity/builder/manifests/client-egress-to-cidr-external-deny.yaml
@@ -13,4 +13,4 @@ spec:
   - toCIDRSet:
     - cidr: {{.ExternalCIDR}}
       except:
-        - {{.ExternalIP}}/32
+        - {{.ExternalIP}}/{{if isIPv6 .ExternalIP}}128{{else}}32{{end}}

--- a/connectivity/builder/manifests/client-egress-to-cidr-external-knp.yaml
+++ b/connectivity/builder/manifests/client-egress-to-cidr-external-knp.yaml
@@ -12,4 +12,4 @@ spec:
         - ipBlock:
             cidr: {{.ExternalCIDR}}
             except:
-              - {{.ExternalOtherIP}}/32
+              - {{.ExternalOtherIP}}/{{if isIPv6 .ExternalOtherIP}}128{{else}}32{{end}}

--- a/connectivity/builder/manifests/client-egress-to-cidr-external.yaml
+++ b/connectivity/builder/manifests/client-egress-to-cidr-external.yaml
@@ -11,4 +11,4 @@ spec:
   - toCIDRSet:
     - cidr: {{.ExternalCIDR}}
       except:
-      - {{.ExternalOtherIP}}/32
+      - {{.ExternalOtherIP}}/{{if isIPv6 .ExternalOtherIP}}128{{else}}32{{end}}

--- a/connectivity/builder/manifests/template/template.go
+++ b/connectivity/builder/manifests/template/template.go
@@ -7,12 +7,15 @@ import (
 	"bytes"
 	"html/template"
 	"strings"
+
+	"github.com/cilium/cilium-cli/connectivity/tests"
 )
 
 // Render executes temp template with data and returns the result
 func Render(temp string, data any) (string, error) {
 	fns := template.FuncMap{
 		"trimSuffix": func(in, suffix string) string { return strings.TrimSuffix(in, suffix) },
+		"isIPv6":     func(in string) bool { return tests.FormattedAsIPv6(in) },
 	}
 
 	tm, err := template.New("template").Funcs(fns).Parse(temp)

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -27,7 +27,7 @@ func FormattedAsIPv6(s string) bool {
 	return net.ParseIP(s) != nil && strings.Contains(s, ":")
 }
 
-func EnsureIPv6InBackets(s string) string {
+func EnsureIPv6InBrackets(s string) string {
 	if s[0] != '[' && FormattedAsIPv6(s) {
 		return fmt.Sprintf("[%s]", s)
 	}

--- a/connectivity/tests/common.go
+++ b/connectivity/tests/common.go
@@ -4,11 +4,35 @@
 package tests
 
 import (
+	"fmt"
+	"net"
 	"strconv"
+	"strings"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/utils/features"
 )
+
+func FormattedAsIPv4(s string) bool {
+	// Test with ParseIP whether this is a valid IP address. Then check that the
+	// string does not contain `:`. If that's the case, it must be a string
+	// formatted as an IPv4 address.
+	return net.ParseIP(s) != nil && !strings.Contains(s, ":")
+}
+
+func FormattedAsIPv6(s string) bool {
+	// Test with ParseIP whether this is a valid IP address. Then check that the
+	// string contains `:`. If that's the case, it must be a string formatted as
+	// and IPv6 address.
+	return net.ParseIP(s) != nil && strings.Contains(s, ":")
+}
+
+func EnsureIPv6InBackets(s string) string {
+	if s[0] != '[' && FormattedAsIPv6(s) {
+		return fmt.Sprintf("[%s]", s)
+	}
+	return s
+}
 
 type labelsContainer interface {
 	HasLabel(key, value string) bool

--- a/connectivity/tests/to-cidr.go
+++ b/connectivity/tests/to-cidr.go
@@ -37,7 +37,7 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 	for _, ip := range []string{ct.Params().ExternalIP, ct.Params().ExternalOtherIP} {
 		ep := check.HTTPEndpoint(
 			fmt.Sprintf("external-%s", strings.ReplaceAll(strings.ReplaceAll(ip, ".", ""), ":", "")),
-			"https://"+EnsureIPv6InBackets(ip),
+			"https://"+EnsureIPv6InBrackets(ip),
 		)
 
 		var i int

--- a/connectivity/tests/to-cidr.go
+++ b/connectivity/tests/to-cidr.go
@@ -35,7 +35,10 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, ip := range []string{ct.Params().ExternalIP, ct.Params().ExternalOtherIP} {
-		ep := check.HTTPEndpoint(fmt.Sprintf("external-%s", strings.ReplaceAll(ip, ".", "")), "https://"+ip)
+		ep := check.HTTPEndpoint(
+			fmt.Sprintf("external-%s", strings.ReplaceAll(strings.ReplaceAll(ip, ".", ""), ":", "")),
+			"https://"+EnsureIPv6InBackets(ip),
+		)
 
 		var i int
 		for _, src := range ct.ClientPods() {


### PR DESCRIPTION
As of today, values specified in options `--external-ip` and `--external-other-ip` are assumed to be IPv4 addresses in several places in the code. This cause some tests to fail even when a proper IPv6 configuration is specified with options `--external-cidr`, `--external-ip`, `--external-other-ip` and `--external-target`. This pull request remove the assumptions that these options holds IPv4 addresses.