### PR TITLE
encrypt: broken IPsec algo removed

### DIFF
--- a/cli/encrypt.go
+++ b/cli/encrypt.go
@@ -69,7 +69,7 @@ func newCmdIPsecRotateKey() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&params.IPsecKeyAuthAlgo, "auth-algo", "", "", "IPsec key authentication algorithm (optional parameter, if omitted the current settings will be used). One of: gcm-aes, hmac-md5, hmac-sha1, hmac-sha256, hmac-sha512")
+	cmd.Flags().StringVarP(&params.IPsecKeyAuthAlgo, "auth-algo", "", "", "IPsec key authentication algorithm (optional parameter, if omitted the current settings will be used). One of: gcm-aes, hmac-sha256, hmac-sha512")
 	cmd.Flags().StringVarP(&params.IPsecKeyPerNode, "key-per-node", "", "", "IPsec key per cluster node (optional parameter, if omitted the current settings will be used). One of: true, false")
 	_ = cmd.Flags().MarkHidden("key-per-node")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 1*time.Minute, "Maximum time to wait for result, default 1 minute")

--- a/encrypt/ipsec_key_rotator.go
+++ b/encrypt/ipsec_key_rotator.go
@@ -6,8 +6,6 @@ package encrypt
 var rotators = map[string]func(key ipsecKey) (ipsecKey, error){
 	"":            func(key ipsecKey) (ipsecKey, error) { return key.rotate() },
 	"gcm-aes":     newGcmAesKey,
-	"hmac-md5":    newHmacMD5Key,
-	"hmac-sha1":   newHmacSHA1Key,
 	"hmac-sha256": newHmacSHA256Key,
 	"hmac-sha512": newHmacSHA512Key,
 }
@@ -34,14 +32,6 @@ func newGcmAesKey(key ipsecKey) (ipsecKey, error) {
 		size:      128,
 	}
 	return newKey, nil
-}
-
-func newHmacMD5Key(key ipsecKey) (ipsecKey, error) {
-	return newCbcAesKey(key, "hmac(md5)", 16, 32)
-}
-
-func newHmacSHA1Key(key ipsecKey) (ipsecKey, error) {
-	return newCbcAesKey(key, "hmac(sha1)", 20, 32)
 }
 
 func newHmacSHA256Key(key ipsecKey) (ipsecKey, error) {

--- a/encrypt/ipsec_key_rotator_test.go
+++ b/encrypt/ipsec_key_rotator_test.go
@@ -23,14 +23,6 @@ func Test_IsIPsecAlgoSupported(t *testing.T) {
 			expected: true,
 		},
 		{
-			have:     "hmac-md5",
-			expected: true,
-		},
-		{
-			have:     "hmac-sha1",
-			expected: true,
-		},
-		{
 			have:     "hmac-sha256",
 			expected: true,
 		},
@@ -214,36 +206,6 @@ func Test_rotateIPsecKey(t *testing.T) {
 				algo:      "rfc4106(gcm(aes))",
 				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
 				size:      128,
-			},
-		},
-		{
-			haveAlgo: "hmac-md5",
-			haveKey: ipsecKey{
-				spi:       1,
-				spiSuffix: true,
-			},
-			expected: ipsecKey{
-				spi:        2,
-				spiSuffix:  true,
-				algo:       "hmac(md5)",
-				key:        "1286b7f6f9f61a4f",
-				cipherMode: "cbc(aes)",
-				cipherKey:  "efbeeb4230992f76a6e4cc2ff995b756",
-			},
-		},
-		{
-			haveAlgo: "hmac-sha1",
-			haveKey: ipsecKey{
-				spi:       2,
-				spiSuffix: true,
-			},
-			expected: ipsecKey{
-				spi:        3,
-				spiSuffix:  true,
-				algo:       "hmac(sha1)",
-				key:        "5448dd20e4528a9c2d5b",
-				cipherMode: "cbc(aes)",
-				cipherKey:  "123d17f2bbbae8009d952b4d0d656f06",
 			},
 		},
 		{


### PR DESCRIPTION
The MD5 and SHA1 IPsec algorithms removed as they are known broken.