### PR TITLE
Connectivity tests concurrent logger.

### DIFF
--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -240,6 +240,9 @@ func newConnectivityTests(params check.Parameters, logger *check.ConcurrentLogge
 		params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
 		params.ExternalDeploymentPort += i
 		params.EchoServerHostPort += i
+		if params.JunitFile != "" {
+			params.JunitFile = fmt.Sprintf("%s-%s", params.TestNamespace, params.JunitFile)
+		}
 		cc, err := check.NewConnectivityTest(k8sClient, params, defaults.CLIVersion, logger)
 		if err != nil {
 			return nil, err

--- a/cli/connectivity_test.go
+++ b/cli/connectivity_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,7 @@ func TestNewConnectivityTests(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		// function to test
-		actual, err := newConnectivityTests(tt.params)
+		actual, err := newConnectivityTests(tt.params, check.NewConcurrentLogger(&bytes.Buffer{}, 1))
 
 		require.NoError(t, err)
 		require.Equal(t, tt.expectedCount, len(actual))

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -153,7 +153,7 @@ func (a *Action) Run(f func(*Action)) {
 	a.Logf("[.] Action [%s]", a)
 
 	// Emit unbuffered progress indicator.
-	a.test.progress()
+	a.test.ctx.logger.Printf(a.test, ".")
 
 	// Retrieve Prometheus metrics only if there are expectations.
 	for _, m := range a.expIngress.Metrics {

--- a/connectivity/check/logger.go
+++ b/connectivity/check/logger.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// NewConcurrentLogger factory function that returns ConcurrentLogger.
+func NewConcurrentLogger(writer io.Writer, concurrency int) *ConcurrentLogger {
+	return &ConcurrentLogger{
+		messageCh: make(chan message),
+		writer:    writer,
+		// The concurrency parameter is used for nsTestsCh buffer size calculation.
+		// The buffer will be able to accept 10 times more unique connectivity tests
+		// than concurrency value. Write to the channel implemented in a separate
+		// goroutine to avoid deadlock in case if buffer is full.
+		nsTestsCh:        make(chan string, concurrency*10),
+		nsTestMsgs:       make(map[string][]message),
+		nsTestMsgsLock:   sync.Mutex{},
+		collectorStarted: atomic.Bool{},
+		printerDoneCh:    make(chan bool),
+	}
+}
+
+type ConcurrentLogger struct {
+	messageCh        chan message
+	writer           io.Writer
+	nsTestsCh        chan string
+	nsTestMsgs       map[string][]message
+	nsTestMsgsLock   sync.Mutex
+	collectorStarted atomic.Bool
+	printerDoneCh    chan bool
+	nsTestCount      int
+}
+
+// Start starts ConcurrentLogger internals in separate goroutines:
+// - collector: collects incoming test messages.
+// - printer: sends messages to the writer in corresponding order.
+func (c *ConcurrentLogger) Start(ctx context.Context) {
+	c.collectorStarted.Store(true)
+	go c.collector(ctx)
+	go c.printer()
+}
+
+// Stop closes incoming message channel and waits while all messages are printed.
+func (c *ConcurrentLogger) Stop() {
+	close(c.messageCh)
+	<-c.printerDoneCh
+}
+
+type message struct {
+	namespace string
+	testName  string
+	data      string
+	finish    bool
+}
+
+func (m message) nsTest() string {
+	return fmt.Sprintf("%s:%s", m.namespace, m.testName)
+}
+
+// Printf schedules message for the test to be printed.
+func (c *ConcurrentLogger) Printf(test *Test, format string, args ...interface{}) {
+	buf := &bytes.Buffer{}
+	if test.ctx.timestamp() {
+		mustFprintf(buf, timestamp())
+	}
+	mustFprintf(buf, format, args...)
+	c.messageCh <- message{
+		namespace: test.ctx.params.TestNamespace,
+		testName:  test.name,
+		data:      buf.String(),
+	}
+}
+
+// FinishTest schedules the final message for the test to be printed.
+// The message will be populated with the test log buffer if the test failed.
+func (c *ConcurrentLogger) FinishTest(test *Test) {
+	buf := &bytes.Buffer{}
+	if test.failed && test.logBuf != nil {
+		if _, err := io.Copy(buf, test.logBuf); err != nil {
+			panic(fmt.Errorf("failed to read from test log buffer: %w", err))
+		}
+	}
+	c.messageCh <- message{
+		namespace: test.Context().Params().TestNamespace,
+		testName:  test.Name(),
+		data:      buf.String(),
+		finish:    true,
+	}
+}
+
+func (c *ConcurrentLogger) collector(ctx context.Context) {
+	defer func() { c.collectorStarted.Store(false) }()
+	for {
+		select {
+		case m, open := <-c.messageCh:
+			if !open {
+				return
+			}
+			nsTest := m.nsTest()
+			c.nsTestMsgsLock.Lock()
+			nsTestMsgs, ok := c.nsTestMsgs[nsTest]
+			if !ok {
+				nsTestMsgs = make([]message, 0)
+				// use a separate goroutine to avoid deadlock if the channel
+				// buffer is full, printer goroutine will pull it eventually
+				go func() { c.nsTestsCh <- nsTest }()
+			}
+			c.nsTestMsgs[nsTest] = append(nsTestMsgs, m)
+			c.nsTestMsgsLock.Unlock()
+		case <-ctx.Done():
+			close(c.messageCh)
+			return
+		}
+	}
+}
+
+func (c *ConcurrentLogger) printer() {
+	for c.collectorStarted.Load() || len(c.nsTestMsgs) > c.nsTestCount {
+		c.printTestMessages(<-c.nsTestsCh)
+	}
+	c.printerDoneCh <- true
+	close(c.nsTestsCh)
+}
+
+func (c *ConcurrentLogger) printTestMessages(nsTest string) {
+	for i := 0; ; {
+		c.nsTestMsgsLock.Lock()
+		messages := c.nsTestMsgs[nsTest]
+		c.nsTestMsgsLock.Unlock()
+		if len(messages) == i {
+			// wait for new test messages
+			time.Sleep(time.Millisecond * 50)
+			continue
+		}
+		for ; i < len(messages); i++ {
+			mustFprintf(c.writer, messages[i].data)
+			if messages[i].finish {
+				c.nsTestCount++
+				return
+			}
+		}
+	}
+}
+
+func mustFprintf(writer io.Writer, format string, args ...interface{}) {
+	if _, err := fmt.Fprintf(writer, format, args...); err != nil {
+		panic(fmt.Errorf("failed to print log message: %w", err))
+	}
+}

--- a/connectivity/check/logger_test.go
+++ b/connectivity/check/logger_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentLogger(t *testing.T) {
+	// prepare test message templates
+	testMessages := []string{"start %s"}
+	for i := 1; i <= 50; i++ {
+		testMessages = append(testMessages, "running-"+strconv.Itoa(i)+" %s")
+	}
+	testMessages = append(testMessages, "finish %s")
+
+	tests := []struct {
+		name        string
+		concurrency int
+		testCount   int
+	}{
+		{
+			name:        "sequential run",
+			concurrency: 1,
+			testCount:   100,
+		},
+		{
+			name:        "concurrent run [2x50]",
+			concurrency: 2,
+			testCount:   50,
+		},
+		{
+			name:        "concurrent run [10x50]",
+			concurrency: 10,
+			testCount:   50,
+		},
+		{
+			name:        "concurrent run [30x50]",
+			concurrency: 30,
+			testCount:   50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logBuf := &bytes.Buffer{}
+			logger := NewConcurrentLogger(logBuf, tt.concurrency)
+			logger.Start(context.Background())
+
+			connTests := make([]*ConnectivityTest, 0, tt.concurrency)
+			wg := &sync.WaitGroup{}
+			for i := 0; i < tt.concurrency; i++ {
+				connTests = append(connTests, &ConnectivityTest{
+					params: Parameters{TestNamespace: fmt.Sprintf("namespace-%d", i)},
+					logger: logger,
+				})
+				wg.Add(1)
+				go func(ct *ConnectivityTest) {
+					defer wg.Done()
+					// simulate tests run for the ConnectivityTest instance
+					for j := 0; j < tt.testCount; j++ {
+						test := &Test{
+							ctx:  ct,
+							name: fmt.Sprintf("test-%d", j),
+						}
+						// print test messages
+						for _, m := range testMessages {
+							logger.Printf(test, m+"\n", fmt.Sprintf("%s:%s", test.ctx.params.TestNamespace, test.name))
+						}
+						logger.FinishTest(test)
+					}
+				}(connTests[i])
+			}
+			wg.Wait()
+			logger.Stop()
+
+			logLines := strings.Split(logBuf.String(), "\n")
+			// remove last empty line
+			logLines = logLines[:len(logLines)-1]
+
+			// assert log lines count
+			expectedLogLines := tt.concurrency * tt.testCount * len(testMessages)
+			require.Equal(t, expectedLogLines, len(logLines))
+
+			// assert test message order and total count
+			uniqueTests := make(map[string]struct{})
+			for i := 0; i < len(logLines); {
+				require.True(t, strings.HasPrefix(logLines[i], "start "))
+				name := strings.TrimPrefix(logLines[i], "start ")
+				for _, m := range testMessages {
+					require.Equal(t, fmt.Sprintf(m, name), logLines[i])
+					i++
+				}
+				uniqueTests[name] = struct{}{}
+			}
+
+			// assert unique test count
+			expectedTestCount := tt.concurrency * tt.testCount
+			require.Equal(t, expectedTestCount, len(uniqueTests))
+		})
+	}
+}

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -4,6 +4,7 @@
 package check
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -236,10 +237,11 @@ func (t *Test) flush() {
 	// Terminate progress so far.
 	fmt.Fprintln(t.ctx.params.Writer)
 
-	// Flush internal buffer to user-specified writer.
-	if _, err := io.Copy(t.ctx.params.Writer, t.logBuf); err != nil {
+	buf := &bytes.Buffer{}
+	if _, err := io.Copy(buf, t.logBuf); err != nil {
 		panic(err)
 	}
+	t.ctx.logger.Printf(t, buf.String())
 
 	// Assign a nil buffer so future writes go to user-specified writer.
 	t.logBuf = nil

--- a/connectivity/check/logging.go
+++ b/connectivity/check/logging.go
@@ -165,19 +165,6 @@ func (ct *ConnectivityTest) Fatalf(format string, a ...interface{}) {
 // should always call the methods implemented on Test.
 //
 
-// progress outputs an unbuffered progress indicator if logging is buffered.
-func (t *Test) progress() {
-	t.logMu.RLock()
-	defer t.logMu.RUnlock()
-
-	// Skip progress indicator if logging is not buffered.
-	if t.logBuf == nil {
-		return
-	}
-
-	fmt.Fprint(t.ctx.params.Writer, ".")
-}
-
 // log takes out a read lock and logs a message to the Test's internal buffer.
 // If the internal log buffer is nil, write to user-specified writer instead.
 // Prefix is an optional prefix to the message.
@@ -245,12 +232,6 @@ func (t *Test) flush() {
 
 	// Assign a nil buffer so future writes go to user-specified writer.
 	t.logBuf = nil
-}
-
-// Headerf prints a formatted, indented header inside the test log scope.
-// Headers are not internally buffered.
-func (t *Test) Headerf(format string, a ...interface{}) {
-	t.ctx.Headerf(testPrefix+format, a...)
 }
 
 // Log logs a message.
@@ -404,11 +385,6 @@ func (a *Action) Fatal(s ...interface{}) {
 func (a *Action) Fatalf(format string, s ...interface{}) {
 	a.fail()
 	a.test.Fatalf(format, s...)
-}
-
-// DebugEnabled returns whether debug logging is enabled.
-func (a *Action) DebugEnabled() bool {
-	return a.test.ctx.debug()
 }
 
 func timestamp() string {

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -66,9 +66,7 @@ func NewTest(name string, verbose bool, debug bool) *Test {
 		ccnps:       make(map[string]*ciliumv2.CiliumClusterwideNetworkPolicy),
 		knps:        make(map[string]*networkingv1.NetworkPolicy),
 		cegps:       make(map[string]*ciliumv2.CiliumEgressGatewayPolicy),
-		verbose:     verbose,
 		logBuf:      &bytes.Buffer{}, // maintain internal buffer by default
-		warnBuf:     &bytes.Buffer{},
 		conditionFn: func() bool { return true },
 	}
 	// Setting the internal buffer to nil causes the logger to
@@ -145,10 +143,8 @@ type Test struct {
 
 	// Buffer to store output until it's flushed by a failure.
 	// Unused when run in verbose or debug mode.
-	logMu   sync.RWMutex
-	logBuf  io.ReadWriter
-	warnBuf *bytes.Buffer
-	verbose bool
+	logMu  sync.RWMutex
+	logBuf io.ReadWriter
 
 	// conditionFn is a function that returns true if the test needs to run,
 	// and false otherwise. By default, it's set to a function that returns

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -334,7 +334,7 @@ func (t *Test) Run(ctx context.Context, index int) error {
 		t.completionTime = time.Now()
 	}()
 
-	t.ctx.Logf("[=] Test [%s] [%d/%d]", t.Name(), index, len(t.ctx.tests))
+	t.ctx.logger.Printf(t, "[=] [%s] Test [%s] [%d/%d]\n", t.ctx.params.TestNamespace, t.Name(), index, len(t.ctx.tests))
 
 	if err := t.setup(ctx); err != nil {
 		return fmt.Errorf("setting up test: %w", err)
@@ -371,7 +371,7 @@ func (t *Test) Run(ctx context.Context, index int) error {
 	}
 
 	if t.logBuf != nil {
-		fmt.Fprintln(t.ctx.params.Writer)
+		t.ctx.logger.Printf(t, "\n")
 	}
 
 	// Don't add any more code here, as Scenario.Run() can call Fatal() and


### PR DESCRIPTION
This PR introduces connectivity tests concurrent logger component.
The concurrency logger used for output aggregation and ordering in case of `--test-concurrency` param is > than 1.

Also, the PR contains fixes for JUnit repot name and some cleanup.