### PR TITLE
connectivity: Add local redirect policy tests

### DIFF
--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -237,6 +237,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		podToK8sOnControlplane{},
 		podToControlplaneHostCidr{},
 		podToK8sOnControlplaneCidr{},
+		localRedirectPolicy{},
 	}
 	return injectTests(tests, connTests...)
 }

--- a/connectivity/builder/local_redirect_policy.go
+++ b/connectivity/builder/local_redirect_policy.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+var (
+	//go:embed manifests/local-redirect-policy.yaml
+	localRedirectPolicyYAML string
+)
+
+type localRedirectPolicy struct{}
+
+func (t localRedirectPolicy) build(ct *check.ConnectivityTest, _ map[string]string) {
+	lrpFrontendIP := "169.254.169.254"
+	lrpFrontendIPSkipRedirect := "169.254.169.255"
+	newTest("local-redirect-policy", ct).
+		WithCiliumLocalRedirectPolicy(check.CiliumLocalRedirectPolicyParams{
+			Policy:                  localRedirectPolicyYAML,
+			Name:                    "lrp-address-matcher",
+			FrontendIP:              lrpFrontendIP,
+			SkipRedirectFromBackend: false,
+		}).
+		WithCiliumLocalRedirectPolicy(check.CiliumLocalRedirectPolicyParams{
+			Policy:                  localRedirectPolicyYAML,
+			Name:                    "lrp-address-matcher-skip-redirect-from-backend",
+			FrontendIP:              lrpFrontendIPSkipRedirect,
+			SkipRedirectFromBackend: true,
+		}).
+		WithFeatureRequirements(features.RequireEnabled(features.LocalRedirectPolicy)).
+		WithFeatureRequirements(features.RequireEnabled(features.KPRSocketLB)).
+		WithScenarios(
+			tests.LRP(false),
+			tests.LRP(true),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Scenario().Name() == "lrp-skip-redirect-from-backend" {
+				if a.Source().HasLabel("lrp", "backend") &&
+					a.Destination().Address(features.IPFamilyV4) == lrpFrontendIPSkipRedirect {
+					return check.ResultCurlTimeout, check.ResultNone
+				}
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/connectivity/builder/manifests/local-redirect-policy.yaml
+++ b/connectivity/builder/manifests/local-redirect-policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name:  # set by WithCiliumLocalRedirectPolicy()
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip:  # set by WithCiliumLocalRedirectPolicy()
+      toPorts:
+        - port: "80"
+          name: "tcp"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        lrp: backend
+    toPorts:
+      - port: "8080"
+        name: "tcp-8080"
+        protocol: TCP
+  skipRedirectFromBackend: # set by WithCiliumLocalRedirectPolicy()

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -146,6 +146,11 @@ func (a *Action) IPFamily() features.IPFamily {
 	return a.ipFam
 }
 
+// Scenario returns the scenario the Action belongs to.
+func (a *Action) Scenario() Scenario {
+	return a.scenario
+}
+
 // Run executes function f.
 //
 // This method is to be called from a Scenario implementation.

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -71,6 +71,8 @@ type ConnectivityTest struct {
 	ingressService       map[string]Service
 	k8sService           Service
 	externalWorkloads    map[string]ExternalWorkload
+	lrpClientPods        map[string]Pod
+	lrpBackendPods       map[string]Pod
 
 	hostNetNSPodsByNode      map[string]Pod
 	secondaryNetworkNodeIPv4 map[string]string // node name => secondary ip
@@ -204,6 +206,8 @@ func NewConnectivityTest(client *k8s.Client, p Parameters, version string, logge
 		echoExternalPods:         make(map[string]Pod),
 		clientPods:               make(map[string]Pod),
 		clientCPPods:             make(map[string]Pod),
+		lrpClientPods:            make(map[string]Pod),
+		lrpBackendPods:           make(map[string]Pod),
 		perfClientPods:           []Pod{},
 		perfServerPod:            []Pod{},
 		PerfResults:              []common.PerfSummary{},
@@ -1115,6 +1119,14 @@ func (ct *ConnectivityTest) PerfClientPods() []Pod {
 
 func (ct *ConnectivityTest) EchoPods() map[string]Pod {
 	return ct.echoPods
+}
+
+func (ct *ConnectivityTest) LrpClientPods() map[string]Pod {
+	return ct.lrpClientPods
+}
+
+func (ct *ConnectivityTest) LrpBackendPods() map[string]Pod {
+	return ct.lrpBackendPods
 }
 
 // EchoServices returns all the non headless services

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -13,15 +13,16 @@ import (
 	"sync"
 	"time"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/k8s"
@@ -261,120 +262,6 @@ func defaultDenyReason(flow *flowpb.Flow) bool {
 func authRequiredDropReason(flow *flowpb.Flow) bool {
 	return flow.GetDropReasonDesc() == flowpb.DropReason_AUTH_REQUIRED
 }
-
-var (
-	// ResultNone expects a successful command, don't match any packets.
-	ResultNone = Result{
-		None: true,
-	}
-
-	// ResultOK expects a successful command and a matching flow.
-	ResultOK = Result{}
-
-	// ResultDNSOK expects a successful command, only generating DNS traffic.
-	ResultDNSOK = Result{
-		DNSProxy: true,
-	}
-
-	// ResultDNSOKDropCurlTimeout expects a failed command, generating DNS traffic and a dropped flow.
-	ResultDNSOKDropCurlTimeout = Result{
-		DNSProxy:       true,
-		Drop:           true,
-		DropReasonFunc: defaultDropReason,
-		ExitCode:       ExitCurlTimeout,
-	}
-
-	// ResultDNSOKDropCurlHTTPError expects a failed command, generating DNS traffic and a dropped flow.
-	ResultDNSOKDropCurlHTTPError = Result{
-		DNSProxy:       true,
-		L7Proxy:        true,
-		Drop:           true,
-		DropReasonFunc: defaultDropReason,
-		ExitCode:       ExitCurlHTTPError,
-	}
-
-	// ResultCurlHTTPError expects a failed command, but no dropped flow or DNS proxy.
-	ResultCurlHTTPError = Result{
-		L7Proxy:        true,
-		Drop:           false,
-		DropReasonFunc: defaultDropReason,
-		ExitCode:       ExitCurlHTTPError,
-	}
-
-	// ResultDrop expects a dropped flow and a failed command.
-	ResultDrop = Result{
-		Drop:           true,
-		ExitCode:       ExitAnyError,
-		DropReasonFunc: defaultDropReason,
-	}
-
-	// ResultDropAuthRequired expects a dropped flow with auth required as reason.
-	ResultDropAuthRequired = Result{
-		Drop:           true,
-		DropReasonFunc: authRequiredDropReason,
-	}
-
-	// ResultAnyReasonEgressDrop expects a dropped flow at Egress and a failed command.
-	ResultAnyReasonEgressDrop = Result{
-		Drop:           true,
-		DropReasonFunc: defaultDropReason,
-		EgressDrop:     true,
-		ExitCode:       ExitAnyError,
-	}
-
-	// ResultPolicyDenyEgressDrop expects a dropped flow at Egress due to policy deny and a failed command.
-	ResultPolicyDenyEgressDrop = Result{
-		Drop:           true,
-		DropReasonFunc: policyDenyReason,
-		EgressDrop:     true,
-		ExitCode:       ExitAnyError,
-	}
-
-	// ResultDefaultDenyEgressDrop expects a dropped flow at Egress due to default deny and a failed command.
-	ResultDefaultDenyEgressDrop = Result{
-		Drop:           true,
-		DropReasonFunc: defaultDenyReason,
-		EgressDrop:     true,
-		ExitCode:       ExitAnyError,
-	}
-
-	// ResultIngressAnyReasonDrop expects a dropped flow at Ingress and a failed command.
-	ResultIngressAnyReasonDrop = Result{
-		Drop:           true,
-		IngressDrop:    true,
-		DropReasonFunc: defaultDropReason,
-		ExitCode:       ExitAnyError,
-	}
-
-	// ResultPolicyDenyIngressDrop expects a dropped flow at Ingress due to policy deny reason and a failed command.
-	ResultPolicyDenyIngressDrop = Result{
-		Drop:           true,
-		IngressDrop:    true,
-		DropReasonFunc: policyDenyReason,
-		ExitCode:       ExitAnyError,
-	}
-
-	// ResultDefaultDenyIngressDrop expects a dropped flow at Ingress due to default deny reason and a failed command.
-	ResultDefaultDenyIngressDrop = Result{
-		Drop:           true,
-		IngressDrop:    true,
-		DropReasonFunc: defaultDenyReason,
-		ExitCode:       ExitAnyError,
-	}
-
-	// ResultDropCurlTimeout expects a dropped flow and a failed command.
-	ResultDropCurlTimeout = Result{
-		Drop:     true,
-		ExitCode: ExitCurlTimeout,
-	}
-
-	// ResultDropCurlHTTPError expects a dropped flow and a failed command.
-	ResultDropCurlHTTPError = Result{
-		L7Proxy:  true,
-		Drop:     true,
-		ExitCode: ExitCurlHTTPError,
-	}
-)
 
 type ExpectationsFunc func(a *Action) (egress, ingress Result)
 

--- a/connectivity/tests/lrp.go
+++ b/connectivity/tests/lrp.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium-cli/utils/wait"
+)
+
+// LRP runs test scenarios for local redirect policy. It tests local redirection
+// connectivity from test source pods to LRP frontend.
+//
+// It tests connectivity with the configured skipRedirectFromBackend flag for:
+// - client pods to LRP frontend
+// - LRP backend pods to LRP frontend
+func LRP(skipRedirectFromBackend bool) check.Scenario {
+	return lrp{skipRedirectFromBackend: skipRedirectFromBackend}
+}
+
+type lrp struct {
+	skipRedirectFromBackend bool
+}
+
+func (s lrp) Name() string {
+	if s.skipRedirectFromBackend {
+		return "lrp-skip-redirect-from-backend"
+	}
+	return "lrp"
+}
+
+func (s lrp) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	policies := make([]*v2.CiliumLocalRedirectPolicy, 0, len(t.CiliumLocalRedirectPolicies()))
+
+	for _, policy := range t.CiliumLocalRedirectPolicies() {
+		spec := policy.Spec
+		if spec.RedirectFrontend.AddressMatcher == nil {
+			continue
+		}
+		policies = append(policies, policy)
+		frontend := check.NewLRPFrontend(spec.RedirectFrontend)
+		frontendStr := net.JoinHostPort(frontend.Address(features.IPFamilyV4), fmt.Sprint(frontend.Port()))
+		lrpBackendsMap := make(map[string][]string)
+		// Check for LRP backend pods deployed on nodes in the cluster.
+		for _, pod := range t.Context().LrpBackendPods() {
+			node := pod.NodeName()
+			podIP := pod.Pod.Status.PodIP
+			if _, ok := lrpBackendsMap[node]; !ok {
+				lrpBackendsMap[node] = []string{podIP}
+				continue
+			}
+			lrpBackendsMap[node] = append(lrpBackendsMap[node], podIP)
+		}
+		// Wait until the local redirect entries are plumbed in the BPF LB map
+		// on the cilium agent nodes hosting LRP backend pods.
+		WaitForLocalRedirectBPFEntries(ctx, t, frontendStr, lrpBackendsMap)
+	}
+
+	// Tests client pods to LRP frontend connectivity: traffic gets redirected
+	// to the LRP backends.
+	for _, pod := range t.Context().LrpClientPods() {
+		pod := pod
+
+		for _, policy := range policies {
+			policy := policy
+
+			if policy.Spec.SkipRedirectFromBackend != s.skipRedirectFromBackend {
+				continue
+			}
+
+			i := 0
+			lf := check.NewLRPFrontend(policy.Spec.RedirectFrontend)
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, lf, features.IPFamilyV4).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(lf, features.IPFamilyV4))
+				i++
+			})
+		}
+	}
+
+	// Tests LRP backend pods to LRP frontend connectivity: traffic gets redirected
+	// based on the configured skipRedirectFromBackend flag.
+	for _, pod := range t.Context().LrpBackendPods() {
+		pod := pod
+
+		for _, policy := range policies {
+			policy := policy
+
+			if policy.Spec.SkipRedirectFromBackend != s.skipRedirectFromBackend {
+				continue
+			}
+
+			i := 0
+			lf := check.NewLRPFrontend(policy.Spec.RedirectFrontend)
+			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, lf, features.IPFamilyV4).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(lf, features.IPFamilyV4))
+
+				if policy.Spec.SkipRedirectFromBackend {
+					a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
+						AltDstIP:   lf.Address(features.IPFamilyV4),
+						AltDstPort: lf.Port(),
+					}))
+				}
+				i++
+			})
+		}
+
+	}
+}
+
+func WaitForLocalRedirectBPFEntries(ctx context.Context, t *check.Test, frontend string, backendsMap map[string][]string) {
+	ct := t.Context()
+	w := wait.NewObserver(ctx, wait.Parameters{Timeout: 20 * time.Second})
+	defer w.Cancel()
+
+	ensureBPFLBEntries := func() error {
+		cmd := strings.Split("cilium bpf lb list -o json", " ")
+		for _, ciliumPod := range ct.CiliumPods() {
+			node := ciliumPod.Pod.Spec.NodeName
+			backends, ok := backendsMap[node]
+			if !ok {
+				// No LRP backend pods deployed on this node.
+				continue
+			}
+			stdout, err := ciliumPod.K8sClient.ExecInPod(ctx, ciliumPod.Pod.Namespace, ciliumPod.Pod.Name, defaults.AgentContainerName, cmd)
+			if err != nil {
+				t.Fatal("Failed to run cilium bpf lb list -o json command:", err)
+			}
+			var resMap map[string][]string
+			err = json.Unmarshal(stdout.Bytes(), &resMap)
+			if err != nil {
+				return fmt.Errorf("error unmarshalling data: %w", err)
+			}
+			// An LB mapping (frontend, backend) for example:
+			// 169.254.169.255:80 (1)   10.244.1.210:8080 (132) (1)
+			parsedLB := make(map[string][]string)
+			for frontendEntry, backendEntry := range resMap {
+				// strip the space and parentheses
+				index := strings.Index(frontendEntry, " ")
+				if index > 0 {
+					frontendEntry = frontendEntry[:index]
+				}
+				if len(backendEntry) > 0 {
+					parsedLB[frontendEntry] = append(parsedLB[frontendEntry], backendEntry...)
+				}
+			}
+			parsedBes, ok := parsedLB[frontend]
+			if !ok {
+				return fmt.Errorf("frontend [%s] not found in BPF LB map [%+v]", frontend, parsedLB)
+			}
+			// Check for frontend and backend mapping in the parsed BPF LB map.
+			for _, backend := range backends {
+				found := false
+				for _, be := range parsedBes {
+					if strings.Contains(be, backend) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("frontend [%s] backend [%s] mapping not found in BPF LB map [%s] %+v", frontend, backend, ciliumPod.Pod.Name, parsedLB)
+				}
+			}
+		}
+
+		return nil
+	}
+
+	for {
+		if err := ensureBPFLBEntries(); err != nil {
+			if err := w.Retry(err); err != nil {
+				t.Fatal("Failed to ensure local redirect BPF entries: %w", err)
+			}
+
+			continue
+		}
+		return
+	}
+}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -18,11 +18,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cilium/cilium/api/v1/models"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	ciliumClientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
-	"github.com/cilium/cilium/pkg/versioncheck"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli/output"
 	appsv1 "k8s.io/api/apps/v1"
@@ -48,6 +43,12 @@ import (
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/transport/spdy"
+
+	"github.com/cilium/cilium/api/v1/models"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	ciliumClientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/defaults"
 )
@@ -683,6 +684,10 @@ func (c *Client) ListCiliumEgressGatewayPolicies(ctx context.Context, opts metav
 
 func (c *Client) DeleteCiliumEgressGatewayPolicy(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().Delete(ctx, name, opts)
+}
+
+func (c *Client) DeleteCiliumLocalRedirectPolicy(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	return c.CiliumClientset.CiliumV2().CiliumLocalRedirectPolicies(namespace).Delete(ctx, name, opts)
 }
 
 func (c *Client) ListCiliumBGPPeeringPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumBGPPeeringPolicyList, error) {

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -10,8 +10,9 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/blang/semver/v4"
-	"github.com/cilium/cilium/pkg/versioncheck"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 const (
@@ -69,6 +70,8 @@ const (
 
 	IPsecEnabled                  Feature = "enable-ipsec"
 	ClusterMeshEnableEndpointSync Feature = "clustermesh-enable-endpoint-sync"
+
+	LocalRedirectPolicy Feature = "enable-local-redirect-policy"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -288,6 +291,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[ClusterMeshEnableEndpointSync] = Status{
 		Enabled: cm.Data[string(ClusterMeshEnableEndpointSync)] == "true",
+	}
+
+	fs[LocalRedirectPolicy] = Status{
+		Enabled: cm.Data[string(LocalRedirectPolicy)] == "true",
 	}
 }
 

--- a/utils/features/features_test.go
+++ b/utils/features/features_test.go
@@ -134,12 +134,13 @@ func TestFeatureSet_extractFromConfigMap(t *testing.T) {
 	cm := corev1.ConfigMap{}
 	fs.ExtractFromConfigMap(&cm)
 	cm.Data = map[string]string{
-		"enable-ipv4":                "true",
-		"enable-ipv6":                "true",
-		"mesh-auth-mutual-enabled":   "true",
-		"enable-ipv4-egress-gateway": "true",
-		"ipam":                       "eni",
-		"enable-ipsec":               "true",
+		"enable-ipv4":                  "true",
+		"enable-ipv6":                  "true",
+		"mesh-auth-mutual-enabled":     "true",
+		"enable-ipv4-egress-gateway":   "true",
+		"ipam":                         "eni",
+		"enable-ipsec":                 "true",
+		"enable-local-redirect-policy": "true",
 	}
 	fs.ExtractFromConfigMap(&cm)
 	assert.True(t, fs[IPv4].Enabled)
@@ -147,5 +148,6 @@ func TestFeatureSet_extractFromConfigMap(t *testing.T) {
 	assert.True(t, fs[AuthSpiffe].Enabled)
 	assert.True(t, fs[EgressGateway].Enabled)
 	assert.True(t, fs[IPsecEnabled].Enabled)
+	assert.True(t, fs[LocalRedirectPolicy].Enabled)
 	assert.Equal(t, "eni", fs[CiliumIPAMMode].Mode)
 }


### PR DESCRIPTION
This PR introduces local redirect policy tests to the connectivity suite.

In order to break the circular dependency, there is a separate PR on cilium/cilium repo that enables these tests using a custom version of cilium-cli obtained from this PR changes.  Here are successful test runs from the cilium/cilium PR CI runs - 

Runs after addressing review comments - 
https://github.com/cilium/cilium/actions/runs/9409627836/job/25920752091
https://github.com/cilium/cilium/actions/runs/9409627836/job/25919911738


https://github.com/cilium/cilium/actions/runs/9387516652/job/25850621644
https://github.com/cilium/cilium/actions/runs/9377202073/job/25819021276
https://github.com/cilium/cilium/actions/runs/9375976798/job/25815109405 
https://github.com/cilium/cilium/actions/runs/9377202073/job/25818391762
