### PR TITLE
Fix clusteremesh status retrieval on Cilium v1.14 when kvstoremesh is enabled

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -399,6 +399,11 @@ func (c *Client) KVStoreMeshStatus(ctx context.Context, namespace, pod string) (
 	stdout, stderr, err := c.ExecInPodWithStderr(ctx, namespace, pod, defaults.ClusterMeshKVStoreMeshContainerName,
 		[]string{defaults.ClusterMeshBinaryName, "kvstoremesh-dbg", "status", "-o", "json"})
 	if err != nil {
+		// Cilium v1.14 has a separate kvstoremesh container, with a separate binary
+		if strings.Contains(err.Error(), "stat /usr/bin/clustermesh-apiserver: no such file or directory") {
+			return nil, ErrKVStoreMeshStatusNotImplemented
+		}
+
 		// Try to figure out if the status command is not yet supported in this version
 		stderrStr := stderr.String()
 		if strings.Contains(stderrStr, "Usage:") || strings.Contains(stderrStr, "unknown command") {


### PR DESCRIPTION
The blamed commit broke clustermesh status retrieval on Cilium v1.14 when kvstoremesh is enabled. Indeed, although it already included a check to try to figure out whether the kvstoremesh status was not yet exposed by a given Cilium version, it did not account for v1.14 using a completely separate image (and binary name) for kvstoremesh. Let's fix this by adding the appropriate exception.

Fixes: fa7e30e1a5db ("clustermesh: output kvstoremesh status as part of clustermesh status")