### PR TITLE
fix: conn tests JUnit file name

### DIFF
--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/sysdump"
+	"github.com/cilium/cilium-cli/utils/junit"
 )
 
 func newCmdConnectivity(hooks api.Hooks) *cobra.Command {
@@ -240,9 +241,7 @@ func newConnectivityTests(params check.Parameters, logger *check.ConcurrentLogge
 		params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
 		params.ExternalDeploymentPort += i
 		params.EchoServerHostPort += i
-		if params.JunitFile != "" {
-			params.JunitFile = fmt.Sprintf("%s-%s", params.TestNamespace, params.JunitFile)
-		}
+		params.JunitFile = junit.NamespacedFileName(params.TestNamespace, params.JunitFile)
 		cc, err := check.NewConnectivityTest(k8sClient, params, defaults.CLIVersion, logger)
 		if err != nil {
 			return nil, err

--- a/utils/junit/junit.go
+++ b/utils/junit/junit.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package junit
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func NamespacedFileName(namespace string, junitFile string) string {
+	if junitFile == "" {
+		return ""
+	}
+	idx := strings.LastIndex(junitFile, string(os.PathSeparator))
+	if idx == -1 {
+		return fmt.Sprintf("%s-%s", namespace, junitFile)
+	}
+	return fmt.Sprintf("%s%s-%s", junitFile[:idx+1], namespace, junitFile[idx+1:])
+}

--- a/utils/junit/junit_test.go
+++ b/utils/junit/junit_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package junit
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJunitFileName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		namespace string
+		junitFile string
+		expected  string
+	}{
+		{
+			name:      "no junit report",
+			namespace: "cilium-test",
+			junitFile: "",
+			expected:  "",
+		},
+		{
+			name:      "junit report contains only file",
+			namespace: "cilium-test",
+			junitFile: "junit.xml",
+			expected:  "cilium-test-junit.xml",
+		},
+		{
+			name:      "junit report contains folder and file",
+			namespace: "cilium-test",
+			junitFile: "folder1" + string(os.PathSeparator) + "junit.xml",
+			expected:  "folder1" + string(os.PathSeparator) + "cilium-test-junit.xml",
+		},
+		{
+			name:      "junit report contains folders and file",
+			namespace: "cilium-test",
+			junitFile: "folder1" + string(os.PathSeparator) + "folder2" + string(os.PathSeparator) + "junit.xml",
+			expected:  "folder1" + string(os.PathSeparator) + "folder2" + string(os.PathSeparator) + "cilium-test-junit.xml",
+		},
+		{
+			name:      "junit report is absolute path",
+			namespace: "cilium-test",
+			junitFile: string(os.PathSeparator) + "folder1" + string(os.PathSeparator) + "folder2" + string(os.PathSeparator) + "junit.xml",
+			expected:  string(os.PathSeparator) + "folder1" + string(os.PathSeparator) + "folder2" + string(os.PathSeparator) + "cilium-test-junit.xml",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := NamespacedFileName(tt.namespace, tt.junitFile)
+
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
The fix for the connectivity tests JUnit report filename.
The name must be namespace specific in case of tests concurrent run to avoid report override.
Also, JUnit file parameter might contain folder(s).