### PR TITLE
fix: properly count wrapped lines in status output in --wait mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -215,7 +215,7 @@ require (
 	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
-	golang.org/x/term v0.19.0 // indirect
+	golang.org/x/term v0.19.0
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect


### PR DESCRIPTION
Signed-off-by: Raphaël Pinson <raphael@isovalent.com>
