### PR TITLE
connectivity: add egress-gateway-with-l7-policy test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,6 +45,7 @@
 /connectivity/builder/echo_ingress_mutual_auth_spiffe.go @cilium/sig-servicemesh
 /connectivity/builder/egress_gateway.go @cilium/egress-gateway
 /connectivity/builder/egress_gateway_excluded_cidrs.go @cilium/egress-gateway
+/connectivity/builder/egress_gateway_with_l7_policy.go @cilium/egress-gateway
 /connectivity/builder/no_ipsec_xfrm_errors.go @cilium/sig-encryption
 /connectivity/builder/node_to_node_encryption.go @cilium/sig-encryption
 /connectivity/builder/pod_to_pod_encryption.go @cilium/sig-encryption

--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -209,6 +209,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		nodeToNodeEncryption{},
 		egressGateway{},
 		egressGatewayExcludedCidrs{},
+		egressGatewayWithL7Policy{},
 		podToNodeCidrpolicy{},
 		northSouthLoadbalancingWithL7Policy{},
 		echoIngressL7{},

--- a/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/pkg/versioncheck"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-icmp.yaml
+var clientEgressICMPYAML string
+
+//go:embed manifests/client-egress-l7-http-external-node.yaml
+var clientEgressL7HTTPExternalYAML string
+
+type egressGatewayWithL7Policy struct{}
+
+func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("egress-gateway-with-l7-policy", ct).
+		WithCondition(func() bool {
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
+		}).
+		WithCiliumPolicy(clientEgressICMPYAML).
+		WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML).  // DNS resolution only
+		WithCiliumPolicy(clientEgressL7HTTPExternalYAML). // L7 allow policy with HTTP introspection
+		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
+			Name:            "cegp-sample-client",
+			PodSelectorKind: "client",
+		}).
+		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
+			Name:            "cegp-sample-echo",
+			PodSelectorKind: "echo",
+		}).
+		WithIPRoutesFromOutsideToPodCIDRs().
+		WithFeatureRequirements(
+			features.RequireEnabled(features.EgressGateway),
+			features.RequireEnabled(features.L7Proxy),
+			features.RequireEnabled(features.NodeWithoutCilium),
+		).
+		WithScenarios(tests.EgressGateway())
+}

--- a/connectivity/builder/manifests/client-egress-icmp.yaml
+++ b/connectivity/builder/manifests/client-egress-icmp.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-icmp
+spec:
+  description: "Allow clients to send ICMP"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - icmps:
+    - fields:
+      - type: 8
+        family: IPv4
+      - type: 128
+        family: IPv6

--- a/connectivity/builder/manifests/client-egress-l7-http-external-node.yaml
+++ b/connectivity/builder/manifests/client-egress-l7-http-external-node.yaml
@@ -1,0 +1,26 @@
+---
+# All clients are allowed to contact
+# echo-external-node.cilium-test.svc.cluster.local/client-ip
+# on port http-8080.
+# The toFQDNs section relies on DNS introspection being performed by
+# the client-egress-only-dns policy.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-l7-http-external-node
+spec:
+  description: "Allow GET echo-external-node.cilium-test.svc.cluster.local:8080/client-ip"
+  endpointSelector:
+    matchLabels:
+      any:kind: client
+  egress:
+  - toFQDNs:
+    - matchName: "echo-external-node.cilium-test.svc.cluster.local"
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: GET
+          path: /client-ip

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -58,18 +58,19 @@ type ConnectivityTest struct {
 	// Clients for source and destination clusters.
 	clients *deploymentClients
 
-	ciliumPods        map[string]Pod
-	echoPods          map[string]Pod
-	echoExternalPods  map[string]Pod
-	clientPods        map[string]Pod
-	clientCPPods      map[string]Pod
-	perfClientPods    []Pod
-	perfServerPod     []Pod
-	PerfResults       []common.PerfSummary
-	echoServices      map[string]Service
-	ingressService    map[string]Service
-	k8sService        Service
-	externalWorkloads map[string]ExternalWorkload
+	ciliumPods           map[string]Pod
+	echoPods             map[string]Pod
+	echoExternalPods     map[string]Pod
+	clientPods           map[string]Pod
+	clientCPPods         map[string]Pod
+	perfClientPods       []Pod
+	perfServerPod        []Pod
+	PerfResults          []common.PerfSummary
+	echoServices         map[string]Service
+	echoExternalServices map[string]Service
+	ingressService       map[string]Service
+	k8sService           Service
+	externalWorkloads    map[string]ExternalWorkload
 
 	hostNetNSPodsByNode      map[string]Pod
 	secondaryNetworkNodeIPv4 map[string]string // node name => secondary ip
@@ -207,6 +208,7 @@ func NewConnectivityTest(client *k8s.Client, p Parameters, version string, logge
 		perfServerPod:            []Pod{},
 		PerfResults:              []common.PerfSummary{},
 		echoServices:             make(map[string]Service),
+		echoExternalServices:     make(map[string]Service),
 		ingressService:           make(map[string]Service),
 		externalWorkloads:        make(map[string]ExternalWorkload),
 		hostNetNSPodsByNode:      make(map[string]Pod),
@@ -1129,6 +1131,10 @@ func (ct *ConnectivityTest) EchoServices() map[string]Service {
 
 func (ct *ConnectivityTest) EchoServicesAll() map[string]Service {
 	return ct.echoServices
+}
+
+func (ct *ConnectivityTest) EchoExternalServices() map[string]Service {
+	return ct.echoExternalServices
 }
 
 func (ct *ConnectivityTest) ExternalEchoPods() map[string]Pod {

--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -201,7 +201,7 @@ func (s Service) Path() string {
 // Address returns the network address of the Service.
 func (s Service) Address(family features.IPFamily) string {
 	// If the cluster IP is empty (headless service case) or the IP family is set to any, return the service name
-	if s.Service.Spec.ClusterIP == "" || family == features.IPFamilyAny {
+	if s.Service.Spec.ClusterIP == "" || s.Service.Spec.ClusterIP == corev1.ClusterIPNone || family == features.IPFamilyAny {
 		return fmt.Sprintf("%s.%s", s.Service.Name, s.Service.Namespace)
 	}
 
@@ -253,6 +253,12 @@ func (s Service) ToNodeportService(node *corev1.Node) NodeportService {
 	return NodeportService{
 		Service: s,
 		Node:    node,
+	}
+}
+
+func (s Service) ToEchoIPService() EchoIPService {
+	return EchoIPService{
+		Service: s,
 	}
 }
 
@@ -498,4 +504,12 @@ type EchoIPPod struct {
 
 func (p EchoIPPod) Path() string {
 	return p.path + "/client-ip"
+}
+
+type EchoIPService struct {
+	Service
+}
+
+func (s EchoIPService) Path() string {
+	return s.URLPath + "/client-ip"
 }


### PR DESCRIPTION
egress-gateway-with-l7-policy checks if traffic from Pods that are selected by both Egress Gateway Policy and L7 Network Policy is properly SNATed with an Egress IP.

https://github.com/cilium/cilium/pull/32828