### PR TITLE
Sanitize the autodetected cluster name

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -214,10 +214,10 @@ jobs:
       kind_config_2: .github/kind-config-2.yaml
       # helm/kind-action will override the "name:" provided in the kind config with "chart-testing" unless these are
       # specified as inputs. These must also match the suffix here for CLUSTER1 and CLUSTER2.
-      CLUSTER_NAME_1: c.1
-      CLUSTER_NAME_2: c.2
-      CLUSTER1: kind-c.1
-      CLUSTER2: kind-c.2
+      CLUSTER_NAME_1: c-1
+      CLUSTER_NAME_2: c-2
+      CLUSTER1: kind-c-1
+      CLUSTER2: kind-c-2
 
     steps:
       - name: Checkout

--- a/install/autodetect.go
+++ b/install/autodetect.go
@@ -127,7 +127,8 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context, helmValues map
 
 	if k.params.ClusterName == "" {
 		if k.flavor.ClusterName != "" {
-			name := strings.ReplaceAll(k.flavor.ClusterName, "_", "-")
+			// Neither underscores nor dots are allowed as part of the cluster name.
+			name := strings.NewReplacer("_", "-", ".", "-").Replace(k.flavor.ClusterName)
 			k.Log("🔮 Auto-detected cluster name: %s", name)
 			k.params.ClusterName = name
 		}

--- a/install/azure.go
+++ b/install/azure.go
@@ -130,7 +130,7 @@ func (k *K8sInstaller) azureRetrieveAKSClusterInfo() error {
 		return fmt.Errorf("missing Azure resource group name")
 	}
 
-	bytes, err := k.azExec("aks", "show", "--subscription", k.params.Azure.SubscriptionID, "--resource-group", k.params.Azure.ResourceGroupName, "--name", k.params.ClusterName)
+	bytes, err := k.azExec("aks", "show", "--subscription", k.params.Azure.SubscriptionID, "--resource-group", k.params.Azure.ResourceGroupName, "--name", k.client.ClusterName())
 	if err != nil {
 		return err
 	}

--- a/install/install.go
+++ b/install/install.go
@@ -66,6 +66,7 @@ type k8sInstallerImplementation interface {
 	GetEndpoints(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Endpoints, error)
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	ContextName() (name string)
+	ClusterName() (name string)
 	GetNamespace(ctx context.Context, namespace string, options metav1.GetOptions) (*corev1.Namespace, error)
 	DeleteNamespace(ctx context.Context, namespace string, opts metav1.DeleteOptions) error
 	DeletePodCollection(ctx context.Context, namespace string, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -590,7 +590,6 @@ func (c *Client) AutodetectFlavor(ctx context.Context) Flavor {
 	// When creating a cluster with eksctl create cluster --name foo,
 	// the cluster name is foo.<region>.eksctl.io
 	if strings.HasSuffix(c.ClusterName(), ".eksctl.io") {
-		f.ClusterName = strings.ReplaceAll(c.ClusterName(), ".", "-")
 		f.Kind = KindEKS
 		return f
 	}


### PR DESCRIPTION
Replace underscores and dots with dashes, as they are not allowed characters for cluster names. 

~~Additionally perform the same validation already implemented by the latest Cilium version, to exit early and provide a helpful message in case of errors.~~

Edit. I've removed these changes as bumping the Cilium dependency seems to cause a couple of tests to fail quite consistently.

~~(The large diff count is caused by bumping the Cilium dependency to the current main, to reuse the already available validation function. Please review commit by commit)~~