### PR TITLE
gha: increase disk size for GKE clusters

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -117,7 +117,7 @@ jobs:
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
-            --disk-size 10GB \
+            --disk-size 20GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible
           CLUSTER_CIDR=$(gcloud container clusters describe ${{ env.clusterName }} --zone ${{ env.zone }} --format="value(clusterIpv4Cidr)")

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -128,7 +128,7 @@ jobs:
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
-            --disk-size 10GB \
+            --disk-size 20GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --async
@@ -146,7 +146,7 @@ jobs:
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
-            --disk-size 10GB \
+            --disk-size 20GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --async


### PR DESCRIPTION
We are increasingly witnessing test failures in these workflows due to test pods being evicted as nodes are under disk pressure.