### PR TITLE
connectivity: Display last assertion error on failure

### DIFF
--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -1070,7 +1070,7 @@ func (a *Action) validateMetric(ctx context.Context, node string, result Metrics
 		select {
 		case <-ctx.Done():
 			// Context timeout is reached, let's exit.
-			a.Failf("failed to collect metrics on node %s, context timeout: %s\n", node, ctx.Err())
+			a.Failf("failed to collect metrics on node %s. context timeout: %q, last error: %s\n", node, ctx.Err(), err)
 			return
 		case <-ticker.C:
 			// Ticker is delivered, let's retry.


### PR DESCRIPTION
When tests have metrics expectations and those expectations are never met, we fail the test. However, the reason for the failure is never displayed unless debug logging is enabled. This commit fixes that by displaying the last assertion error when the test is failed.