### PR TITLE
connectivity: Add pod-to-pod-no-frag to check MTU misconfigurations

### DIFF
--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -238,6 +238,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		podToControlplaneHostCidr{},
 		podToK8sOnControlplaneCidr{},
 		localRedirectPolicy{},
+		noFragmentation{},
 	}
 	return injectTests(tests, connTests...)
 }

--- a/connectivity/builder/no_fragmentation.go
+++ b/connectivity/builder/no_fragmentation.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+)
+
+type noFragmentation struct{}
+
+func (t noFragmentation) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("pod-to-pod-no-frag", ct).
+		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithScenarios(
+			tests.PodToPodNoFrag(),
+		)
+
+}

--- a/connectivity/builder/pod_to_pod_encryption.go
+++ b/connectivity/builder/pod_to_pod_encryption.go
@@ -38,5 +38,4 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithScenarios(
 			tests.PodToPodEncryption(features.RequireEnabled(features.EncryptionPod)),
 		)
-
 }

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -1029,7 +1029,7 @@ func (ct *ConnectivityTest) CurlCommandParallelWithOutput(peer TestPeer, ipFam f
 	return cmd
 }
 
-func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily) []string {
+func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily, extraArgs ...string) []string {
 	cmd := []string{"ping", "-c", "1"}
 
 	if ipFam == features.IPFamilyV6 {
@@ -1040,7 +1040,10 @@ func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily) 
 		cmd = append(cmd, "-W", strconv.FormatFloat(connectTimeout, 'f', -1, 64))
 	}
 
+	cmd = append(cmd, extraArgs...)
+
 	cmd = append(cmd, peer.Address(ipFam))
+
 	return cmd
 }
 

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -62,7 +62,7 @@ const (
 	ConnectivityCheckNamespace = "cilium-test"
 
 	// renovate: datasource=docker
-	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.9.0@sha256:e9f5bd17e6fe42f56d926674624dc915e4d3ff3d3c42f4d9c2f10c72ee9993ff"
+	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.10.0@sha256:913e8c9f3d960dde03882defa0edd3a919d529c2eb167caa7f54194528bde364"
 	// renovate: datasource=docker
 	ConnectivityPerformanceImage = "quay.io/cilium/network-perf:a816f935930cb2b40ba43230643da4d5751a5711@sha256:679d3a370c696f63884da4557a4466f3b5569b4719bb4f86e8aac02fbe390eea"
 	// renovate: datasource=docker


### PR DESCRIPTION
CI run - https://github.com/cilium/cilium/pull/33286. Only ci-ipsec and ci-eks failures are relevant. I will fix them in a PR for cilium/cilium, which bumps CLI vsn.