### PR TITLE
Dockerfile: Install aws / azure / gcloud CLIs

### DIFF
--- a/.github/cilium-cli-test-job-chart/templates/job.yaml
+++ b/.github/cilium-cli-test-job-chart/templates/job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - args:
-        - "sh"
+        - "bash"
         - "/root/test/in-cluster-test-script.sh"
         image: quay.io/cilium/cilium-cli-ci:{{ .Values.tag }}
         imagePullPolicy: Always

--- a/.github/in-cluster-test-scripts/aks-byocni-install.sh
+++ b/.github/in-cluster-test-scripts/aks-byocni-install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/aks.sh
+++ b/.github/in-cluster-test-scripts/aks.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/eks-tunnel.sh
+++ b/.github/in-cluster-test-scripts/eks-tunnel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/eks-uninstall.sh
+++ b/.github/in-cluster-test-scripts/eks-uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/eks.sh
+++ b/.github/in-cluster-test-scripts/eks.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/external-workloads-install.sh
+++ b/.github/in-cluster-test-scripts/external-workloads-install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/external-workloads.sh
+++ b/.github/in-cluster-test-scripts/external-workloads.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/.github/in-cluster-test-scripts/multicluster.sh
+++ b/.github/in-cluster-test-scripts/multicluster.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 set -e

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,26 @@ RUN apk add --no-cache git make ca-certificates
 COPY . .
 RUN make
 
-FROM docker.io/library/busybox:stable-glibc@sha256:25e9fcbd3799fce9c0ec978303d35dbb18a6ffb1fc76fc9b181dd4e657e2cd13
+FROM ubuntu:24.04
 LABEL maintainer="maintainer@cilium.io"
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+WORKDIR /root/app
 COPY --from=builder /go/src/github.com/cilium/cilium-cli/cilium /usr/local/bin/cilium
-RUN ["wget", "-P", "/usr/local/bin", "https://dl.k8s.io/release/v1.23.6/bin/linux/amd64/kubectl"]
-RUN ["chmod", "+x", "/usr/local/bin/kubectl"]
+
+# Install cloud CLIs. Based on these instructions:
+# - https://cloud.google.com/sdk/docs/install#deb
+# - https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+# - https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#install-azure-cli
+RUN apt-get update -y \
+ && apt-get install -y curl gnupg unzip \
+ && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+ && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+ && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+ && apt-get update -y \
+ && apt-get install -y google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin kubectl \
+ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+ && unzip awscliv2.zip \
+ && ./aws/install \
+ && rm -r ./aws awscliv2.zip \
+ && curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
 ENTRYPOINT []


### PR DESCRIPTION
Install cloud CLIs so that you can run cilium-cli from inside a container and connect to AKS / EKS / GKE clusters.

This commit also changes in-cluster scripts to use bash instead of sh. Some of these scripts are not POSIX-compliant, and they don't work with sh that comes with Ubuntu.

Ref: #2623
Ref: cilium/design-cfps#9