### PR TITLE
gke: Set --test-concurrency to 5

### DIFF
--- a/.github/in-cluster-test-scripts/gke.sh
+++ b/.github/in-cluster-test-scripts/gke.sh
@@ -25,7 +25,7 @@ sleep 10s
 [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
 # Run connectivity test
-cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target google.com.
+cilium connectivity test --test-concurrency=5 --debug --all-flows --collect-sysdump-on-failure --external-target google.com.
 
 # Run performance test
 cilium connectivity perf --duration 1s

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -14,9 +14,9 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
-  pull_request_target: {}
+  # pull_request_target: {}
   # Run every 6 hours
   schedule:
     - cron:  '0 2/6 * * *'


### PR DESCRIPTION
We've been baking in this flag with the Kind workflow. Let's start using it more widely.