### PR TITLE
action: Add an option to run cilium-cli inside a container

### DIFF
--- a/.github/tools/cilium.sh
+++ b/.github/tools/cilium.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ex
+
+CILIUM_CLI_IMAGE_REPO=${CILIUM_CLI_IMAGE_REPO:-quay.io/cilium/cilium-cli-ci}
+CILIUM_CLI_IMAGE_TAG=${CILIUM_CLI_IMAGE_TAG:-latest}
+
+docker run \
+  --network host \
+  -v ~/.kube/config:/root/.kube/config \
+  -v "$(pwd)":/root/app \
+  -v ~/.aws:/root/.aws \
+  -v ~/.azure:/root/.azure \
+  -v ~/.config/gcloud:/root/.config/gcloud \
+  "$CILIUM_CLI_IMAGE_REPO":"$CILIUM_CLI_IMAGE_TAG" cilium "$@"

--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -127,88 +127,46 @@ jobs:
             --resource-group ${{ steps.vars.outputs.name }} \
             --name ${{ steps.vars.outputs.name }}
 
-      - name: Create kubeconfig and load it in configmap
+      - name: Install Cilium CLI
+        uses: ./
+        with:
+          skip-build: 'true'
+          image-tag: ${{ steps.vars.outputs.sha }}
+
+      - name: Run test
         run: |
-          .github/get-kubeconfig.sh
-          kubectl create configmap cilium-cli-kubeconfig -n kube-system --from-file kubeconfig
+          cilium install \
+            --version "${{ env.cilium_version }}" \
+            --datapath-mode=aks-byocni \
+            --wait=false \
+            --set loadBalancer.l7.backend=envoy \
+            --set tls.secretsBackend=k8s \
+            --set bpf.monitorAggregation=none \
+            --set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
+          # Enable Relay
+          cilium hubble enable
 
-      - name: Load cilium install script in configmap
-        run: |
-          kubectl create configmap cilium-cli-test-script-install -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/aks-byocni-install.sh
+          # Wait for cilium and hubble relay to be ready
+          # NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
+          cilium status --wait
 
-      - name: Create cilium-cli install job
-        run: |
-          helm install .github/cilium-cli-test-job-chart \
-            --generate-name \
-            --set job_name=cilium-cli-install \
-            --set test_script_cm=cilium-cli-test-script-install \
-            --set tag=${{ steps.vars.outputs.sha }} \
-            --set cilium_version=${{ env.cilium_version }}
+          # Port forward Relay
+          cilium hubble port-forward&
+          sleep 10s
+          [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
 
-      - name: Wait for install job
-        env:
-          timeout: 5m
-        run: |
-          # Background wait for job to complete or timeout
-          kubectl -n kube-system wait job/cilium-cli-install --for=condition=complete --timeout=${{ env.timeout }} &
-          complete_pid=$!
+          # Run connectivity test
+          cilium connectivity test --all-flows --collect-sysdump-on-failure --external-target bing.com.
 
-          # Background wait for job to fail
-          (kubectl -n kube-system wait job/cilium-cli-install --for=condition=failed --timeout=${{ env.timeout }} && exit 1) &
-          failed_pid=$!
+          # Run performance test
+          cilium connectivity perf --duration 1s
 
-          # Active wait for whichever background process ends first
-          wait -n $complete_pid $failed_pid
-          EXIT_CODE=$?
-
-          # Retrieve job logs
-          kubectl logs --timestamps -n kube-system job/cilium-cli-install
-          exit ${EXIT_CODE}
-        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
-
-      - name: Load test script in configmap
-        run: |
-          kubectl create configmap cilium-cli-test-script -n kube-system --from-file=in-cluster-test-script.sh=.github/in-cluster-test-scripts/aks.sh
-
-      - name: Create cilium-cli job
-        run: |
-          helm install .github/cilium-cli-test-job-chart \
-            --generate-name \
-            --set job_name=cilium-cli \
-            --set test_script_cm=cilium-cli-test-script \
-            --set tag=${{ steps.vars.outputs.sha }}
-
-      - name: Wait for test job
-        env:
-          timeout: 45m
-        run: |
-          # Background wait for job to complete or timeout
-          kubectl -n kube-system wait job/cilium-cli --for=condition=complete --timeout=${{ env.timeout }} &
-          complete_pid=$!
-
-          # Background wait for job to fail
-          (kubectl -n kube-system wait job/cilium-cli --for=condition=failed --timeout=${{ env.timeout }} && exit 1) &
-          failed_pid=$!
-
-          # Active wait for whichever background process ends first
-          wait -n $complete_pid $failed_pid
-          EXIT_CODE=$?
-
-          # Retrieve job logs
-          kubectl logs --timestamps -n kube-system job/cilium-cli
-          exit ${EXIT_CODE}
-        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+          # Retrieve Cilium status
+          cilium status
 
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Install latest stable CLI ==="
-          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
-          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
-          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
-          rm cilium-linux-amd64.tar.gz{,.sha256sum}
-          cilium version
-
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,14 @@ inputs:
   skip-build:
     description: 'Skip building CLI from source'
     default: 'false'
+  image-repo:
+    description: 'Container image repo to download cilium-cli image from'
+    default: 'quay.io/cilium/cilium-cli-ci'
+  image-tag:
+    description: >
+      Container image tag to use. If this input parameter is specified, this
+      action downloads the container image and sets up Cilium CLI to be executed
+      inside a container.
 runs:
   using: "composite"
   steps:
@@ -65,10 +73,10 @@ runs:
         sudo mv ${TARGET} ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
 
     - name: Check Required Version
-      if: ${{ steps.build-cli.outputs.path == '' && inputs.release-version == '' && inputs.ci-version == '' }}
+      if: ${{ steps.build-cli.outputs.path == '' && inputs.release-version == '' && inputs.ci-version == '' && inputs.image-tag == '' }}
       shell: bash
       run: |
-        echo "'release-version' or 'ci-version' has to be specified!"
+        echo "One of 'release-version', 'ci-version', or 'image-tag' has to be specified!"
         exit 42
 
     - name: Install Released Cilium CLI
@@ -88,6 +96,20 @@ runs:
         cid=$(docker create quay.io/cilium/cilium-cli-ci:${{ inputs.ci-version }} ls)
         docker cp $cid:/usr/local/bin/cilium ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
         docker rm $cid
+
+    - name: Set up Cilium CLI to be executed inside a container
+      if: ${{ steps.build-cli.outputs.path == '' && inputs.image-tag != '' }}
+      shell: bash
+      run: |
+        until docker pull ${{ inputs.image-repo }}:${{ inputs.image-tag }} &> /dev/null
+        do
+          echo "Waiting for ${{ inputs.image-repo }}:${{ inputs.image-tag }} image to become available..."
+          sleep 10
+        done
+        export CILIUM_CLI_IMAGE_REPO=${{ inputs.image-repo }}
+        export CILIUM_CLI_IMAGE_TAG=${{ inputs.image-tag }}
+        cat .github/tools/cilium.sh | envsubst > /tmp/cilium
+        sudo install /tmp/cilium ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
 
     - name: Run Cilium CLI Version
       shell: bash


### PR DESCRIPTION
Add image-repo and image-tag parameters to the cilium-cli action that set up cilium-cli to run inside a container. Update aks-byocni.yaml to run cilium-cli inside a container using the action instead of using cilium-cli-test-job-chart.

Ref: #2623
Ref: cilium/design-cfps#9