### PR TITLE
Dockerfile: Fix a warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/library/golang:1.22.4-alpine3.19@sha256:c46c4609d3cc74a149347161fc277e11516f523fd8aa6347c9631527da0b7a56 as builder
+FROM docker.io/library/golang:1.22.4-alpine3.19@sha256:c46c4609d3cc74a149347161fc277e11516f523fd8aa6347c9631527da0b7a56 AS builder
 WORKDIR /go/src/github.com/cilium/cilium-cli
 RUN apk add --no-cache git make ca-certificates
 COPY . .


### PR DESCRIPTION
Fix this warning [^1]:

     1 warning found (use --debug to expand):
     - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 6)

[^1]: https://github.com/cilium/cilium-cli/actions/runs/9667251137/job/26668630277#step:6:9076