### PR TITLE
Add support for passing annotations to `clustermesh-apiserver` service in the Helm CLI mode

### DIFF
--- a/cli/clustermesh.go
+++ b/cli/clustermesh.go
@@ -252,6 +252,7 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 	cmd.Flags().BoolVar(&params.EnableExternalWorkloads, "enable-external-workloads", false, "Enable support for external workloads, such as VMs")
 	cmd.Flags().BoolVar(&params.EnableKVStoreMesh, "enable-kvstoremesh", false, "Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore (Cilium >=1.14 only)")
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { LoadBalancer | NodePort | ClusterIP }")
+	cmd.Flags().StringArrayVarP(&params.ServiceAnnotations, "service-annotation", "a", []string{}, "Annotations to add to the clustermesh-apiserver service")
 
 	return cmd
 }


### PR DESCRIPTION
In a previous PR (https://github.com/cilium/cilium-cli/pull/1938), support was added for passing annotations to the `clustermesh-apiserver` Service definition using the classic CLI.

However the current mode for the CLI, which relies on Helm, lacks this functionality. This PR therefore introduces this feature by relying on the `clustermesh.apiserver.service.annotations` Helm value and setting it.

I have made sure that passing annotations will also work with the automatic detection of Kubernetes flavor + allow overriding the preset annotations for these flavors.

