### PR TITLE
fix: ExternalTargetCANamespace name

### DIFF
--- a/cli/connectivity_test.go
+++ b/cli/connectivity_test.go
@@ -14,35 +14,63 @@ import (
 
 func TestNewConnectivityTests(t *testing.T) {
 	testCases := []struct {
-		params                 check.Parameters
-		expectedCount          int
-		expectedTestNamespaces []string
+		params                            check.Parameters
+		expectedCount                     int
+		expectedTestNamespaces            []string
+		expectedExternalTargetCANamespace []string
 	}{
 		{
 			params: check.Parameters{
-				FlowValidation: check.FlowValidationModeDisabled,
-				TestNamespace:  "cilium-test",
+				FlowValidation:            check.FlowValidationModeDisabled,
+				TestNamespace:             "cilium-test",
+				ExternalTargetCANamespace: "",
 			},
-			expectedCount:          1,
-			expectedTestNamespaces: []string{"cilium-test"},
+			expectedCount:                     1,
+			expectedTestNamespaces:            []string{"cilium-test"},
+			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 		{
 			params: check.Parameters{
-				FlowValidation:  check.FlowValidationModeDisabled,
-				TestNamespace:   "cilium-test",
-				TestConcurrency: -1,
+				FlowValidation:            check.FlowValidationModeDisabled,
+				TestNamespace:             "cilium-test",
+				ExternalTargetCANamespace: "cilium-test",
 			},
-			expectedCount:          1,
-			expectedTestNamespaces: []string{"cilium-test"},
+			expectedCount:                     1,
+			expectedTestNamespaces:            []string{"cilium-test"},
+			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 		{
 			params: check.Parameters{
-				FlowValidation:  check.FlowValidationModeDisabled,
-				TestNamespace:   "cilium-test",
-				TestConcurrency: 3,
+				FlowValidation:            check.FlowValidationModeDisabled,
+				TestNamespace:             "cilium-test",
+				ExternalTargetCANamespace: "cilium-test",
+				TestConcurrency:           -1,
 			},
-			expectedCount:          3,
-			expectedTestNamespaces: []string{"cilium-test-1", "cilium-test-2", "cilium-test-3"},
+			expectedCount:                     1,
+			expectedTestNamespaces:            []string{"cilium-test"},
+			expectedExternalTargetCANamespace: []string{"cilium-test"},
+		},
+		{
+			params: check.Parameters{
+				FlowValidation:            check.FlowValidationModeDisabled,
+				TestNamespace:             "cilium-test",
+				ExternalTargetCANamespace: "",
+				TestConcurrency:           3,
+			},
+			expectedCount:                     3,
+			expectedTestNamespaces:            []string{"cilium-test-1", "cilium-test-2", "cilium-test-3"},
+			expectedExternalTargetCANamespace: []string{"cilium-test-1", "cilium-test-2", "cilium-test-3"},
+		},
+		{
+			params: check.Parameters{
+				FlowValidation:            check.FlowValidationModeDisabled,
+				TestNamespace:             "cilium-test",
+				ExternalTargetCANamespace: "cilium-test",
+				TestConcurrency:           3,
+			},
+			expectedCount:                     3,
+			expectedTestNamespaces:            []string{"cilium-test-1", "cilium-test-2", "cilium-test-3"},
+			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 	}
 	for _, tt := range testCases {
@@ -53,6 +81,9 @@ func TestNewConnectivityTests(t *testing.T) {
 		require.Equal(t, tt.expectedCount, len(actual))
 		for i, n := range tt.expectedTestNamespaces {
 			require.Equal(t, n, actual[i].Params().TestNamespace)
+		}
+		for i, n := range tt.expectedExternalTargetCANamespace {
+			require.Equal(t, n, actual[i].Params().ExternalTargetCANamespace)
 		}
 	}
 }


### PR DESCRIPTION
The fix for connectivity tests ExternalTargetCANamespace name.
The name must be namespace specific in case of tests
concurrent run for proper CiliumNetworkPolicy provisioning.

- GKE [workflow](https://github.com/cilium/cilium-cli/actions/runs/9680663068/job/26709342342?pr=2637)
- AKS BYOCNI [workflow](https://github.com/cilium/cilium-cli/actions/runs/9681060475/job/26710815715?pr=2637)
- External workloads [workflow](https://github.com/cilium/cilium-cli/actions/runs/9681060471/job/26710757362?pr=2637)
- EKS tunnel [workflow](https://github.com/cilium/cilium-cli/actions/runs/9681060443/job/26711054780?pr=2637) failed (not enough resources for `test-concurrency=5`)
- EKS ENI [workflow](https://github.com/cilium/cilium-cli/actions/runs/9681060455/job/26711054745?pr=2637) failed (not enough resources for `test-concurrency=5`)
- Multicluster [workflow](https://github.com/cilium/cilium-cli/actions/runs/9681060454/job/26710803371?pr=2637) failed (looks like not related to `test-concurrency` param)