### PR TITLE
ci: speedup workflows

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -149,7 +149,7 @@ jobs:
           cilium status --wait
 
           # Run connectivity test
-          cilium connectivity test --collect-sysdump-on-failure --external-target bing.com.
+          cilium connectivity test --test-concurrency=5 --collect-sysdump-on-failure --external-target bing.com.
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -161,7 +161,7 @@ jobs:
           [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
 
           # Run connectivity test
-          cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target amazon.com. \
+          cilium connectivity test --test-concurrency=3 --all-flows --collect-sysdump-on-failure --external-target amazon.com. \
             --test '!dns-only,!to-fqdns,!client-egress-l7,!health'
             # workaround for nslookup issues in tunnel mode causing tests to fail reliably
             # TODO: remove once:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -160,7 +160,7 @@ jobs:
           [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
 
           # Run connectivity test
-          cilium connectivity test --debug --all-flows --collect-sysdump-on-failure --external-target amazon.com.
+          cilium connectivity test --test-concurrency=3 --all-flows --collect-sysdump-on-failure --external-target amazon.com.
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -214,7 +214,7 @@ jobs:
         timeout-minutes: 30
         run: |
           # Run connectivity test
-          cilium connectivity test --all-flows --collect-sysdump-on-failure --external-target google.com.
+          cilium connectivity test --test-concurrency=5 --all-flows --collect-sysdump-on-failure --external-target google.com.
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -155,7 +155,7 @@ jobs:
           [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
 
           # Run connectivity test
-          cilium connectivity test --all-flows --collect-sysdump-on-failure --external-target google.com.
+          cilium connectivity test --test-concurrency=5 --all-flows --collect-sysdump-on-failure --external-target google.com.
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -251,7 +251,7 @@ jobs:
           [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
 
           # Run connectivity test
-          cilium --context "${{ steps.contexts.outputs.cluster1 }}" connectivity test \
+          cilium --context "${{ steps.contexts.outputs.cluster1 }}" connectivity test --test-concurrency=5 \
             --multi-cluster "${{ steps.contexts.outputs.cluster2 }}" --test '!/*-deny,!/pod-to-.*-nodeport' \
             --all-flows --collect-sysdump-on-failure --external-target google.com.
 


### PR DESCRIPTION
The PR adds `test-concurrency` param for connectivity tests concurrent run to speedup CI workflows.

Workflow stats:
- AKS [BYOCNI](https://github.com/cilium/cilium-cli/actions/runs/9687502486/job/26732261111?pr=2639): ~10m vs ~30m before
- EKS [ENI](https://github.com/cilium/cilium-cli/actions/runs/9687502474/job/26732261088?pr=2639): ~10m vs ~27m before
- EKS [tunnel](https://github.com/cilium/cilium-cli/actions/runs/9687502485/job/26732261079?pr=2639): ~8m vs ~19m before
- External [workloads](https://github.com/cilium/cilium-cli/actions/runs/9687502491/job/26732261355?pr=2639): ~6m vs  ~16m before
- [GKE](https://github.com/cilium/cilium-cli/actions/runs/9687502480/job/26732260922?pr=2639): ~10m vs ~27m before
- [Multicluster](https://github.com/cilium/cilium-cli/actions/runs/9687502465/job/26732260962?pr=2639): ~10m vs ~14m before

Fix: https://github.com/cilium/cilium-cli/issues/2644