### PR TITLE
image: Push Docker image on tag push

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
@@ -41,6 +43,8 @@ jobs:
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
             echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_type }}" == "tag" ]; then
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
@@ -50,7 +54,7 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
-      # main branch pushes
+      # main branch or tag pushes
       - name: CI Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
         uses: docker/build-push-action@31159d49c0d4756269a0940a750801a1ea5d7003 # v6.1.0


### PR DESCRIPTION
Trigger image workflow on tag push so that so that you can use release version string to pull cilium-cli Docker images.