### PR TITLE
aks: Temporarily disable Hubble Relay

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -143,20 +143,13 @@ jobs:
             --set tls.secretsBackend=k8s \
             --set bpf.monitorAggregation=none \
             --set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
-          # Enable Relay
-          cilium hubble enable
 
-          # Wait for cilium and hubble relay to be ready
+          # Wait for cilium to be ready
           # NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
           cilium status --wait
 
-          # Port forward Relay
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
-
           # Run connectivity test
-          cilium connectivity test --all-flows --collect-sysdump-on-failure --external-target bing.com.
+          cilium connectivity test --collect-sysdump-on-failure --external-target bing.com.
 
           # Run performance test
           cilium connectivity perf --duration 1s


### PR DESCRIPTION
Disable flow validation until #2642 is fixed.