### PR TITLE
connectivity: Introduce BGP CP connectivity tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,11 +26,13 @@
 /cmd/ @cilium/cli
 /clustermesh/ @cilium/sig-clustermesh
 /connectivity/ @cilium/ci-structure
+/connectivity/check/frr.go @cilium/sig-bgp
 /connectivity/check/ipcache.go @cilium/ipcache
 /connectivity/check/metrics*.go @cilium/metrics
 /connectivity/check/policy.go @cilium/sig-policy
 /connectivity/builder/** @cilium/ci-structure
 /connectivity/builder/all_ingress_deny_from_outside.go @cilium/sig-encryption
+/connectivity/builder/bgp_control_plane.go @cilium/sig-bgp
 /connectivity/builder/cluster_entity_multi_cluster.go @cilium/sig-clustermesh
 /connectivity/builder/dns_only.go @cilium/sig-clustermesh
 /connectivity/builder/echo_ingress.go @cilium/sig-servicemesh
@@ -47,6 +49,7 @@
 /connectivity/builder/no_ipsec_xfrm_errors.go @cilium/sig-encryption
 /connectivity/builder/node_to_node_encryption.go @cilium/sig-encryption
 /connectivity/builder/pod_to_pod_encryption.go @cilium/sig-encryption
+/connectivity/tests/bgp.go @cilium/sig-bgp
 /connectivity/tests/clustermesh-endpointslice-sync.go @cilium/sig-clustermesh
 /connectivity/tests/egressgateway.go @cilium/egress-gateway
 /connectivity/tests/encryption.go @cilium/sig-encryption

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -148,6 +148,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
 	cmd.Flags().StringVar(&params.TestConnDisruptImage, "test-conn-disrupt-image", defaults.ConnectivityTestConnDisruptImage, "Image path to use for connection disruption tests")
+	cmd.Flags().StringVar(&params.FRRImage, "frr-image", defaults.ConnectivityTestFRRImage, "Image path to use for FRR")
 
 	cmd.Flags().UintVar(&params.Retry, "retry", defaults.ConnectRetry, "Number of retries on connection failure to external targets")
 	cmd.Flags().DurationVar(&params.RetryDelay, "retry-delay", defaults.ConnectRetryDelay, "Delay between retries for external targets")

--- a/connectivity/builder/bgp_control_plane.go
+++ b/connectivity/builder/bgp_control_plane.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/pkg/versioncheck"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+type bgpControlPlane struct{}
+
+func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("bgp-control-plane-v1", ct).
+		WithCondition(func() bool {
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
+		}).
+		WithCondition(func() bool {
+			return ct.Params().IncludeUnsafeTests
+		}).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.BGPControlPlane),
+			features.RequireEnabled(features.NodeWithoutCilium),
+		).
+		WithScenarios(tests.BGPAdvertisements(1))
+
+	newTest("bgp-control-plane-v2", ct).
+		WithCondition(func() bool {
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
+		}).
+		WithCondition(func() bool {
+			return ct.Params().IncludeUnsafeTests
+		}).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.BGPControlPlane),
+			features.RequireEnabled(features.NodeWithoutCilium),
+		).
+		WithScenarios(tests.BGPAdvertisements(2))
+}

--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -239,6 +239,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		podToK8sOnControlplaneCidr{},
 		localRedirectPolicy{},
 		noFragmentation{},
+		bgpControlPlane{},
 	}
 	return injectTests(tests, connTests...)
 }

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -54,6 +54,7 @@ type Parameters struct {
 	PerformanceImage       string
 	JSONMockImage          string
 	TestConnDisruptImage   string
+	FRRImage               string
 	AgentDaemonSetName     string
 	DNSTestServerImage     string
 	IncludeUnsafeTests     bool

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -994,6 +994,27 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		}
 	}
 
+	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled {
+		_, err = ct.clients.src.GetDaemonSet(ctx, ct.params.TestNamespace, frrDaemonSetNameName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying %s daemonset...", ct.clients.src.ClusterName(), frrDaemonSetNameName)
+			ds := NewFRRDaemonSet(ct.params)
+			_, err = ct.clients.src.CreateDaemonSet(ctx, ct.params.TestNamespace, ds, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create daemonset %s: %w", frrDaemonSetNameName, err)
+			}
+			_, err = ct.clients.src.GetConfigMap(ctx, ct.params.TestNamespace, frrConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				cm := NewFRRConfigMap()
+				ct.Logf("✨ [%s] Deploying %s configmap...", ct.clients.dst.ClusterName(), cm.Name)
+				_, err = ct.clients.dst.CreateConfigMap(ctx, ct.params.TestNamespace, cm, metav1.CreateOptions{})
+				if err != nil {
+					return fmt.Errorf("unable to create configmap %s: %w", cm.Name, err)
+				}
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1350,6 +1371,22 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			ct.echoExternalServices[echoExternalService.Name] = Service{
 				Service: echoExternalService.DeepCopy(),
 			}
+		}
+	}
+
+	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled {
+		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, frrDaemonSetNameName); err != nil {
+			return err
+		}
+		frrPods, err := ct.clients.dst.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + frrDaemonSetNameName})
+		if err != nil {
+			return fmt.Errorf("unable to list FRR pods: %w", err)
+		}
+		for _, pod := range frrPods.Items {
+			ct.frrPods = append(ct.frrPods, Pod{
+				K8sClient: ct.client,
+				Pod:       pod.DeepCopy(),
+			})
 		}
 	}
 

--- a/connectivity/check/frr.go
+++ b/connectivity/check/frr.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"text/template"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium-cli/utils/wait"
+)
+
+const (
+	frrDaemonSetNameName = "frr-external-node"
+	frrConfigMapName     = "frr-config"
+
+	frrBaseConfig = `
+log stdout debugging
+debug bgp zebra
+debug bgp neighbor-events
+debug bgp updates
+`
+
+	frrBGPPeeringTemplate = `
+router bgp {{ .LocalASN }}
+  no bgp ebgp-requires-policy
+  bgp default ipv6-unicast
+  neighbor CILIUM peer-group
+  neighbor CILIUM remote-as external
+{{- range $peer := .Peers }}
+  neighbor {{$peer}} peer-group CILIUM
+{{- end }}
+exit
+`
+)
+
+// FRRBGPPeeringParams holds information for rendering FRR BGP peering configuration.
+type FRRBGPPeeringParams struct {
+	LocalASN int
+	Peers    []netip.Addr
+}
+
+// FRRBGPNeighborInfo holds FRR BGP neighbor information equivalent to "show bgp neighbor json" CLI output entry.
+type FRRBGPNeighborInfo struct {
+	RemoteAS       int    `json:"remoteAs"`
+	LocalAS        int    `json:"localAs"`
+	Hostname       string `json:"hostname"`
+	RemoteRouterID string `json:"remoteRouterId"`
+	LocalRouterID  string `json:"localRouterId"`
+	BGPState       string `json:"bgpState"`
+}
+
+// FRRBGPPrefixMap is a map of BGP route information indexed by prefix.
+type FRRBGPPrefixMap map[string][]FRRBGPRouteInfo
+
+// FRRBGPAddressFamilyInfo holds FRR BGP address family information
+// equivalent to "show bgp <family> detail json" CLI output entry.
+type FRRBGPAddressFamilyInfo struct {
+	VrfID    int             `json:"vrfId"`
+	VrfName  string          `json:"vrfName"`
+	RouterID string          `json:"routerId"`
+	LocalAS  int             `json:"localAS"`
+	Routes   FRRBGPPrefixMap `json:"routes"`
+}
+
+// FRRBGPRouteInfo holds information about a BGP route,
+// as it can be retried from the "show bgp <family> detail json" CLI output.
+type FRRBGPRouteInfo struct {
+	Origin   string `json:"origin"`
+	Valid    bool   `json:"valid"`
+	Version  int    `json:"version"`
+	BestPath struct {
+		Overall         bool   `json:"overall"`
+		SelectionReason string `json:"selectionReason"`
+	} `json:"bestpath"`
+	ASPath struct {
+		String   string `json:"string"`
+		Segments []struct {
+			Type string `json:"type"`
+			List []int  `json:"list"`
+		} `json:"segments"`
+		Length int `json:"length"`
+	} `json:"aspath"`
+	Community struct {
+		String string   `json:"string"`
+		List   []string `json:"list"`
+	} `json:"community"`
+	NextHops []FRRBGPNextHopInfo `json:"nexthops"`
+}
+
+// FRRBGPNextHopInfo holds next hop information of a BGP route,
+// as it can be retried from the "show bgp <family> detail json" CLI output.
+type FRRBGPNextHopInfo struct {
+	IP         string `json:"ip"`
+	Hostname   string `json:"hostname"`
+	Afi        string `json:"afi"`
+	Scope      string `json:"scope"`
+	Metric     int    `json:"metric"`
+	Accessible bool   `json:"accessible"`
+	Used       bool   `json:"used"`
+}
+
+// NewFRRDaemonSet returns a k8s DaemonSet with FRR, configured to run on "nodes without cilium".
+func NewFRRDaemonSet(params Parameters) *appsv1.DaemonSet {
+	ds := newDaemonSet(daemonSetParameters{
+		Name:         frrDaemonSetNameName,
+		Kind:         frrDaemonSetNameName,
+		Image:        params.FRRImage,
+		Labels:       map[string]string{"external": "frr"},
+		NodeSelector: map[string]string{"cilium.io/no-schedule": "true"},
+		HostNetwork:  true,
+		Tolerations: []corev1.Toleration{
+			{Operator: corev1.TolerationOpExists},
+		},
+		Capabilities: []corev1.Capability{"NET_ADMIN", "NET_RAW", "SYS_ADMIN"},
+	})
+	ds.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To[int64](0)
+	ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: frrConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: frrConfigMapName,
+					},
+				},
+			},
+		},
+	}
+	ds.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+		{
+			Name:      frrConfigMapName,
+			SubPath:   "daemons",
+			MountPath: "/etc/frr/daemons",
+		},
+		{
+			Name:      frrConfigMapName,
+			SubPath:   "vtysh.conf",
+			MountPath: "/etc/frr/vtysh.conf",
+		},
+	}
+	return ds
+}
+
+// NewFRRConfigMap returns a k8s ConfigMap used by the FRR DaemonSet, containing FRR daemon configuration.
+func NewFRRConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: frrConfigMapName,
+		},
+		Data: map[string]string{
+			"vtysh.conf": "service integrated-vtysh-config",
+			"daemons": `
+bgpd=yes
+ospfd=no
+ospf6d=no
+ripd=no
+ripngd=no
+isisd=no
+pimd=no
+ldpd=no
+nhrpd=no
+eigrpd=no
+babeld=no
+sharpd=no
+pbrd=no
+bfdd=yes
+fabricd=no
+vrrpd=no
+vtysh_enable=yes
+zebra_options="  -A 127.0.0.1 -s 90000000"
+bgpd_options="   -A 127.0.0.1"
+ospfd_options="  -A 127.0.0.1"
+ospf6d_options=" -A ::1"
+ripd_options="   -A 127.0.0.1"
+ripngd_options=" -A ::1"
+isisd_options="  -A 127.0.0.1"
+pimd_options="   -A 127.0.0.1"
+ldpd_options="   -A 127.0.0.1"
+nhrpd_options="  -A 127.0.0.1"
+eigrpd_options=" -A 127.0.0.1"
+babeld_options=" -A 127.0.0.1"
+sharpd_options=" -A 127.0.0.1"
+pbrd_options="   -A 127.0.0.1"
+staticd_options="-A 127.0.0.1"
+bfdd_options="   -A 127.0.0.1"
+fabricd_options="-A 127.0.0.1"
+vrrpd_options="  -A 127.0.0.1"
+MAX_FDS=1024
+`,
+		},
+	}
+}
+
+// RunFRRCommand runs a CLI command on the given FRR pod.
+func RunFRRCommand(ctx context.Context, t *Test, frrPod *Pod, cmd string) []byte {
+	cmdArr := []string{"vtysh", "-c", cmd}
+	stdout, stderr, err := frrPod.K8sClient.ExecInPodWithStderr(ctx,
+		frrPod.Pod.Namespace, frrPod.Pod.Name, frrPod.Pod.Labels["name"], cmdArr)
+	if err != nil || stderr.String() != "" {
+		t.Fatalf("failed to run FRR command: %v: %s", err, stderr.String())
+	}
+	return stdout.Bytes()
+}
+
+// ApplyFRRConfig applies provided CLI configuration on the given FRR pod
+// by replacing its existing config. Base FRR config is applied along with the provided one.
+func ApplyFRRConfig(ctx context.Context, t *Test, frrPod *Pod, config string) {
+	err := writeDataToPod(ctx, frrPod, "/etc/frr/frr.conf", []byte(frrBaseConfig+config))
+	if err != nil {
+		t.Fatalf("failed writing config to FRR: %v", err)
+	}
+	_, stderr, err := frrPod.K8sClient.ExecInPodWithStderr(ctx,
+		frrPod.Pod.Namespace, frrPod.Pod.Name, frrPod.Pod.Labels["name"], []string{"/usr/lib/frr/frr-reload"})
+	if err != nil { // do not check stderr - contains logs upon successful reload aas well
+		t.Fatalf("failed reloading FRR config: %v: %s", err, stderr.String())
+	}
+}
+
+// ClearFRRConfig clears configuration on the given FRR pod. Only base config remains applied.
+func ClearFRRConfig(ctx context.Context, t *Test, frrPod *Pod) {
+	ApplyFRRConfig(ctx, t, frrPod, "")
+}
+
+// RenderFRRBGPPeeringConfig renders standard BGP peering configuration for provided list of
+// peer addresses. The returned config can be used to apply in an FRR pod.
+func RenderFRRBGPPeeringConfig(t *Test, params FRRBGPPeeringParams) string {
+	var config bytes.Buffer
+	tpl, err := template.New("").Parse(frrBGPPeeringTemplate)
+	if err != nil {
+		t.Fatalf("failed to parse FRR config template: %v", err)
+	}
+	err = tpl.Execute(&config, params)
+	if err != nil {
+		t.Fatalf("failed to render FRR config template: %v", err)
+	}
+	return config.String()
+}
+
+// WaitForFRRBGPNeighborsState waits until provided list of BGP peers reach the provided state
+// on the provided FRR pod.
+func WaitForFRRBGPNeighborsState(ctx context.Context, t *Test, frrPod *Pod, expPeers []netip.Addr, expState string) {
+	w := wait.NewObserver(ctx, wait.Parameters{Timeout: 30 * time.Second})
+	defer w.Cancel()
+
+	ensureBGPNeighborsState := func() error {
+		stdout := RunFRRCommand(ctx, t, frrPod, "show bgp neighbor json")
+		entries := map[string]FRRBGPNeighborInfo{}
+		err := json.Unmarshal(stdout, &entries)
+		if err != nil {
+			return err
+		}
+		if len(entries) < len(expPeers) {
+			return fmt.Errorf("expected %d peers, got %d", len(expPeers), len(entries))
+		}
+		for _, peer := range expPeers {
+			frrPeer, exists := entries[peer.String()]
+			if !exists {
+				return fmt.Errorf("missing peer %s", peer.String())
+			}
+			if frrPeer.BGPState != expState {
+				return fmt.Errorf("peer %s: expected %s state, got %s", peer, expState, entries[peer.String()].BGPState)
+			}
+		}
+		return nil
+	}
+
+	for {
+		if err := ensureBGPNeighborsState(); err != nil {
+			if err := w.Retry(err); err != nil {
+				t.Fatalf("Failed to ensure FRR BGP neighbor states: %v", err)
+			}
+			continue
+		}
+		return
+	}
+}
+
+// WaitForFRRBGPPrefixes waits until the provided prefixes are learned via BGP on the provided FRR pod
+// and returns detailed information about all learned prefixes.
+func WaitForFRRBGPPrefixes(ctx context.Context, t *Test, frrPod *Pod, expPrefixes []netip.Prefix, ipFamily features.IPFamily) FRRBGPPrefixMap {
+	w := wait.NewObserver(ctx, wait.Parameters{Timeout: 15 * time.Second})
+	defer w.Cancel()
+
+	ensureBGPNeighborsState := func() (FRRBGPPrefixMap, error) {
+		cmd := "show bgp ipv4 detail json"
+		if ipFamily == features.IPFamilyV6 {
+			cmd = "show bgp ipv6 detail json"
+		}
+		stdout := RunFRRCommand(ctx, t, frrPod, cmd)
+		entries := FRRBGPAddressFamilyInfo{}
+		err := json.Unmarshal(stdout, &entries)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries.Routes) < len(expPrefixes) {
+			return nil, fmt.Errorf("expected %d prefixes, got %d", len(expPrefixes), len(entries.Routes))
+		}
+		for _, prefix := range expPrefixes {
+			if _, exists := entries.Routes[prefix.String()]; !exists {
+				return nil, fmt.Errorf("prefix %s missing on FFR", prefix.String())
+			}
+		}
+		return entries.Routes, nil
+	}
+
+	for {
+		frrPrefixes, err := ensureBGPNeighborsState()
+		if err != nil {
+			if err := w.Retry(err); err != nil {
+				t.Fatalf("Failed to ensure FRR BGP prefixes: %v", err)
+			}
+			continue
+		}
+		return frrPrefixes
+	}
+}
+
+// AssertFRRBGPCommunity asserts that provided BGP community is present in provided FRR BGP prefixes
+// filtered by checkPrefixes list.
+func AssertFRRBGPCommunity(t *Test, frrPrefixes FRRBGPPrefixMap, checkPrefixes []netip.Prefix, expectedCommunity string) {
+	for _, prefix := range checkPrefixes {
+		for _, frrPrefix := range frrPrefixes[prefix.String()] {
+			if frrPrefix.Community.String != expectedCommunity {
+				t.Fatalf("prefix %s: expected community '%s', got '%s'", prefix.String(), expectedCommunity, frrPrefix.Community.String)
+			}
+		}
+	}
+}
+
+// DumpFRRBGPState dumps FRR's BGP state into the log.
+func DumpFRRBGPState(ctx context.Context, t *Test, frrPod *Pod) {
+	t.Logf("FRR %s state:", frrPod.Name())
+	t.Logf("%s", RunFRRCommand(ctx, t, frrPod, "show bgp neighbors"))
+	t.Logf("%s", RunFRRCommand(ctx, t, frrPod, "show bgp ipv4 detail"))
+	t.Logf("%s", RunFRRCommand(ctx, t, frrPod, "show bgp ipv6 detail"))
+}
+
+func writeDataToPod(ctx context.Context, pod *Pod, filePath string, data []byte) error {
+	encodedData := base64.StdEncoding.EncodeToString(data)
+	_, stderr, err := pod.K8sClient.ExecInPodWithStderr(ctx,
+		pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Labels["name"],
+		[]string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d > %s", encodedData, filePath)})
+
+	if err != nil || stderr.String() != "" {
+		return fmt.Errorf("failed writing data to pod: %s: %s", err, stderr.String())
+	}
+	return nil
+}

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -170,6 +170,10 @@ func (t *Test) Name() string {
 	return t.name
 }
 
+func (t *Test) Failed() bool {
+	return t.failed
+}
+
 // ScenarioName returns the Test name and Scenario name concatenated in
 // a standard way. Scenario names are not unique, as they can occur multiple
 // times in the same Test.

--- a/connectivity/tests/bgp.go
+++ b/connectivity/tests/bgp.go
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+const (
+	bgpPeeringPolicyName = "test-bgp-peering-policy"
+	bgpAdvertisementName = "test-bgp-advertisement"
+	bgpPeerConfigName    = "test-bgp-peer-config"
+	bgpClusterConfigName = "test-bgp-cluster-config"
+
+	bgpCiliumASN = 65001
+	bgpFRRASN    = 65000
+
+	bgpCommunityPodCIDR = "65001:100"
+	bgpCommunityService = "65001:200"
+)
+
+func BGPAdvertisements(bgpAPIVersion uint8) check.Scenario {
+	return &bgpAdvertisements{
+		bgpAPIVersion: bgpAPIVersion,
+	}
+}
+
+type bgpAdvertisements struct {
+	bgpAPIVersion uint8
+}
+
+func (s *bgpAdvertisements) Name() string {
+	return fmt.Sprintf("bgpv%d-advertisements", s.bgpAPIVersion)
+}
+
+func (s *bgpAdvertisements) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+
+	t.ForEachIPFamily(func(ipFamily features.IPFamily) {
+		defer func() {
+			s.cleanup(ctx, t)
+		}()
+
+		// configure FRR
+		frrPeers := ct.InternalNodeIPAddresses(ipFamily)
+		frrConfig := check.RenderFRRBGPPeeringConfig(t, check.FRRBGPPeeringParams{
+			LocalASN: bgpFRRASN,
+			Peers:    frrPeers,
+		})
+		for _, frr := range ct.FRRPods() {
+			check.ApplyFRRConfig(ctx, t, &frr, frrConfig)
+		}
+
+		// configure BGP on Cilium
+		if s.bgpAPIVersion == 1 {
+			s.configureBGPv1Peering(ctx, t, ipFamily)
+		} else {
+			s.configureBGPv2Peering(ctx, t, ipFamily)
+		}
+
+		// wait for BGP peers and expected prefixes
+		podCIDRPrefixes := ct.PodCIDRPrefixes(ipFamily)
+		svcPrefixes := ct.EchoServicePrefixes(ipFamily)
+		for _, frr := range ct.FRRPods() {
+			check.WaitForFRRBGPNeighborsState(ctx, t, &frr, frrPeers, "Established")
+
+			frrPrefixes := check.WaitForFRRBGPPrefixes(ctx, t, &frr, podCIDRPrefixes, ipFamily)
+			check.AssertFRRBGPCommunity(t, frrPrefixes, podCIDRPrefixes, bgpCommunityPodCIDR)
+
+			frrPrefixes = check.WaitForFRRBGPPrefixes(ctx, t, &frr, svcPrefixes, ipFamily)
+			if s.bgpAPIVersion != 1 { // BGPv1 does not support path attributes for ClusterIP service advertisements
+				check.AssertFRRBGPCommunity(t, frrPrefixes, svcPrefixes, bgpCommunityService)
+			}
+		}
+
+		for _, client := range ct.ExternalEchoPods() {
+			// curl from external echo pods to in-cluster echo pods
+			i := 0
+			for _, echo := range ct.EchoPods() {
+				t.NewAction(s, fmt.Sprintf("curl-echo-pod-%s-%d", ipFamily, i), &client, echo, ipFamily).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, ct.CurlCommand(echo, ipFamily))
+				})
+				i++
+			}
+			//  curl from external echo pods to ClusterIP service IPs
+			i = 0
+			if status, ok := ct.Feature(features.BPFLBExternalClusterIP); ok && status.Enabled {
+				for _, echo := range ct.EchoServices() {
+					t.NewAction(s, fmt.Sprintf("curl-echo-service-%s-%d", ipFamily, i), &client, echo, ipFamily).Run(func(a *check.Action) {
+						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFamily))
+					})
+					i++
+				}
+			}
+		}
+	})
+}
+
+func (s *bgpAdvertisements) cleanup(ctx context.Context, t *check.Test) {
+	if t.Failed() {
+		for _, frr := range t.Context().FRRPods() {
+			check.DumpFRRBGPState(ctx, t, &frr)
+		}
+	}
+
+	// delete test-configured K8s resources
+	s.deleteK8sResources(ctx, t)
+
+	// clear FRR config
+	for _, frr := range t.Context().FRRPods() {
+		check.ClearFRRConfig(ctx, t, &frr)
+	}
+}
+
+func (s *bgpAdvertisements) deleteK8sResources(ctx context.Context, t *check.Test) {
+	client := t.Context().K8sClient().CiliumClientset.CiliumV2alpha1()
+
+	if s.bgpAPIVersion == 1 {
+		check.DeleteK8sResourceWithWait(ctx, t, client.CiliumBGPPeeringPolicies(), bgpPeeringPolicyName)
+	} else {
+		check.DeleteK8sResourceWithWait(ctx, t, client.CiliumBGPClusterConfigs(), bgpClusterConfigName)
+		check.DeleteK8sResourceWithWait(ctx, t, client.CiliumBGPPeerConfigs(), bgpPeerConfigName)
+		check.DeleteK8sResourceWithWait(ctx, t, client.CiliumBGPAdvertisements(), bgpAdvertisementName)
+	}
+}
+
+func (s *bgpAdvertisements) configureBGPv1Peering(ctx context.Context, t *check.Test, ipFamily features.IPFamily) {
+	ct := t.Context()
+	client := ct.K8sClient().CiliumClientset.CiliumV2alpha1()
+	s.deleteK8sResources(ctx, t)
+
+	peeringPolicy := &ciliumv2alpha1.CiliumBGPPeeringPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: bgpPeeringPolicyName,
+		},
+		Spec: ciliumv2alpha1.CiliumBGPPeeringPolicySpec{
+			VirtualRouters: []ciliumv2alpha1.CiliumBGPVirtualRouter{
+				{
+					LocalASN:      bgpCiliumASN,
+					ExportPodCIDR: ptr.To[bool](true),
+					ServiceSelector: &slimv1.LabelSelector{
+						MatchLabels: map[string]string{"kind": "echo"},
+					},
+					ServiceAdvertisements: []ciliumv2alpha1.BGPServiceAddressType{
+						ciliumv2alpha1.BGPClusterIPAddr,
+					},
+				},
+			},
+		},
+	}
+	prefix := "/32"
+	if ipFamily == features.IPFamilyV6 {
+		prefix = "/128"
+	}
+	for _, frr := range ct.FRRPods() {
+		peeringPolicy.Spec.VirtualRouters[0].Neighbors = append(peeringPolicy.Spec.VirtualRouters[0].Neighbors,
+			ciliumv2alpha1.CiliumBGPNeighbor{
+				PeerAddress:             frr.Address(ipFamily) + prefix,
+				PeerASN:                 bgpFRRASN,
+				ConnectRetryTimeSeconds: ptr.To[int32](1),
+				KeepAliveTimeSeconds:    ptr.To[int32](1),
+				HoldTimeSeconds:         ptr.To[int32](3),
+				AdvertisedPathAttributes: []ciliumv2alpha1.CiliumBGPPathAttributes{
+					{
+						SelectorType: ciliumv2alpha1.PodCIDRSelectorName,
+						Communities: &ciliumv2alpha1.BGPCommunities{
+							Standard: []ciliumv2alpha1.BGPStandardCommunity{bgpCommunityPodCIDR},
+						},
+					},
+				},
+			})
+	}
+	_, err := client.CiliumBGPPeeringPolicies().Create(ctx, peeringPolicy, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create CiliumBGPPeeringPolicy: %v", err)
+	}
+}
+
+func (s *bgpAdvertisements) configureBGPv2Peering(ctx context.Context, t *check.Test, ipFamily features.IPFamily) {
+	ct := t.Context()
+	client := ct.K8sClient().CiliumClientset.CiliumV2alpha1()
+	s.deleteK8sResources(ctx, t)
+
+	// configure advertisement
+	advertisement := &ciliumv2alpha1.CiliumBGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   bgpAdvertisementName,
+			Labels: map[string]string{"test": s.Name()},
+		},
+		Spec: ciliumv2alpha1.CiliumBGPAdvertisementSpec{
+			Advertisements: []ciliumv2alpha1.BGPAdvertisement{
+				{
+					AdvertisementType: ciliumv2alpha1.BGPPodCIDRAdvert,
+					Attributes: &ciliumv2alpha1.BGPAttributes{
+						Communities: &ciliumv2alpha1.BGPCommunities{
+							Standard: []ciliumv2alpha1.BGPStandardCommunity{bgpCommunityPodCIDR},
+						},
+					},
+				},
+				{
+					AdvertisementType: ciliumv2alpha1.BGPServiceAdvert,
+					Service: &ciliumv2alpha1.BGPServiceOptions{
+						Addresses: []ciliumv2alpha1.BGPServiceAddressType{ciliumv2alpha1.BGPClusterIPAddr},
+					},
+					Selector: &slimv1.LabelSelector{
+						MatchLabels: map[string]string{"kind": "echo"},
+					},
+					Attributes: &ciliumv2alpha1.BGPAttributes{
+						Communities: &ciliumv2alpha1.BGPCommunities{
+							Standard: []ciliumv2alpha1.BGPStandardCommunity{bgpCommunityService},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := client.CiliumBGPAdvertisements().Create(ctx, advertisement, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create CiliumBGPAdvertisement: %v", err)
+	}
+
+	// configure peer config
+	peerConfig := &ciliumv2alpha1.CiliumBGPPeerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: bgpPeerConfigName,
+		},
+		Spec: ciliumv2alpha1.CiliumBGPPeerConfigSpec{
+			Timers: &ciliumv2alpha1.CiliumBGPTimers{
+				ConnectRetryTimeSeconds: ptr.To[int32](1),
+				KeepAliveTimeSeconds:    ptr.To[int32](1),
+				HoldTimeSeconds:         ptr.To[int32](3),
+			},
+			Families: []ciliumv2alpha1.CiliumBGPFamilyWithAdverts{
+				{
+					CiliumBGPFamily: ciliumv2alpha1.CiliumBGPFamily{
+						Afi:  ipFamily.String(),
+						Safi: "unicast",
+					},
+					Advertisements: &slimv1.LabelSelector{
+						MatchLabels: advertisement.Labels,
+					},
+				},
+			},
+		},
+	}
+	_, err = client.CiliumBGPPeerConfigs().Create(ctx, peerConfig, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create CiliumBGPPeerConfig: %v", err)
+	}
+
+	// configure cluster config
+	clusterConfig := &ciliumv2alpha1.CiliumBGPClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: bgpClusterConfigName,
+		},
+		Spec: ciliumv2alpha1.CiliumBGPClusterConfigSpec{
+			BGPInstances: []ciliumv2alpha1.CiliumBGPInstance{
+				{
+					Name:     "test-instance",
+					LocalASN: ptr.To[int64](bgpCiliumASN),
+				},
+			},
+		},
+	}
+	for _, frr := range ct.FRRPods() {
+		clusterConfig.Spec.BGPInstances[0].Peers = append(clusterConfig.Spec.BGPInstances[0].Peers,
+			ciliumv2alpha1.CiliumBGPPeer{
+				Name:        "peer-" + frr.Address(ipFamily),
+				PeerAddress: ptr.To[string](frr.Address(ipFamily)),
+				PeerASN:     ptr.To[int64](bgpFRRASN),
+				PeerConfigRef: &ciliumv2alpha1.PeerConfigReference{
+					Name: peerConfig.Name,
+				},
+			})
+	}
+	_, err = client.CiliumBGPClusterConfigs().Create(ctx, clusterConfig, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create CiliumBGPClusterConfig: %v", err)
+	}
+}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -71,6 +71,8 @@ const (
 	ConnectivityDNSTestServerImage = "docker.io/coredns/coredns:1.11.1@sha256:1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1"
 	// renovate: datasource=docker
 	ConnectivityTestConnDisruptImage = "quay.io/cilium/test-connection-disruption:v0.0.14@sha256:c3fd56e326ae16f6cb63dbb2e26b4e47ec07a123040623e11399a7fe1196baa0"
+	// renovate: datasource=docker
+	ConnectivityTestFRRImage = "quay.io/frrouting/frr:10.0.1@sha256:83e2ff39e9c033c086e02e1cfd32ff188837a666876212f2a875bd85a79afb7c"
 
 	ConfigMapName = "cilium-config"
 

--- a/k8s/types.go
+++ b/k8s/types.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourceClient is a common client interface for typed k8s resource clients.
+type ResourceClient[T any] interface {
+	Create(ctx context.Context, r *T, opts metav1.CreateOptions) (*T, error)
+	Update(ctx context.Context, r *T, opts metav1.UpdateOptions) (*T, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*T, error)
+}

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -32,6 +32,8 @@ const (
 	KPRNodePort            Feature = "kpr-nodeport"
 	KPRSessionAffinity     Feature = "kpr-session-affinity"
 
+	BPFLBExternalClusterIP Feature = "bpf-lb-external-clusterip"
+
 	HostPort Feature = "host-port"
 
 	NodeWithoutCilium Feature = "node-without-cilium"
@@ -72,6 +74,8 @@ const (
 	ClusterMeshEnableEndpointSync Feature = "clustermesh-enable-endpoint-sync"
 
 	LocalRedirectPolicy Feature = "enable-local-redirect-policy"
+
+	BGPControlPlane Feature = "enable-bgp-control-plane"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -295,6 +299,14 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[LocalRedirectPolicy] = Status{
 		Enabled: cm.Data[string(LocalRedirectPolicy)] == "true",
+	}
+
+	fs[BPFLBExternalClusterIP] = Status{
+		Enabled: cm.Data[string(BPFLBExternalClusterIP)] == "true",
+	}
+
+	fs[BGPControlPlane] = Status{
+		Enabled: cm.Data[string(BGPControlPlane)] == "true",
 	}
 }
 

--- a/utils/features/features_test.go
+++ b/utils/features/features_test.go
@@ -141,6 +141,8 @@ func TestFeatureSet_extractFromConfigMap(t *testing.T) {
 		"ipam":                         "eni",
 		"enable-ipsec":                 "true",
 		"enable-local-redirect-policy": "true",
+		"bpf-lb-external-clusterip":    "true",
+		"enable-bgp-control-plane":     "true",
 	}
 	fs.ExtractFromConfigMap(&cm)
 	assert.True(t, fs[IPv4].Enabled)
@@ -149,5 +151,7 @@ func TestFeatureSet_extractFromConfigMap(t *testing.T) {
 	assert.True(t, fs[EgressGateway].Enabled)
 	assert.True(t, fs[IPsecEnabled].Enabled)
 	assert.True(t, fs[LocalRedirectPolicy].Enabled)
+	assert.True(t, fs[BPFLBExternalClusterIP].Enabled)
+	assert.True(t, fs[BGPControlPlane].Enabled)
 	assert.Equal(t, "eni", fs[CiliumIPAMMode].Mode)
 }


### PR DESCRIPTION
Introduces BGP Control Plane connectivity tests, working with FRR router instance running in the host network namespace on the `node-without-cilium`.

The aim of this PR is mostly to introduce the BGP + FRR testing infrastructure, more testing scenarios need to be added in follow-up PRs. At the moment, we are testing:

- BGPv1 control plane, IPv4 + IPv6 scenario,
- BGPv2 control plane, IPv4 + IPv6 scenario,
- in both scenarios we test PodCIDR advertisements and ClusterIP service advertisements.

<details>
  <summary>Example run with debug enabled:</summary>

```
[=] [cilium-test] Test [bgp-control-plane-v1] [80/84]
  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-pod-ipv4-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-same-node-7f896b84-sbqv4 (10.244.1.188:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.244.1.188:8080]
.  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-pod-ipv4-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-other-node-58999bbffd-qsrq8 (10.244.0.254:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.244.0.254:8080]
  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-service-ipv4-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-same-node (10.96.136.144:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.96.136.144:8080]
..  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-service-ipv4-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-other-node (10.96.194.250:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.96.194.250:8080]
.  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-pod-ipv6-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-other-node-58999bbffd-qsrq8 (fd00:10:244::9227:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:244::9227]:8080]
.  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-pod-ipv6-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-same-node-7f896b84-sbqv4 (fd00:10:244:1::1a8:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:244:1::1a8]:8080]
  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-service-ipv6-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-same-node (fd00:10:96::4567:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:96::4567]:8080]
..  [.] Action [bgp-control-plane-v1/bgpv1-advertisements/curl-echo-service-ipv6-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-other-node (fd00:10:96::4763:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:96::4763]:8080]
.  🐛 Finalizing Test bgp-control-plane-v1
  [-] Scenario [bgp-control-plane-v2/bgpv2-advertisements]
[=] [cilium-test] Test [bgp-control-plane-v2] [81/84]
  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-pod-ipv4-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-other-node-58999bbffd-qsrq8 (10.244.0.254:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.244.0.254:8080]
.  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-pod-ipv4-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-same-node-7f896b84-sbqv4 (10.244.1.188:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.244.1.188:8080]
.  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-service-ipv4-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-other-node (10.96.194.250:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.96.194.250:8080]
.  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-service-ipv4-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (172.22.0.4) -> cilium-test/echo-same-node (10.96.136.144:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://10.96.136.144:8080]
.  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-pod-ipv6-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-other-node-58999bbffd-qsrq8 (fd00:10:244::9227:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:244::9227]:8080]
.  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-pod-ipv6-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-same-node-7f896b84-sbqv4 (fd00:10:244:1::1a8:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:244:1::1a8]:8080]
.  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-service-ipv6-0: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-same-node (fd00:10:96::4567:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:96::4567]:8080]
.  [.] Action [bgp-control-plane-v2/bgpv2-advertisements/curl-echo-service-ipv6-1: cilium-test/echo-external-node-89864b5bd-4lzt4 (fc00:c111::4) -> cilium-test/echo-other-node (fd00:10:96::4763:8080)]
  🐛 Executing command [curl -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code} --silent --fail --show-error --output /dev/null --connect-timeout 2 --max-time 10 http://[fd00:10:96::4763]:8080]
.  🐛 Finalizing Test bgp-control-plane-v2
```
</details>

Example e2e job: https://github.com/cilium/cilium/actions/runs/9778585998/job/26995747615