### PR TITLE
connectivity: Label test namespaces

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -150,6 +150,7 @@ jobs:
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=5 --collect-sysdump-on-failure --external-target bing.com.
+          kubectl delete namespace -l "app.kubernetes.io/name=cilium-cli"
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -168,6 +168,7 @@ jobs:
             # - https://github.com/cilium/cilium/issues/16975 is fixed
             # - fix has been deployed to a stable branch
             # - cilium-cli default cilium version has been updated to pick up the fix
+          kubectl delete namespace -l "app.kubernetes.io/name=cilium-cli"
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -161,6 +161,7 @@ jobs:
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=3 --all-flows --collect-sysdump-on-failure --external-target amazon.com.
+          kubectl delete namespace -l "app.kubernetes.io/name=cilium-cli"
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -215,6 +215,7 @@ jobs:
         run: |
           # Run connectivity test
           cilium connectivity test --test-concurrency=5 --all-flows --collect-sysdump-on-failure --external-target google.com.
+          kubectl delete namespace -l "app.kubernetes.io/name=cilium-cli"
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -156,6 +156,7 @@ jobs:
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=5 --all-flows --collect-sysdump-on-failure --external-target google.com.
+          kubectl delete namespace -l "app.kubernetes.io/name=cilium-cli"
 
           # Run performance test
           cilium connectivity perf --duration 1s

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -67,6 +67,12 @@ const (
 	KindTestConnDisrupt                 = "test-conn-disrupt"
 )
 
+var (
+	appLabels = map[string]string{
+		"app.kubernetes.io/name": "cilium-cli",
+	}
+)
+
 type deploymentParameters struct {
 	Name                          string
 	Kind                          string
@@ -409,6 +415,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        ct.params.TestNamespace,
 					Annotations: ct.params.NamespaceAnnotations,
+					Labels:      appLabels,
 				},
 			}
 			_, err = client.CreateNamespace(ctx, namespace, metav1.CreateOptions{})


### PR DESCRIPTION
Sometimes the perf command fails to schedule pods because there are too many pods [^1]. Add app.kubernetes.io/name label [^2] to connectivity test namespaces, and use the label to delete test namespaces before running the perf command.

[^1]: https://github.com/cilium/cilium-cli/actions/runs/9730132031/job/26852838732
[^2]: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels