### PR TITLE
Allow changing Kube Service type for connectivity tests

### DIFF
--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -130,6 +130,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalIP, "external-ip", "1.1.1.1", "IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")
+	cmd.Flags().StringVar(&params.ServiceType, "service-type", "NodePort", "Type of Kubernetes Services created for connectivity tests")
 	cmd.Flags().StringSliceVar(&params.NodeCIDRs, "node-cidr", nil, "one or more CIDRs that cover all nodes in the cluster")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
 	cmd.Flags().StringToStringVar(&params.JunitProperties, "junit-property", map[string]string{}, "Add key=value properties to the generated junit file")

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -67,6 +67,7 @@ type Parameters struct {
 	ExternalIP             string
 	ExternalDeploymentPort int
 	ExternalOtherIP        string
+	ServiceType            string
 	EchoServerHostPort     int
 	PodCIDRs               []podCIDRs
 	NodeCIDRs              []string

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -303,7 +303,7 @@ var serviceLabels = map[string]string{
 	"kind": kindEchoName,
 }
 
-func newService(name string, selector map[string]string, labels map[string]string, portName string, port int) *corev1.Service {
+func newService(name string, selector map[string]string, labels map[string]string, portName string, port int, serviceType string) *corev1.Service {
 	ipFamPol := corev1.IPFamilyPolicyPreferDualStack
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -311,7 +311,7 @@ func newService(name string, selector map[string]string, labels map[string]strin
 			Labels: labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
+			Type: corev1.ServiceType(serviceType),
 			Ports: []corev1.ServicePort{
 				{Name: portName, Port: int32(port)},
 			},
@@ -470,7 +470,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			_, err = client.GetService(ctx, ct.params.TestNamespace, testConnDisruptServiceName, metav1.GetOptions{})
 			if err != nil {
 				ct.Logf("✨ [%s] Deploying %s service...", client.ClusterName(), testConnDisruptServiceName)
-				svc := newService(testConnDisruptServiceName, map[string]string{"app": "test-conn-disrupt-server"}, nil, "http", 8000)
+				svc := newService(testConnDisruptServiceName, map[string]string{"app": "test-conn-disrupt-server"}, nil, "http", 8000, ct.Params().ServiceType)
 				svc.ObjectMeta.Annotations = map[string]string{"service.cilium.io/global": "true"}
 				_, err = client.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
 				if err != nil {
@@ -523,7 +523,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	_, err = ct.clients.src.GetService(ctx, ct.params.TestNamespace, echoSameNodeDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying %s service...", ct.clients.src.ClusterName(), echoSameNodeDeploymentName)
-		svc := newService(echoSameNodeDeploymentName, map[string]string{"name": echoSameNodeDeploymentName}, serviceLabels, "http", 8080)
+		svc := newService(echoSameNodeDeploymentName, map[string]string{"name": echoSameNodeDeploymentName}, serviceLabels, "http", 8080, ct.Params().ServiceType)
 		_, err = ct.clients.src.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
 		if err != nil {
 			return err
@@ -532,7 +532,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 
 	if ct.params.MultiCluster != "" {
 		_, err = ct.clients.src.GetService(ctx, ct.params.TestNamespace, echoOtherNodeDeploymentName, metav1.GetOptions{})
-		svc := newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, serviceLabels, "http", 8080)
+		svc := newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, serviceLabels, "http", 8080, ct.Params().ServiceType)
 		svc.ObjectMeta.Annotations = map[string]string{}
 		svc.ObjectMeta.Annotations["service.cilium.io/global"] = "true"
 		svc.ObjectMeta.Annotations["io.cilium/global-service"] = "true"
@@ -763,7 +763,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if !ct.params.SingleNode || ct.params.MultiCluster != "" {
 
 		_, err = ct.clients.dst.GetService(ctx, ct.params.TestNamespace, echoOtherNodeDeploymentName, metav1.GetOptions{})
-		svc := newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, serviceLabels, "http", 8080)
+		svc := newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, serviceLabels, "http", 8080, ct.Params().ServiceType)
 		if ct.params.MultiCluster != "" {
 			svc.ObjectMeta.Annotations = map[string]string{}
 			svc.ObjectMeta.Annotations["service.cilium.io/global"] = "true"
@@ -911,9 +911,8 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 
 				svc := newService(echoExternalNodeDeploymentName,
 					map[string]string{"name": echoExternalNodeDeploymentName, "kind": kindEchoExternalNodeName},
-					map[string]string{"kind": kindEchoExternalNodeName}, "http", 8080)
+					map[string]string{"kind": kindEchoExternalNodeName}, "http", 8080, "ClusterIP")
 				svc.Spec.ClusterIP = corev1.ClusterIPNone
-				svc.Spec.Type = corev1.ServiceTypeClusterIP
 				_, err := ct.clients.src.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
 				if err != nil {
 					return fmt.Errorf("unable to create service %s: %w", echoExternalNodeDeploymentName, err)


### PR DESCRIPTION
# Description
The goal of this PR is to allow users to change the type of Services created by automated connectivity tests. 

The default type is hardcoded to `NodePort` which is not necessarily the best choice for everyone. For example, we are currently setting up a [GateKeeper rule](https://open-policy-agent.github.io/gatekeeper-library/website/validation/block-nodeport-services) to block `NodePort` service creation in all of our clusters, mainly for security, performance and practicality reasons (for more context, see for instance https://oteemo.com/think-nodeport-kubernetes/).

The newly added parameter looks like this (and still has `NodePort` as the default):
```
      --service-type string             Type of Kubernetes Services created for connectivity tests (default "NodePort")
```

# Testing
- [x] Ran the tests without setting `--service-type`, verified that `NodePort` services were still being created
- [x] Ran the tests with `--service-type=ClusterIP`, verified that `ClusterIP` services were properly created:
```
$ kubectl -n cilium-test get svc echo-other-node
NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
echo-other-node   ClusterIP   10.x.x.x        <none>        8080/TCP   4m23s
```
- [x] Ran the tests with an invalid value `--service-type=FAIL`, verified that the tests failed with a clear error:
```
connectivity test failed: Service "echo-same-node" is invalid: spec.type: Unsupported value: "FAIL": supported values: "ClusterIP", "ExternalName", "LoadBalancer", "NodePort"
```