### PR TITLE
action: Use github.action_path when accessing cilium.sh

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -108,7 +108,7 @@ runs:
         done
         export CILIUM_CLI_IMAGE_REPO=${{ inputs.image-repo }}
         export CILIUM_CLI_IMAGE_TAG=${{ inputs.image-tag }}
-        cat .github/tools/cilium.sh | envsubst > /tmp/cilium
+        cat ${{ github.action_path }}/.github/tools/cilium.sh | envsubst > /tmp/cilium
         sudo install /tmp/cilium ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
 
     - name: Run Cilium CLI Version


### PR DESCRIPTION
Use ${{ github.action_path }} [^1] when accessing cilium.sh. Otherwise this action cannot find the file when it's used in a different repo.

[^1]: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context