### PR TITLE
Add --disable-check flag back

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -89,6 +89,7 @@ cilium install --context kind-cluster1 --set cluster.id=1 --set cluster.name=clu
 	cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "Write resources to be installed to stdout without actually installing them")
 	cmd.Flags().BoolVar(&params.DryRunHelmValues, "dry-run-helm-values", false, "Write non-default Helm values to stdout without performing the actual installation")
 	cmd.Flags().StringVar(&params.HelmRepository, "repository", defaults.HelmRepository, "Helm chart repository to download Cilium charts from")
+	cmd.Flags().StringSliceVar(&params.DisableChecks, "disable-check", []string{}, "Disable a particular validation check")
 	return cmd
 }
 


### PR DESCRIPTION
I accidentally removed this flag in #2328. Validation checks still exist [^1], so it's useful to have this flag.

Tested locally by disabling Kind version check:

    % ./cilium install --disable-check=minimum-version
    🔮 Auto-detected Kubernetes kind: kind
    ✨ Running "kind" validation checks
    ⏭️   Skipping disabled validation test "minimum-version"
    ℹ️   Using Cilium version 1.15.6
    🔮 Auto-detected cluster name: kind-chart-testing
    🔮 Auto-detected kube-proxy has been installed

Fixes: e435b47ba63c ("Delete classic mode install/uninstall/upgrade commands")

[^1]: https://github.com/cilium/cilium-cli/blob/120fcbbb52845e04f94412fb44190ac450080a61/install/autodetect.go#L24-L33