### PR TITLE
connectivity: add local-redirect-policy-with-node-dns test

### DIFF
--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -248,6 +248,7 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 	tests := []testBuilder{
 		hostFirewallIngress{},
 		hostFirewallEgress{},
+		localRedirectPolicyWithNodeDNS{},
 	}
 	return injectTests(tests, ct)
 }
@@ -268,6 +269,7 @@ func renderTemplates(param check.Parameters) (map[string]string, error) {
 		"clientEgressToFQDNsPolicyYAML":            clientEgressToFQDNsPolicyYAML,
 		"clientEgressL7TLSPolicyYAML":              clientEgressL7TLSPolicyYAML,
 		"clientEgressL7HTTPMatchheaderSecretYAML":  clientEgressL7HTTPMatchheaderSecretYAML,
+		"clientEgressNodeLocalDNSYAML":             clientEgressNodeLocalDNSYAML,
 		"echoIngressFromCIDRYAML":                  echoIngressFromCIDRYAML,
 		"denyCIDRPolicyYAML":                       denyCIDRPolicyYAML,
 	}

--- a/connectivity/builder/local_redirect_policy_with_nodedns.go
+++ b/connectivity/builder/local_redirect_policy_with_nodedns.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/deploy"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+var (
+	//go:embed manifests/node-local-dns-lrp.yaml
+	nodeDNSLocalRedirectPolicyYAML string
+
+	//go:embed manifests/client-egress-node-local-dns.yaml
+	clientEgressNodeLocalDNSYAML string
+)
+
+type localRedirectPolicyWithNodeDNS struct{}
+
+func (t localRedirectPolicyWithNodeDNS) build(ct *check.ConnectivityTest, template map[string]string) {
+	newTest("local-redirect-policy-with-node-dns", ct).
+		WithSetupFunc(deploy.NodeDNS).
+		WithCiliumPolicy(template["clientEgressNodeLocalDNSYAML"]).
+		WithCiliumLocalRedirectPolicy(check.CiliumLocalRedirectPolicyParams{
+			Policy:                  nodeDNSLocalRedirectPolicyYAML,
+			NameSpace:               "kube-system",
+			Name:                    "nodelocaldns",
+			SkipRedirectFromBackend: false,
+		}).
+		WithFeatureRequirements(features.RequireEnabled(features.LocalRedirectPolicy)).
+		WithFeatureRequirements(features.RequireEnabled(features.KPRSocketLB)).
+		WithScenarios(
+			tests.LRPWithNodeDNS(),
+		)
+}

--- a/connectivity/builder/manifests/client-egress-node-local-dns.yaml
+++ b/connectivity/builder/manifests/client-egress-node-local-dns.yaml
@@ -1,0 +1,33 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-node-local-dns
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEndpoints:
+    - matchLabels:
+        k8s-app: node-local-dns
+        io.kubernetes.pod.namespace: kube-system
+    # Allow GET / requests, only towards {{.ExternalTarget}}.
+  - toFQDNs:
+    - matchName: "{{.ExternalTarget}}"
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/"

--- a/connectivity/builder/manifests/node-local-dns-lrp.yaml
+++ b/connectivity/builder/manifests/node-local-dns-lrp.yaml
@@ -1,0 +1,20 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "nodelocaldns"
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: kube-dns
+      namespace: kube-system
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        k8s-app: node-local-dns
+    toPorts:
+      - port: "53"
+        name: dns
+        protocol: UDP
+      - port: "53"
+        name: dns-tcp
+        protocol: TCP

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -547,6 +547,9 @@ type CiliumLocalRedirectPolicyParams struct {
 	// Policy is the local redirect policy yaml.
 	Policy string
 
+	// NameSpace is the name space of the local redirect policy.
+	NameSpace string
+
 	// Name is the name of the local redirect policy.
 	Name string
 
@@ -563,10 +566,17 @@ func (t *Test) WithCiliumLocalRedirectPolicy(params CiliumLocalRedirectPolicyPar
 		t.Fatalf("Parsing local redirect policy YAML: %s", err)
 	}
 
+	ns := t.ctx.params.TestNamespace
+	if len(params.NameSpace) > 0 {
+		ns = params.NameSpace
+	}
+
 	for i := range pl {
-		pl[i].Namespace = t.ctx.params.TestNamespace
+		pl[i].Namespace = ns
 		pl[i].Name = params.Name
-		pl[i].Spec.RedirectFrontend.AddressMatcher.IP = params.FrontendIP
+		if pl[i].Spec.RedirectFrontend.AddressMatcher != nil {
+			pl[i].Spec.RedirectFrontend.AddressMatcher.IP = params.FrontendIP
+		}
 		pl[i].Spec.SkipRedirectFromBackend = params.SkipRedirectFromBackend
 	}
 

--- a/connectivity/deploy/manifests/node-local-dns-cm.yaml
+++ b/connectivity/deploy/manifests/node-local-dns-cm.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        health
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__UPSTREAM__SERVERS__
+        prometheus :9253
+        }

--- a/connectivity/deploy/manifests/node-local-dns-ds.yaml
+++ b/connectivity/deploy/manifests/node-local-dns-ds.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: node-local-dns
+      annotations:
+        policy.cilium.io/no-track-port: "53"
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cilium.io/no-schedule
+                operator: NotIn
+                values:
+                - "true"
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.15.16
+        resources:
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args: [ "-localip", "169.254.20.10,{{.PILLAR_DNS_SERVER}}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream", "-skipteardown=true", "-setupinterface=false", "-setupiptables=false" ]
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        - name: kube-dns-config
+          mountPath: /etc/kube-dns
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true
+      - name: config-volume
+        configMap:
+          name: node-local-dns
+          items:
+            - key: Corefile
+              path: Corefile.base

--- a/connectivity/deploy/manifests/node-local-dns-service.yaml
+++ b/connectivity/deploy/manifests/node-local-dns-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-upstream
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: "KubeDNSUpstream"
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/connectivity/deploy/nodedns.go
+++ b/connectivity/deploy/nodedns.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package deploy
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/cilium/cilium-cli/connectivity/builder/manifests/template"
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/k8s"
+)
+
+var (
+	//go:embed manifests/node-local-dns-service.yaml
+	nodeLocalDNSService string
+
+	//go:embed manifests/node-local-dns-cm.yaml
+	nodeLocalDNSConfigMap string
+
+	//go:embed manifests/node-local-dns-ds.yaml
+	nodeLocalDNSDaemonSet string
+)
+
+func NodeDNS(ctx context.Context, t *check.Test, ct *check.ConnectivityTest) error {
+	var (
+		ns      = "kube-system"
+		name    = "node-local-dns"
+		svcName = "kube-dns-upstream"
+		clients = ct.Clients()
+	)
+
+	client := clients[0]
+
+	_, err := client.GetServiceAccount(ctx, ns, name, metav1.GetOptions{})
+	if err != nil {
+		_, err = client.CreateServiceAccount(ctx, ns, k8s.NewServiceAccount(name), metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create service account %s: %w", name, err)
+		}
+	}
+
+	t.WithFinalizer(func(_ context.Context) error {
+		// Use a detached context to make sure this call is not affected by
+		// context cancellation. This deletion needs to happen event when the
+		// user interrupted the program.
+		if err := client.DeleteServiceAccount(context.TODO(), ns, name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("unable to delete service account %s: %w", name, err)
+		}
+		return nil
+	})
+
+	_, err = client.GetService(ctx, ns, svcName, metav1.GetOptions{})
+	if err != nil {
+		sv := &corev1.Service{}
+		err = yaml.Unmarshal([]byte(nodeLocalDNSService), &sv)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.CreateService(ctx, ns, sv, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create service %s: %w", name, err)
+		}
+	}
+
+	t.WithFinalizer(func(_ context.Context) error {
+		if err := client.DeleteService(context.TODO(), ns, svcName, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("unable to delete service %s: %w", svcName, err)
+		}
+		return nil
+	})
+
+	_, err = client.GetConfigMap(ctx, ns, name, metav1.GetOptions{})
+	if err != nil {
+		cm := &corev1.ConfigMap{}
+		err = yaml.Unmarshal([]byte(nodeLocalDNSConfigMap), &cm)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.CreateConfigMap(ctx, ns, cm, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create configmap %s: %s", name, err)
+		}
+	}
+
+	t.WithFinalizer(func(_ context.Context) error {
+		if err := client.DeleteConfigMap(context.TODO(), ns, name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("unable to delete configMap %s: %w", name, err)
+		}
+		return nil
+	})
+
+	_, err = client.GetDaemonSet(ctx, ns, name, metav1.GetOptions{})
+	if err != nil {
+		kubeDNSService, err := client.GetService(ctx, ns, "kube-dns", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		dsYaml, err := template.Render(nodeLocalDNSDaemonSet, map[string]interface{}{
+			"PILLAR_DNS_SERVER": kubeDNSService.Spec.ClusterIP,
+		})
+		if err != nil {
+			return err
+		}
+
+		ds := &appsv1.DaemonSet{}
+		err = yaml.Unmarshal([]byte(dsYaml), &ds)
+		if err != nil {
+			return err
+		}
+		_, err = client.CreateDaemonSet(ctx, ns, ds, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create daemonset %s: %w", name, err)
+		}
+	}
+
+	t.WithFinalizer(func(_ context.Context) error {
+		if err := client.DeleteDaemonSet(context.TODO(), ns, name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("unable to delete DaemonSet %s: %w", name, err)
+		}
+		return nil
+	})
+
+	if err := check.WaitForDaemonSet(ctx, ct, client, ns, name); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -187,6 +187,10 @@ func (c *Client) DeleteServiceAccount(ctx context.Context, namespace, name strin
 	return c.Clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, opts)
 }
 
+func (c *Client) GetServiceAccount(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ServiceAccount, error) {
+	return c.Clientset.CoreV1().ServiceAccounts(namespace).Get(ctx, name, opts)
+}
+
 func (c *Client) GetClusterRole(ctx context.Context, name string, opts metav1.GetOptions) (*rbacv1.ClusterRole, error) {
 	return c.Clientset.RbacV1().ClusterRoles().Get(ctx, name, opts)
 }
@@ -445,6 +449,10 @@ func (c *Client) DeleteConfigMap(ctx context.Context, namespace, name string, op
 
 func (c *Client) CreateDaemonSet(ctx context.Context, namespace string, ds *appsv1.DaemonSet, opts metav1.CreateOptions) (*appsv1.DaemonSet, error) {
 	return c.Clientset.AppsV1().DaemonSets(namespace).Create(ctx, ds, opts)
+}
+
+func (c *Client) DeleteDaemonSet(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	return c.Clientset.AppsV1().DaemonSets(namespace).Delete(ctx, name, opts)
 }
 
 func (c *Client) PatchDaemonSet(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.DaemonSet, error) {


### PR DESCRIPTION
This PR introduces local-redirect-policy-with-node-dns connectivity test that checks if the LRP with node-local-dns setup is properly working.
https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/#node-local-dns-cache

ref: https://github.com/cilium/cilium/issues/33415