### PR TITLE
kvstoremesh: don't disable by default

### DIFF
--- a/cli/clustermesh.go
+++ b/cli/clustermesh.go
@@ -238,10 +238,11 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 		Use:   "enable",
 		Short: "Enable ClusterMesh ability in a cluster using Helm",
 		Long:  ``,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			params.Namespace = namespace
 			params.HelmReleaseName = helmReleaseName
 			ctx := context.Background()
+			params.EnableKVStoreMeshChanged = cmd.Flags().Changed("enable-kvstoremesh")
 			if err := clustermesh.EnableWithHelm(ctx, k8sClient, params); err != nil {
 				fatalf("Unable to enable ClusterMesh: %s", err)
 			}

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -115,6 +115,9 @@ type Parameters struct {
 	// EnableKVStoreMesh indicates whether kvstoremesh should be enabled.
 	// For Helm mode only.
 	EnableKVStoreMesh bool
+	// Indicates if we should actually set the kvstoremesh.enabled Helm value
+	// or rely on the default value. Default value of kvstoremesh changed in 1.16
+	EnableKVStoreMeshChanged bool
 
 	// HelmReleaseName specifies the Helm release name for the Cilium CLI.
 	// Useful for referencing Cilium installations installed directly through Helm
@@ -1494,10 +1497,12 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 			},
 		}
 
-	helmVals["clustermesh"].(map[string]interface{})["apiserver"].(map[string]interface{})["kvstoremesh"] =
-		map[string]interface{}{
-			"enabled": params.EnableKVStoreMesh,
-		}
+	if params.EnableKVStoreMeshChanged {
+		helmVals["clustermesh"].(map[string]interface{})["apiserver"].(map[string]interface{})["kvstoremesh"] =
+			map[string]interface{}{
+				"enabled": params.EnableKVStoreMesh,
+			}
+	}
 
 	return helmVals, nil
 }


### PR DESCRIPTION
In 1.16 we enabled kvstoremesh by default in helm. Currently, cilium-cli was still setting kvstoremesh.enabled to false. Now, if user does not explicitly specify if kvstoremesh should be enabled or disabled, we will rely on default helm value.