### PR TITLE
clustermesh: validate service type, and fix deprecated LB annotations

### DIFF
--- a/cli/clustermesh.go
+++ b/cli/clustermesh.go
@@ -251,7 +251,7 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 
 	cmd.Flags().BoolVar(&params.EnableExternalWorkloads, "enable-external-workloads", false, "Enable support for external workloads, such as VMs")
 	cmd.Flags().BoolVar(&params.EnableKVStoreMesh, "enable-kvstoremesh", false, "Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore (Cilium >=1.14 only)")
-	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { LoadBalancer | NodePort | ClusterIP }")
+	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { LoadBalancer | NodePort }")
 
 	return cmd
 }

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1438,12 +1438,12 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 	if params.ServiceType == "" {
 		switch flavor.Kind {
 		case k8s.KindGKE:
-			log("🔮 Auto-exposing service within GCP VPC (cloud.google.com/load-balancer-type=Internal)")
+			log("🔮 Auto-exposing service within GCP VPC (networking.gke.io/load-balancer-type=Internal)")
 			helmVals["clustermesh"].(map[string]interface{})["apiserver"] = map[string]interface{}{
 				"service": map[string]interface{}{
 					"type": corev1.ServiceTypeLoadBalancer,
 					"annotations": map[string]interface{}{
-						"cloud.google.com/load-balancer-type": "Internal",
+						"networking.gke.io/load-balancer-type": "Internal",
 						// Allows cross-region access
 						"networking.gke.io/internal-load-balancer-allow-global-access": "true",
 					},
@@ -1460,12 +1460,12 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 				},
 			}
 		case k8s.KindEKS:
-			log("🔮 Auto-exposing service within AWS VPC (service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0")
+			log("🔮 Auto-exposing service within AWS VPC (service.beta.kubernetes.io/aws-load-balancer-scheme: internal")
 			helmVals["clustermesh"].(map[string]interface{})["apiserver"] = map[string]interface{}{
 				"service": map[string]interface{}{
 					"type": corev1.ServiceTypeLoadBalancer,
 					"annotations": map[string]interface{}{
-						"service.beta.kubernetes.io/aws-load-balancer-internal": "0.0.0.0/0",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
 					},
 				},
 			}

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1475,7 +1475,10 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 	} else {
 		if corev1.ServiceType(params.ServiceType) == corev1.ServiceTypeNodePort {
 			log("⚠️  Using service type NodePort may fail when nodes are removed from the cluster!")
+		} else if corev1.ServiceType(params.ServiceType) != corev1.ServiceTypeLoadBalancer {
+			return nil, fmt.Errorf("service type %q is not valid", params.ServiceType)
 		}
+
 		helmVals["clustermesh"].(map[string]interface{})["apiserver"] = map[string]interface{}{
 			"service": map[string]interface{}{
 				"type": params.ServiceType,


### PR DESCRIPTION
Currently, the "clustermesh enable" command lists ClusterIP as one of the supported service types. However, exposing the clustermesh-apiserver via a ClusterIP service is hardly ever a sensible idea, as this component must be reachable from other clusters. Still, this possibility has proved to be sometimes confusing for newbie users, who ended up with a broken setup.

In an effort to prevent these problems, let's explicitly validate the specified service type, and allow only NodePort and LoadBalancer services. In any case, it is still possible to configure a service of type ClusterIP via the helm chart in the handful of very advanced use-cases (if any) which can actually work and benefit from it.

While being there, let's also update the deprecated annotations used to configure internal LoadBalancers.