### PR TITLE
clustermesh: fix remote clusters configuration reset upon deactivation

### DIFF
--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -1522,13 +1522,18 @@ func DisableWithHelm(ctx context.Context, k8sClient *k8s.Client, params Paramete
 	helmStrValues := []string{
 		"clustermesh.useAPIServer=false",
 		"clustermesh.config.enabled=false",
-		"clustermesh.config.clusters=null",
 		"externalWorkloads.enabled=false",
 	}
 	vals, err := helm.ParseVals(helmStrValues)
 	if err != nil {
 		return err
 	}
+
+	err = unstructured.SetNestedSlice(vals, []interface{}{}, "clustermesh", "config", "clusters")
+	if err != nil {
+		return err
+	}
+
 	upgradeParams := helm.UpgradeParameters{
 		Namespace:   params.Namespace,
 		Name:        params.HelmReleaseName,


### PR DESCRIPTION
The blamed commit explicitly reset the list of remote clusters upon clustermesh deactivation. However, it did so setting the corresponding setting to nil, which in Cilium v1.16 triggers an error due to not matching the schema configured. Let's address this by configuring an empty array instead.

Fixes: b148800cf7a2 ("clustermesh: reset remote clusters configuration upon disconnection")