### PR TITLE
connectivity: add local-redirect-policy-with-node-dns test

### DIFF
--- a/.github/node-local-dns/kustomization.yaml
+++ b/.github/node-local-dns/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - node-local-dns.yaml
+  - node-local-dns-lrp.yaml
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: node-local-dns
+    patch: |-
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: cilium.io/no-schedule
+                  operator: NotIn
+                  values:
+                  - "true"

--- a/.github/node-local-dns/node-local-dns-lrp.yaml
+++ b/.github/node-local-dns/node-local-dns-lrp.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "nodelocaldns"
+  namespace: kube-system
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: kube-dns
+      namespace: kube-system
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        k8s-app: node-local-dns
+    toPorts:
+      - port: "53"
+        name: dns
+        protocol: UDP
+      - port: "53"
+        name: dns-tcp
+        protocol: TCP

--- a/.github/node-local-dns/node-local-dns.yaml
+++ b/.github/node-local-dns/node-local-dns.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-upstream
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: "KubeDNSUpstream"
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        health
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__UPSTREAM__SERVERS__
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: node-local-dns
+      annotations:
+        policy.cilium.io/no-track-port: "53"
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.15.16
+        resources:
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args: [ "-localip", "169.254.20.10,__PILLAR__DNS__SERVER__", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream", "-skipteardown=true", "-setupinterface=false", "-setupiptables=false" ]
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        - name: kube-dns-config
+          mountPath: /etc/kube-dns
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true
+      - name: config-volume
+        configMap:
+          name: node-local-dns
+          items:
+            - key: Corefile
+              path: Corefile.base

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -69,7 +69,9 @@ jobs:
             --set cni.chainingMode=portmap \
             --set loadBalancer.l7.backend=envoy \
             --set tls.secretsBackend=k8s \
-            --set prometheus.enabled=true
+            --set prometheus.enabled=true \
+            --set localRedirectPolicy=true \
+            --set socketLB.enabled=true
 
       - name: Enable Relay
         run: |
@@ -98,6 +100,12 @@ jobs:
           kubectl apply -n external-targets -f .github/external-targets/nginx.yaml
           kubectl rollout status -n external-targets ds/nginx
 
+      - name: Set up node local DNS
+        run: |
+          kubedns=$(kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}) && sed -i "s/__PILLAR__DNS__SERVER__/$kubedns/g;" .github/node-local-dns/node-local-dns.yaml
+          kubectl apply -k .github/node-local-dns
+          kubectl rollout status -n kube-system ds/node-local-dns
+
       - name: Connectivity Test
         run: |
           # Setup the connectivity disruption tests. We don't really care about the result
@@ -122,6 +130,10 @@ jobs:
             --external-cidr 172.18.0.0/16 \
             --external-ip ${{ steps.external_targets.outputs.worker2_ip }} \
             --external-other-ip ${{ steps.external_targets.outputs.worker3_ip }}
+
+      - name: Uninstall node local DNS
+        run: |
+          kubectl delete -k .github/node-local-dns
 
       - name: Uninstall cilium
         run: |

--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -247,6 +247,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		podToControlplaneHostCidr{},
 		podToK8sOnControlplaneCidr{},
 		localRedirectPolicy{},
+		localRedirectPolicyWithNodeDNS{},
 		noFragmentation{},
 		bgpControlPlane{},
 	}
@@ -281,6 +282,7 @@ func renderTemplates(param check.Parameters) (map[string]string, error) {
 		"clientEgressL7TLSPolicyPortRangeYAML":             clientEgressL7TLSPolicyPortRangeYAML,
 		"clientEgressL7HTTPMatchheaderSecretYAML":          clientEgressL7HTTPMatchheaderSecretYAML,
 		"clientEgressL7HTTPMatchheaderSecretPortRangeYAML": clientEgressL7HTTPMatchheaderSecretPortRangeYAML,
+		"clientEgressNodeLocalDNSYAML":                     clientEgressNodeLocalDNSYAML,
 		"echoIngressFromCIDRYAML":                          echoIngressFromCIDRYAML,
 		"denyCIDRPolicyYAML":                               denyCIDRPolicyYAML,
 	}

--- a/connectivity/builder/local_redirect_policy.go
+++ b/connectivity/builder/local_redirect_policy.go
@@ -6,6 +6,8 @@ package builder
 import (
 	_ "embed"
 
+	"github.com/cilium/cilium/pkg/versioncheck"
+
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium-cli/utils/features"
@@ -22,6 +24,9 @@ func (t localRedirectPolicy) build(ct *check.ConnectivityTest, _ map[string]stri
 	lrpFrontendIP := "169.254.169.254"
 	lrpFrontendIPSkipRedirect := "169.254.169.255"
 	newTest("local-redirect-policy", ct).
+		WithCondition(func() bool {
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
+		}).
 		WithCiliumLocalRedirectPolicy(check.CiliumLocalRedirectPolicyParams{
 			Policy:                  localRedirectPolicyYAML,
 			Name:                    "lrp-address-matcher",

--- a/connectivity/builder/local_redirect_policy_with_nodedns.go
+++ b/connectivity/builder/local_redirect_policy_with_nodedns.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-node-local-dns.yaml
+var clientEgressNodeLocalDNSYAML string
+
+type localRedirectPolicyWithNodeDNS struct{}
+
+func (t localRedirectPolicyWithNodeDNS) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("local-redirect-policy-with-node-dns", ct).
+		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithCiliumPolicy(templates["clientEgressNodeLocalDNSYAML"]).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.NodeLocalDNS),
+			features.RequireEnabled(features.NodeWithoutCilium),
+			features.RequireEnabled(features.LocalRedirectPolicy),
+			features.RequireEnabled(features.KPRSocketLB),
+		).
+		WithScenarios(
+			tests.LRPWithNodeDNS(),
+		)
+}

--- a/connectivity/builder/manifests/client-egress-node-local-dns.yaml
+++ b/connectivity/builder/manifests/client-egress-node-local-dns.yaml
@@ -1,0 +1,32 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-node-local-dns
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+    - toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+      toEndpoints:
+        - matchLabels:
+            k8s-app: node-local-dns
+            io.kubernetes.pod.namespace: kube-system
+    - toFQDNs:
+      - matchName: "echo-external-node.{{.TestNamespace}}.svc.cluster.local"
+      toPorts:
+      - ports:
+        - port: "{{.ExternalDeploymentPort}}"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/client-ip"

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -921,7 +921,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 
 				svc := newService(echoExternalNodeDeploymentName,
 					map[string]string{"name": echoExternalNodeDeploymentName, "kind": kindEchoExternalNodeName},
-					map[string]string{"kind": kindEchoExternalNodeName}, "http", 8080)
+					map[string]string{"kind": kindEchoExternalNodeName}, "http", port)
 				svc.Spec.ClusterIP = corev1.ClusterIPNone
 				svc.Spec.Type = corev1.ServiceTypeClusterIP
 				_, err := ct.clients.src.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -959,14 +959,23 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			Annotations:  ct.params.DeploymentAnnotations.Match(lrpClientDeploymentName),
 			NodeSelector: ct.params.NodeSelector,
 		})
-		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(lrpClientDeploymentName), metav1.CreateOptions{})
+
+		_, err = ct.clients.src.GetServiceAccount(ctx, ct.params.TestNamespace, lrpClientDeploymentName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create service account %s: %w", lrpClientDeployment, err)
+			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(lrpClientDeploymentName), metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service account %s: %w", lrpClientDeployment, err)
+			}
 		}
-		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, lrpClientDeployment, metav1.CreateOptions{})
+
+		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, lrpClientDeploymentName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create deployment %s: %w", lrpClientDeployment, err)
+			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, lrpClientDeployment, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create deployment %s: %w", lrpClientDeployment, err)
+			}
 		}
+
 		ct.Logf("✨ [%s] Deploying lrp-backend deployment...", ct.clients.src.ClusterName())
 		containerPort := 8080
 		lrpBackendDeployment := newDeployment(deploymentParameters{
@@ -994,13 +1003,21 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			},
 			NodeSelector: ct.params.NodeSelector,
 		})
-		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(lrpBackendDeploymentName), metav1.CreateOptions{})
+
+		_, err = ct.clients.src.GetServiceAccount(ctx, ct.params.TestNamespace, lrpBackendDeploymentName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create service account %s: %w", lrpBackendDeployment, err)
+			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(lrpBackendDeploymentName), metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service account %s: %w", lrpBackendDeployment, err)
+			}
 		}
-		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, lrpBackendDeployment, metav1.CreateOptions{})
+
+		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, lrpBackendDeploymentName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create deployment %s: %w", lrpBackendDeployment, err)
+			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, lrpBackendDeployment, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create deployment %s: %w", lrpBackendDeployment, err)
+			}
 		}
 	}
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -689,6 +689,10 @@ func (c *Client) DeleteCiliumEgressGatewayPolicy(ctx context.Context, name strin
 	return c.CiliumClientset.CiliumV2().CiliumEgressGatewayPolicies().Delete(ctx, name, opts)
 }
 
+func (c *Client) GetCiliumLocalRedirectPolicy(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*ciliumv2.CiliumLocalRedirectPolicy, error) {
+	return c.CiliumClientset.CiliumV2().CiliumLocalRedirectPolicies(namespace).Get(ctx, name, opts)
+}
+
 func (c *Client) DeleteCiliumLocalRedirectPolicy(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.CiliumClientset.CiliumV2().CiliumLocalRedirectPolicies(namespace).Delete(ctx, name, opts)
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -187,6 +187,10 @@ func (c *Client) DeleteServiceAccount(ctx context.Context, namespace, name strin
 	return c.Clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, opts)
 }
 
+func (c *Client) GetServiceAccount(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ServiceAccount, error) {
+	return c.Clientset.CoreV1().ServiceAccounts(namespace).Get(ctx, name, opts)
+}
+
 func (c *Client) GetClusterRole(ctx context.Context, name string, opts metav1.GetOptions) (*rbacv1.ClusterRole, error) {
 	return c.Clientset.RbacV1().ClusterRoles().Get(ctx, name, opts)
 }

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -77,6 +77,8 @@ const (
 	LocalRedirectPolicy Feature = "enable-local-redirect-policy"
 
 	BGPControlPlane Feature = "enable-bgp-control-plane"
+
+	NodeLocalDNS Feature = "node-local-dns"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)


### PR DESCRIPTION
This PR introduces local-redirect-policy-with-node-dns connectivity test that checks if the LRP with node-local-dns setup is properly working.
https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/#node-local-dns-cache

ref: https://github.com/cilium/cilium/issues/33415

context: https://github.com/cilium/cilium-cli/pull/2657#issuecomment-2215725134