### PR TITLE
connectivity: Add echo-ingress-l7-via-hostport-with-encryption testcase

### DIFF
--- a/connectivity/builder/echo_ingress_l7.go
+++ b/connectivity/builder/echo_ingress_l7.go
@@ -16,26 +16,28 @@ var echoIngressL7HTTPPolicyYAML string
 
 type echoIngressL7 struct{}
 
+func expectation(a *check.Action) (egress, ingress check.Result) {
+	if a.Source().HasLabel("other", "client") { // Only client2 is allowed to make HTTP calls.
+		// Trying to access private endpoint without "secret" header set
+		// should lead to a drop.
+		if a.Destination().Path() == "/private" && !a.Destination().HasLabel("X-Very-Secret-Token", "42") {
+			return check.ResultDropCurlHTTPError, check.ResultNone
+		}
+		egress = check.ResultOK
+		// Expect all curls from client2 to be proxied and to be GET calls.
+		egress.HTTP = check.HTTP{
+			Method: "GET",
+		}
+		return egress, check.ResultNone
+	}
+	return check.ResultDrop, check.ResultDefaultDenyIngressDrop
+}
+
 func (t echoIngressL7) build(ct *check.ConnectivityTest, _ map[string]string) {
 	// Test L7 HTTP introspection using an ingress policy on echo pods.
 	newTest("echo-ingress-l7", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(echoIngressL7HTTPPolicyYAML). // L7 allow policy with HTTP introspection
 		WithScenarios(tests.PodToPodWithEndpoints()).
-		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
-			if a.Source().HasLabel("other", "client") { // Only client2 is allowed to make HTTP calls.
-				// Trying to access private endpoint without "secret" header set
-				// should lead to a drop.
-				if a.Destination().Path() == "/private" && !a.Destination().HasLabel("X-Very-Secret-Token", "42") {
-					return check.ResultDropCurlHTTPError, check.ResultNone
-				}
-				egress = check.ResultOK
-				// Expect all curls from client2 to be proxied and to be GET calls.
-				egress.HTTP = check.HTTP{
-					Method: "GET",
-				}
-				return egress, check.ResultNone
-			}
-			return check.ResultDrop, check.ResultDefaultDenyIngressDrop
-		})
+		WithExpectations(expectation)
 }


### PR DESCRIPTION
Add testcase to cover https://github.com/cilium/cilium/issues/32899.

The new testcase has been tested by https://github.com/cilium/cilium/pull/33691, two failing checks are ci-e2e-upgrade and mergeability.