### PR TITLE
connectivity: disrupt deployment improved

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -105,8 +105,7 @@ jobs:
           # disruption), but we want to make sure that the command works as expected.
           #
           # Dispatch interval is set to 100ms, b/c otherwise (default is 0), the flow validation might time out.
-          cilium connectivity test --test-namespace test-namespace \
-            --test-concurrency=5 \
+          cilium connectivity test --test-namespace test-namespace-1 \
             --conn-disrupt-dispatch-interval 100ms \
             --include-conn-disrupt-test --conn-disrupt-test-setup
 

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -243,6 +243,7 @@ func newConnectivityTests(params check.Parameters, logger *check.ConcurrentLogge
 	for i := 0; i < params.TestConcurrency; i++ {
 		params := params
 		params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
+		params.TestNamespaceIndex = i
 		if params.ExternalTargetCANamespace == "" {
 			params.ExternalTargetCANamespace = params.TestNamespace
 		}

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -23,6 +23,7 @@ type Parameters struct {
 	AssumeCiliumVersion   string
 	CiliumNamespace       string
 	TestNamespace         string
+	TestNamespaceIndex    int
 	TestConcurrency       int
 	SingleNode            bool
 	PrintFlows            bool

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -346,7 +346,7 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context, extra SetupHoo
 			return fmt.Errorf("unable to detect nodes w/o Cilium IPs: %w", err)
 		}
 	}
-	if match, _ := ct.Features.MatchRequirements((features.RequireEnabled(features.CIDRMatchNodes))); match {
+	if match, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.CIDRMatchNodes)); match {
 		if err := ct.detectNodeCIDRs(ctx); err != nil {
 			return fmt.Errorf("unable to detect node CIDRs: %w", err)
 		}

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -429,8 +429,9 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		return ct.deployPerf(ctx)
 	}
 
-	// Deploy test-conn-disrupt actors
-	if ct.params.ConnDisruptTestSetup {
+	// Deploy test-conn-disrupt actors (only in the first
+	// test namespace in case of tests concurrent run)
+	if ct.params.ConnDisruptTestSetup && ct.params.TestNamespaceIndex == 0 {
 		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.GetOptions{})
 		if err != nil {
 			ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), testConnDisruptServerDeploymentName)
@@ -1156,7 +1157,7 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 		}
 	}
 
-	if ct.params.IncludeConnDisruptTest {
+	if ct.params.IncludeConnDisruptTest && ct.params.TestNamespaceIndex == 0 {
 		// We append the server and client deployment names to two different
 		// lists. This matters when running in multi-cluster mode, because
 		// the server is deployed in the local cluster (targeted by the "src"


### PR DESCRIPTION
Deploy conn-disrupt test actors only in the first test namespace in case of tests concurrent run to avoid resource wasting. Conn-disrupt tests always run at the beginning, sequentially and in the first test namespace.