### PR TITLE
connectivity: test namespace suffix

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -105,7 +105,7 @@ jobs:
           # disruption), but we want to make sure that the command works as expected.
           #
           # Dispatch interval is set to 100ms, b/c otherwise (default is 0), the flow validation might time out.
-          cilium connectivity test --test-namespace test-namespace-1 \
+          cilium connectivity test --test-namespace test-namespace \
             --conn-disrupt-dispatch-interval 100ms \
             --include-conn-disrupt-test --conn-disrupt-test-setup
 

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -179,7 +179,6 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().DurationVar(&params.Timeout, "timeout", defaults.ConnectivityTestSuiteTimeout, "Maximum time to allow the connectivity test suite to take")
 
 	cmd.Flags().IntVar(&params.TestConcurrency, "test-concurrency", 1, "Count of namespaces to perform the connectivity tests in parallel (value <= 0 will be treated as 1)")
-	_ = cmd.Flags().MarkHidden("test-concurrency")
 
 	hooks.AddConnectivityTestFlags(cmd.Flags())
 
@@ -227,16 +226,6 @@ func newConnectivityTests(params check.Parameters, logger *check.ConcurrentLogge
 	if params.TestConcurrency < 1 {
 		fmt.Printf("--test-concurrency parameter value is invalid [%d], using 1 instead\n", params.TestConcurrency)
 		params.TestConcurrency = 1
-	}
-	if params.TestConcurrency < 2 {
-		if params.ExternalTargetCANamespace == "" {
-			params.ExternalTargetCANamespace = defaults.ConnectivityCheckNamespace
-		}
-		cc, err := check.NewConnectivityTest(k8sClient, params, defaults.CLIVersion, logger)
-		if err != nil {
-			return nil, err
-		}
-		return []*check.ConnectivityTest{cc}, nil
 	}
 
 	connTests := make([]*check.ConnectivityTest, 0, params.TestConcurrency)

--- a/cli/connectivity_test.go
+++ b/cli/connectivity_test.go
@@ -26,8 +26,8 @@ func TestNewConnectivityTests(t *testing.T) {
 				ExternalTargetCANamespace: "",
 			},
 			expectedCount:                     1,
-			expectedTestNamespaces:            []string{"cilium-test"},
-			expectedExternalTargetCANamespace: []string{"cilium-test"},
+			expectedTestNamespaces:            []string{"cilium-test-1"},
+			expectedExternalTargetCANamespace: []string{"cilium-test-1"},
 		},
 		{
 			params: check.Parameters{
@@ -36,7 +36,7 @@ func TestNewConnectivityTests(t *testing.T) {
 				ExternalTargetCANamespace: "cilium-test",
 			},
 			expectedCount:                     1,
-			expectedTestNamespaces:            []string{"cilium-test"},
+			expectedTestNamespaces:            []string{"cilium-test-1"},
 			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 		{
@@ -47,7 +47,7 @@ func TestNewConnectivityTests(t *testing.T) {
 				TestConcurrency:           -1,
 			},
 			expectedCount:                     1,
-			expectedTestNamespaces:            []string{"cilium-test"},
+			expectedTestNamespaces:            []string{"cilium-test-1"},
 			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 		{


### PR DESCRIPTION
Always suffix test namespace with concurrent group number.
Unhide `--test-concurrency` input param.

Thanks @asauber and @michi-covalent for the idea.
However I think these changes might be breakable for users who rely on test namespace (e.g.: in CI or other automation stuff). WDYT?