### PR TITLE
golangci-lint: Add errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - bodyclose
     - gocheckcompilerdirectives
     - err113
+    - errorlint
     - gofmt
     - goheader
     - goimports

--- a/bgp/peers.go
+++ b/bgp/peers.go
@@ -101,14 +101,14 @@ func (s *Status) fetchPeeringStateFromPod(ctx context.Context, pod *corev1.Pod) 
 	cmd := []string{"cilium", "bgp", "peers", "-o", "json"}
 	output, err := s.client.ExecInPod(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch bgp state from %s: %v", pod.Name, err)
+		return nil, fmt.Errorf("failed to fetch bgp state from %s: %w", pod.Name, err)
 	}
 
 	bgpPeers := make([]*models.BgpPeer, 0)
 
 	err = json.Unmarshal(output.Bytes(), &bgpPeers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal bgp state from %s: %v", pod.Name, err)
+		return nil, fmt.Errorf("failed to unmarshal bgp state from %s: %w", pod.Name, err)
 	}
 
 	return bgpPeers, nil

--- a/bgp/routes.go
+++ b/bgp/routes.go
@@ -142,7 +142,7 @@ func (s *Status) fetchRoutesFromPod(ctx context.Context, fetchCmd []string, pod 
 
 	err = json.Unmarshal(output.Bytes(), &bgpRoutes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal bgp routes from %s: %v", pod.Name, err)
+		return nil, fmt.Errorf("failed to unmarshal bgp routes from %s: %w", pod.Name, err)
 	}
 
 	return bgpRoutes, nil

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -252,7 +252,7 @@ func (k *K8sClusterMesh) getSecret(ctx context.Context, client k8sClusterMeshImp
 func (k *K8sClusterMesh) getCACert(ctx context.Context, client k8sClusterMeshImplementation) ([]byte, error) {
 	secret, err := client.GetSecret(ctx, k.params.Namespace, defaults.CASecretName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("get secret %q to retrieve CA: %s", defaults.CASecretName, err)
+		return nil, fmt.Errorf("get secret %q to retrieve CA: %w", defaults.CASecretName, err)
 	}
 
 	// The helm and cronjob certificate generation methods currently store

--- a/config/config.go
+++ b/config/config.go
@@ -105,7 +105,7 @@ func (k *K8sConfig) restartPodsUponConfigChange(ctx context.Context, params Para
 
 	if err := k.client.DeletePodCollection(ctx, params.Namespace,
 		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector}); err != nil {
-		return fmt.Errorf("⚠️  unable to restart Cilium pods: %v", err)
+		return fmt.Errorf("⚠️  unable to restart Cilium pods: %w", err)
 	}
 
 	fmt.Println("♻️  Restarted Cilium pods")

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -334,7 +334,7 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context, extra SetupHoo
 	}
 	if ct.params.Hubble {
 		if err := ct.enableHubbleClient(ctx); err != nil {
-			return fmt.Errorf("unable to create hubble client: %s", err)
+			return fmt.Errorf("unable to create hubble client: %w", err)
 		}
 	}
 	if match, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.NodeWithoutCilium)); match {

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -590,7 +590,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		ct.Logf("✨ [%s] Deploying DNS test server configmap...", ct.clients.src.ClusterName())
 		_, err = ct.clients.src.CreateConfigMap(ctx, ct.params.TestNamespace, dnsConfigMap, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create configmap %s: %s", corednsConfigMapName, err)
+			return fmt.Errorf("unable to create configmap %s: %w", corednsConfigMapName, err)
 		}
 	}
 	if ct.params.MultiCluster != "" {
@@ -599,7 +599,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			ct.Logf("✨ [%s] Deploying DNS test server configmap...", ct.clients.dst.ClusterName())
 			_, err = ct.clients.dst.CreateConfigMap(ctx, ct.params.TestNamespace, dnsConfigMap, metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("unable to create configmap %s: %s", corednsConfigMapName, err)
+				return fmt.Errorf("unable to create configmap %s: %w", corednsConfigMapName, err)
 			}
 		}
 	}
@@ -635,11 +635,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		}, ct.params.DNSTestServerImage)
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(echoSameNodeDeploymentName), metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create service account %s: %s", echoSameNodeDeploymentName, err)
+			return fmt.Errorf("unable to create service account %s: %w", echoSameNodeDeploymentName, err)
 		}
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoDeployment, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create deployment %s: %s", echoSameNodeDeploymentName, err)
+			return fmt.Errorf("unable to create deployment %s: %w", echoSameNodeDeploymentName, err)
 		}
 	}
 
@@ -656,11 +656,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		})
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(clientDeploymentName), metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create service account %s: %s", clientDeploymentName, err)
+			return fmt.Errorf("unable to create service account %s: %w", clientDeploymentName, err)
 		}
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create deployment %s: %s", clientDeploymentName, err)
+			return fmt.Errorf("unable to create deployment %s: %w", clientDeploymentName, err)
 		}
 	}
 
@@ -693,11 +693,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		})
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(client2DeploymentName), metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create service account %s: %s", client2DeploymentName, err)
+			return fmt.Errorf("unable to create service account %s: %w", client2DeploymentName, err)
 		}
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create deployment %s: %s", client2DeploymentName, err)
+			return fmt.Errorf("unable to create deployment %s: %w", client2DeploymentName, err)
 		}
 	}
 
@@ -731,11 +731,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			})
 			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(client3DeploymentName), metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("unable to create service account %s: %s", client3DeploymentName, err)
+				return fmt.Errorf("unable to create service account %s: %w", client3DeploymentName, err)
 			}
 			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("unable to create deployment %s: %s", client3DeploymentName, err)
+				return fmt.Errorf("unable to create deployment %s: %w", client3DeploymentName, err)
 			}
 		}
 	}
@@ -760,11 +760,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		})
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(clientCPDeployment), metav1.CreateOptions{})
 		if err != nil && !k8sErrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create service account %s: %s", clientCPDeployment, err)
+			return fmt.Errorf("unable to create service account %s: %w", clientCPDeployment, err)
 		}
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil && !k8sErrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create deployment %s: %s", clientCPDeployment, err)
+			return fmt.Errorf("unable to create deployment %s: %w", clientCPDeployment, err)
 		}
 	}
 
@@ -835,7 +835,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			}, ct.params.DNSTestServerImage)
 			_, err = ct.clients.dst.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(echoOtherNodeDeploymentName), metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("unable to create service account %s: %s", echoOtherNodeDeploymentName, err)
+				return fmt.Errorf("unable to create service account %s: %w", echoOtherNodeDeploymentName, err)
 			}
 			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeployment, metav1.CreateOptions{})
 			if err != nil {
@@ -910,11 +910,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				})
 				_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(echoExternalNodeDeploymentName), metav1.CreateOptions{})
 				if err != nil {
-					return fmt.Errorf("unable to create service account %s: %s", echoExternalNodeDeploymentName, err)
+					return fmt.Errorf("unable to create service account %s: %w", echoExternalNodeDeploymentName, err)
 				}
 				_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoExternalDeployment, metav1.CreateOptions{})
 				if err != nil {
-					return fmt.Errorf("unable to create deployment %s: %s", echoExternalNodeDeploymentName, err)
+					return fmt.Errorf("unable to create deployment %s: %w", echoExternalNodeDeploymentName, err)
 				}
 
 				svc := newService(echoExternalNodeDeploymentName,
@@ -959,11 +959,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		})
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(lrpClientDeploymentName), metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create service account %s: %s", lrpClientDeployment, err)
+			return fmt.Errorf("unable to create service account %s: %w", lrpClientDeployment, err)
 		}
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, lrpClientDeployment, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create deployment %s: %s", lrpClientDeployment, err)
+			return fmt.Errorf("unable to create deployment %s: %w", lrpClientDeployment, err)
 		}
 		ct.Logf("✨ [%s] Deploying lrp-backend deployment...", ct.clients.src.ClusterName())
 		containerPort := 8080
@@ -994,11 +994,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		})
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(lrpBackendDeploymentName), metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create service account %s: %s", lrpBackendDeployment, err)
+			return fmt.Errorf("unable to create service account %s: %w", lrpBackendDeployment, err)
 		}
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, lrpBackendDeployment, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to create deployment %s: %s", lrpBackendDeployment, err)
+			return fmt.Errorf("unable to create deployment %s: %w", lrpBackendDeployment, err)
 		}
 	}
 
@@ -1046,7 +1046,7 @@ func (ct *ConnectivityTest) createClientPerfDeployment(ctx context.Context, name
 	})
 	_, err := ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(name), metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to create service account %s: %s", name, err)
+		return fmt.Errorf("unable to create service account %s: %w", name, err)
 	}
 	_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, perfClientDeployment, metav1.CreateOptions{})
 	if err != nil {
@@ -1074,7 +1074,7 @@ func (ct *ConnectivityTest) createServerPerfDeployment(ctx context.Context, name
 	})
 	_, err := ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(name), metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to create service account %s: %s", name, err)
+		return fmt.Errorf("unable to create service account %s: %w", name, err)
 	}
 
 	_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, perfServerDeployment, metav1.CreateOptions{})
@@ -1300,7 +1300,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 
 	clientPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindClientName})
 	if err != nil {
-		return fmt.Errorf("unable to list client pods: %s", err)
+		return fmt.Errorf("unable to list client pods: %w", err)
 	}
 
 	for _, pod := range clientPods.Items {

--- a/connectivity/check/frr.go
+++ b/connectivity/check/frr.go
@@ -355,7 +355,7 @@ func writeDataToPod(ctx context.Context, pod *Pod, filePath string, data []byte)
 		[]string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d > %s", encodedData, filePath)})
 
 	if err != nil || stderr.String() != "" {
-		return fmt.Errorf("failed writing data to pod: %s: %s", err, stderr.String())
+		return fmt.Errorf("failed writing data to pod: %w: %s", err, stderr.String())
 	}
 	return nil
 }

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -481,7 +481,7 @@ func (t *Test) applyPolicies(ctx context.Context) error {
 	if sumMap(revDeltas) > 0 {
 		t.Debug("Policy difference detected, waiting for Cilium agents to increment policy revisions..")
 		if err := t.waitCiliumPolicyRevisions(ctx, revisions, revDeltas); err != nil {
-			return fmt.Errorf("policies were not applied on all Cilium nodes in time: %s", err)
+			return fmt.Errorf("policies were not applied on all Cilium nodes in time: %w", err)
 		}
 	}
 

--- a/connectivity/perf/common/metrics.go
+++ b/connectivity/perf/common/metrics.go
@@ -168,10 +168,10 @@ func exportSummary(content perfData, reportDir string) error {
 	filePath := path.Join(reportDir, strings.Join([]string{fileName, "json"}, "."))
 	contentStr, err := prettyPrintJSON(content)
 	if err != nil {
-		return fmt.Errorf("error formatting summary: %v error: %v", content, err)
+		return fmt.Errorf("error formatting summary: %v error: %w", content, err)
 	}
 	if err := os.WriteFile(filePath, []byte(contentStr), 0600); err != nil {
-		return fmt.Errorf("writing to file %v error: %v", filePath, err)
+		return fmt.Errorf("writing to file %v error: %w", filePath, err)
 	}
 	return nil
 }
@@ -179,11 +179,11 @@ func exportSummary(content perfData, reportDir string) error {
 func prettyPrintJSON(data interface{}) (string, error) {
 	output := &bytes.Buffer{}
 	if err := json.NewEncoder(output).Encode(data); err != nil {
-		return "", fmt.Errorf("building encoder error: %v", err)
+		return "", fmt.Errorf("building encoder error: %w", err)
 	}
 	formatted := &bytes.Buffer{}
 	if err := json.Indent(formatted, output.Bytes(), "", "  "); err != nil {
-		return "", fmt.Errorf("indenting error: %v", err)
+		return "", fmt.Errorf("indenting error: %w", err)
 	}
 	return formatted.String(), nil
 }

--- a/connectivity/tests/health.go
+++ b/connectivity/tests/health.go
@@ -93,13 +93,13 @@ func validateHealthStatus(t *check.ConnectivityTest, pod *check.Pod, out bytes.B
 	var data interface{}
 	err := json.Unmarshal(out.Bytes(), &data)
 	if err != nil {
-		return fmt.Errorf("Failed to unmarshal cilium-health output: %s", err)
+		return fmt.Errorf("Failed to unmarshal cilium-health output: %w", err)
 	}
 
 	// Check that status of all nodes is reported
 	nodes, err := filterJSON(data, nodesFilter)
 	if err != nil {
-		return fmt.Errorf("Failed to filter nodes: %s", err)
+		return fmt.Errorf("Failed to filter nodes: %w", err)
 	}
 	nodeCount := strings.Split(nodes, " ")
 	if len(nodeCount) < len(t.CiliumPods()) {
@@ -113,7 +113,7 @@ func validateHealthStatus(t *check.ConnectivityTest, pod *check.Pod, out bytes.B
 		kvExpr := fmt.Sprintf(`{range .nodes[*]}{.name}{"%s="}{%s}{"\n"}{end}`, statusPath, statusPath)
 		healthStatus, err := filterJSON(data, kvExpr)
 		if err != nil {
-			return fmt.Errorf("cilium-agent '%s': failed to filter node health status: %s", pod.Name(), err)
+			return fmt.Errorf("cilium-agent '%s': failed to filter node health status: %w", pod.Name(), err)
 		}
 
 		for path, status := range parseKVPairs(healthStatus) {

--- a/encrypt/ipsec_key_status.go
+++ b/encrypt/ipsec_key_status.go
@@ -29,7 +29,7 @@ func (s *Encrypt) IPsecKeyStatus(ctx context.Context) error {
 func (s *Encrypt) readIPsecKey(ctx context.Context) (string, error) {
 	secret, err := s.client.GetSecret(ctx, s.params.CiliumNamespace, defaults.EncryptionSecretName, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch IPsec secret: %s", err)
+		return "", fmt.Errorf("failed to fetch IPsec secret: %w", err)
 	}
 
 	if key, ok := secret.Data["keys"]; ok {

--- a/encrypt/ipsec_rotate_key.go
+++ b/encrypt/ipsec_rotate_key.go
@@ -34,7 +34,7 @@ func (s *Encrypt) IPsecRotateKey(ctx context.Context) error {
 
 	secret, err := s.client.GetSecret(ctx, s.params.CiliumNamespace, defaults.EncryptionSecretName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to fetch IPsec secret: %s", err)
+		return fmt.Errorf("failed to fetch IPsec secret: %w", err)
 	}
 
 	keyBytes, ok := secret.Data["keys"]
@@ -48,7 +48,7 @@ func (s *Encrypt) IPsecRotateKey(ctx context.Context) error {
 
 	newKey, err := rotateIPsecKey(key, s.params.IPsecKeyAuthAlgo)
 	if err != nil {
-		return fmt.Errorf("failed to rotate IPsec key: %s", err)
+		return fmt.Errorf("failed to rotate IPsec key: %w", err)
 	}
 
 	if s.params.IPsecKeyPerNode != "" {
@@ -58,7 +58,7 @@ func (s *Encrypt) IPsecRotateKey(ctx context.Context) error {
 	patch := []byte(`{"stringData":{"keys":"` + newKey.String() + `"}}`)
 	_, err = s.client.PatchSecret(ctx, s.params.CiliumNamespace, defaults.EncryptionSecretName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to patch IPsec secret with new key: %s", err)
+		return fmt.Errorf("failed to patch IPsec secret with new key: %w", err)
 	}
 
 	_, err = fmt.Printf("IPsec key successfully rotated, new key SPI: %d\n", newKey.spi)
@@ -150,14 +150,14 @@ const maxIPsecSPI = 16
 func (k ipsecKey) rotate() (ipsecKey, error) {
 	key, err := generateRandomHex(len(k.key))
 	if err != nil {
-		return ipsecKey{}, fmt.Errorf("failed to generate authentication key: %s", err)
+		return ipsecKey{}, fmt.Errorf("failed to generate authentication key: %w", err)
 	}
 
 	cipherKey := ""
 	if k.cipherMode != "" {
 		cipherKey, err = generateRandomHex(len(k.cipherKey))
 		if err != nil {
-			return ipsecKey{}, fmt.Errorf("failed to generate symmetric encryption key: %s", err)
+			return ipsecKey{}, fmt.Errorf("failed to generate symmetric encryption key: %w", err)
 		}
 	}
 
@@ -197,7 +197,7 @@ func generateRandomHex(size int) (string, error) {
 func mustParseBool(v string) bool {
 	b, err := strconv.ParseBool(v)
 	if err != nil {
-		panic(fmt.Errorf("failed to parse string [%s] to bool: %s", v, err))
+		panic(fmt.Errorf("failed to parse string [%s] to bool: %w", v, err))
 	}
 	return b
 }

--- a/encrypt/status.go
+++ b/encrypt/status.go
@@ -92,11 +92,11 @@ func (s *Encrypt) fetchEncryptStatusFromPod(ctx context.Context, pod corev1.Pod)
 	cmd := []string{"cilium", "encrypt", "status", "-o", "json"}
 	output, err := s.client.ExecInPod(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 	if err != nil {
-		return models.EncryptionStatus{}, fmt.Errorf("failed to fetch encryption status from %s: %v", pod.Name, err)
+		return models.EncryptionStatus{}, fmt.Errorf("failed to fetch encryption status from %s: %w", pod.Name, err)
 	}
 	encStatus, err := nodeStatusFromOutput(output.String())
 	if err != nil {
-		return models.EncryptionStatus{}, fmt.Errorf("failed to parse encryption status from %s: %v", pod.Name, err)
+		return models.EncryptionStatus{}, fmt.Errorf("failed to parse encryption status from %s: %w", pod.Name, err)
 	}
 	return encStatus, nil
 }
@@ -105,13 +105,13 @@ func nodeStatusFromOutput(output string) (models.EncryptionStatus, error) {
 	if !json.Valid([]byte(output)) {
 		res, err := nodeStatusFromText(output)
 		if err != nil {
-			return models.EncryptionStatus{}, fmt.Errorf("failed to parse text: %v", err)
+			return models.EncryptionStatus{}, fmt.Errorf("failed to parse text: %w", err)
 		}
 		return res, nil
 	}
 	encStatus := models.EncryptionStatus{}
 	if err := json.Unmarshal([]byte(output), &encStatus); err != nil {
-		return models.EncryptionStatus{}, fmt.Errorf("failed to unmarshal json: %v", err)
+		return models.EncryptionStatus{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 	return encStatus, nil
 }
@@ -145,19 +145,19 @@ func nodeStatusFromText(str string) (models.EncryptionStatus, error) {
 		case "Keys in use":
 			keys, err := strconv.Atoi(value)
 			if err != nil {
-				return models.EncryptionStatus{}, fmt.Errorf("invalid number 'Keys in use' [%s]: %v", value, err)
+				return models.EncryptionStatus{}, fmt.Errorf("invalid number 'Keys in use' [%s]: %w", value, err)
 			}
 			res.Ipsec.KeysInUse = int64(keys)
 		case "Errors":
 			count, err := strconv.Atoi(value)
 			if err != nil {
-				return models.EncryptionStatus{}, fmt.Errorf("invalid number 'Errors' [%s]: %v", value, err)
+				return models.EncryptionStatus{}, fmt.Errorf("invalid number 'Errors' [%s]: %w", value, err)
 			}
 			res.Ipsec.ErrorCount = int64(count)
 		default:
 			count, err := strconv.Atoi(value)
 			if err != nil {
-				return models.EncryptionStatus{}, fmt.Errorf("invalid number '%s' [%s]: %v", key, value, err)
+				return models.EncryptionStatus{}, fmt.Errorf("invalid number '%s' [%s]: %w", key, value, err)
 			}
 			res.Ipsec.XfrmErrors[key] = int64(count)
 		}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -216,7 +216,7 @@ func ResolveHelmChartVersion(versionFlag, chartDirectoryFlag, repository string)
 	// Get the chart version from the local Helm chart specified with --chart-directory flag.
 	localChart, err := newChartFromDirectory(chartDirectoryFlag)
 	if err != nil {
-		return semver.Version{}, nil, fmt.Errorf("failed to load Helm chart directory %s: %s", chartDirectoryFlag, err)
+		return semver.Version{}, nil, fmt.Errorf("failed to load Helm chart directory %s: %w", chartDirectoryFlag, err)
 	}
 	return versioncheck.MustVersion(localChart.Metadata.Version), localChart, nil
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -975,7 +975,7 @@ func (c *Client) GetServerVersion() (*semver.Version, error) {
 			return &ver, nil
 		}
 	}
-	return nil, fmt.Errorf("unable to parse Kubernetes version (got %s): %s", sv.String(), err)
+	return nil, fmt.Errorf("unable to parse Kubernetes version (got %s): %w", sv.String(), err)
 }
 
 func (c *Client) GetIngress(ctx context.Context, namespace string, name string, opts metav1.GetOptions) (*networkingv1.Ingress, error) {

--- a/status/k8s.go
+++ b/status/k8s.go
@@ -204,7 +204,8 @@ func (k *K8sStatusCollector) podCount(ctx context.Context, status *Status) error
 	// for any pods to be managed by Cilium. So continue, with 0 managed pods.
 	ciliumEps, err := k.client.ListCiliumEndpoints(ctx, "", metav1.ListOptions{})
 	if err != nil {
-		if err, ok := err.(*k8serrors.StatusError); ok && err.Status().Code != http.StatusNotFound {
+		var statusErr *k8serrors.StatusError
+		if errors.As(err, &statusErr) && statusErr.Status().Code != http.StatusNotFound {
 			return err
 		}
 	}

--- a/status/status.go
+++ b/status/status.go
@@ -199,7 +199,7 @@ func (s *Status) parseCiliumSubsystemStatus(deployment, podName, subsystem strin
 
 func (s *Status) parseStatusResponse(deployment, podName string, r *models.StatusResponse, err error) {
 	if err != nil {
-		s.AddAggregatedError(deployment, podName, fmt.Errorf("unable to retrieve cilium status: %s", err))
+		s.AddAggregatedError(deployment, podName, fmt.Errorf("unable to retrieve cilium status: %w", err))
 		return
 	}
 
@@ -244,7 +244,7 @@ func (s *Status) parseStatusResponse(deployment, podName string, r *models.Statu
 
 func (s *Status) parseEndpointsResponse(deployment, podName string, eps []*models.Endpoint, err error) {
 	if err != nil {
-		s.AddAggregatedError(deployment, podName, fmt.Errorf("unable to retrieve cilium endpoint information: %s", err))
+		s.AddAggregatedError(deployment, podName, fmt.Errorf("unable to retrieve cilium endpoint information: %w", err))
 		return
 	}
 

--- a/utils/wait/wait.go
+++ b/utils/wait/wait.go
@@ -74,7 +74,7 @@ func (w *Observer) Retry(err error) error {
 	select {
 	case <-w.ctx.Done():
 		if err != nil {
-			return fmt.Errorf("timeout while waiting for condition, last error: %s", err)
+			return fmt.Errorf("timeout while waiting for condition, last error: %w", err)
 		}
 		return fmt.Errorf("timeout while waiting for condition")
 	case <-time.After(w.params.retryInterval()):


### PR DESCRIPTION
Add errorlint linter to be consistent with cilium/cilium configuration [^1], and fix lint errors.

Ref: https://github.com/cilium/design-cfps/pull/9
[^1]: https://github.com/cilium/cilium/blob/3fa34b170493b48ef7befedef72badbd05429b18/.golangci.yaml#L117