### PR TITLE
flags: Use option.NewNamedMapOptions

### DIFF
--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -40,6 +41,8 @@ func newCmdConnectivity(hooks api.Hooks) *cobra.Command {
 var params = check.Parameters{
 	ExternalDeploymentPort: 8080,
 	EchoServerHostPort:     4000,
+	JunitProperties:        make(map[string]string),
+	NodeSelector:           make(map[string]string),
 	Writer:                 os.Stdout,
 	SysdumpOptions: sysdump.Options{
 		LargeSysdumpAbortTimeout: sysdump.DefaultLargeSysdumpAbortTimeout,
@@ -132,7 +135,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")
 	cmd.Flags().StringSliceVar(&params.NodeCIDRs, "node-cidr", nil, "one or more CIDRs that cover all nodes in the cluster")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
-	cmd.Flags().StringToStringVar(&params.JunitProperties, "junit-property", map[string]string{}, "Add key=value properties to the generated junit file")
+	cmd.Flags().Var(option.NewNamedMapOptions("junit-property", &params.JunitProperties, nil), "junit-property", "Add key=value properties to the generated junit file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster nodes state")
@@ -218,7 +221,7 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 
 func registerCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
-	flags.StringToStringVar(&params.NodeSelector, "node-selector", map[string]string{}, "Restrict connectivity pods to nodes matching this label")
+	flags.Var(option.NewNamedMapOptions("node-selector", &params.NodeSelector, nil), "node-selector", "Restrict connectivity pods to nodes matching this label")
 	flags.StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity in")
 	flags.Var(&params.DeploymentAnnotations, "deployment-pod-annotations", "Add annotations to the connectivity pods, e.g. '{\"client\":{\"foo\":\"bar\"}}'")
 }

--- a/cli/connectivity_test.go
+++ b/cli/connectivity_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium-cli/api"
 	"github.com/cilium/cilium-cli/connectivity/check"
 )
 
@@ -86,4 +87,20 @@ func TestNewConnectivityTests(t *testing.T) {
 			require.Equal(t, n, actual[i].Params().ExternalTargetCANamespace)
 		}
 	}
+}
+
+func TestConnectivityTestFlags(t *testing.T) {
+	ct := newCmdConnectivityTest(&api.NopHooks{})
+	require.Empty(t, params.JunitProperties)
+	ct.Flags().Set("junit-property", "a=b")
+	require.NoError(t, ct.Flags().Set("junit-property", "a=b"))
+	require.Equal(t, map[string]string{"a": "b"}, params.JunitProperties)
+	require.NoError(t, ct.Flags().Set("junit-property", "c=d"))
+	require.Equal(t, map[string]string{"a": "b", "c": "d"}, params.JunitProperties)
+
+	require.Empty(t, params.NodeSelector)
+	require.NoError(t, ct.Flags().Set("node-selector", "a=b"))
+	require.Equal(t, map[string]string{"a": "b"}, params.NodeSelector)
+	require.NoError(t, ct.Flags().Set("node-selector", "c=d"))
+	require.Equal(t, map[string]string{"a": "b", "c": "d"}, params.NodeSelector)
 }


### PR DESCRIPTION
Use option.NewNamedMapOptions instead of flags.StringToStringVar to avoid getting lint errors when merging cilium-cli repo to cilium repo [^1].

[^1]: https://github.com/cilium/cilium/blob/main/contrib/scripts/check-viper.sh