### PR TITLE
Fix lint errors

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -5,11 +5,11 @@ package cli
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"runtime"
 	"strings"
 
+	"github.com/cilium/cilium/pkg/safeio"
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium-cli/defaults"
@@ -22,7 +22,7 @@ func getLatestStableVersion() string {
 	}
 	defer resp.Body.Close()
 
-	b, err := io.ReadAll(resp.Body)
+	b, err := safeio.ReadAllLimit(resp.Body, safeio.KB)
 	if err != nil {
 		return "unknown"
 	}

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -18,13 +18,13 @@ import (
 	"sync"
 	"time"
 
-	hubprinter "github.com/cilium/cilium/hubble/pkg/printer"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/api/v1/relay"
+	hubprinter "github.com/cilium/cilium/hubble/pkg/printer"
+	"github.com/cilium/cilium/pkg/lock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/cilium/cilium-cli/connectivity/filters"
 	"github.com/cilium/cilium-cli/defaults"
@@ -68,7 +68,7 @@ type Action struct {
 	expIngress Result
 
 	// flowsMu protects flows.
-	flowsMu sync.Mutex
+	flowsMu lock.Mutex
 	// flows is a map of all flow logs generated during the Action.
 	flows flowsSet
 

--- a/connectivity/check/action.go
+++ b/connectivity/check/action.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/api/v1/relay"
 	hubprinter "github.com/cilium/cilium/hubble/pkg/printer"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -801,7 +802,7 @@ func (a *Action) waitForRelay(ctx context.Context, client observer.ObserverClien
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("hubble server status failure: %w", ctx.Err())
-		case <-time.After(time.Second):
+		case <-inctimer.After(time.Second):
 			a.Debug("retrying hubble relay server status request")
 		}
 	}

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -16,15 +16,15 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/cilium/cilium/api/v1/observer"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/cilium/cilium/api/v1/observer"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 
 	"github.com/cilium/cilium-cli/connectivity/internal/junit"
 	"github.com/cilium/cilium-cli/connectivity/perf/common"
@@ -817,7 +817,7 @@ func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.
 
 // multiClusterClientLock protects K8S client instantiation (Scheme registration)
 // for the cluster mesh setup in case of connectivity test concurrency > 1
-var multiClusterClientLock = sync.Mutex{}
+var multiClusterClientLock = lock.Mutex{}
 
 // determine if only single node tests can be ran.
 // if the user specified SingleNode on the CLI this is taken as the truth and

--- a/connectivity/check/logger.go
+++ b/connectivity/check/logger.go
@@ -8,9 +8,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 // NewConcurrentLogger factory function that returns ConcurrentLogger.
@@ -24,7 +25,7 @@ func NewConcurrentLogger(writer io.Writer, concurrency int) *ConcurrentLogger {
 		// goroutine to avoid deadlock in case if buffer is full.
 		nsTestsCh:        make(chan string, concurrency*10),
 		nsTestMsgs:       make(map[string][]message),
-		nsTestMsgsLock:   sync.Mutex{},
+		nsTestMsgsLock:   lock.Mutex{},
 		collectorStarted: atomic.Bool{},
 		printerDoneCh:    make(chan bool),
 	}
@@ -35,7 +36,7 @@ type ConcurrentLogger struct {
 	writer            io.Writer
 	nsTestsCh         chan string
 	nsTestMsgs        map[string][]message
-	nsTestMsgsLock    sync.Mutex
+	nsTestMsgsLock    lock.Mutex
 	collectorStarted  atomic.Bool
 	printerDoneCh     chan bool
 	nsTestFinishCount int

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -10,19 +10,18 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
+	"github.com/cilium/cilium/pkg/lock"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-
-	flowpb "github.com/cilium/cilium/api/v1/flow"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/k8s"
@@ -375,7 +374,7 @@ func sumMap(m map[string]int) int {
 
 // policyApplyDeleteLock guarantees that only one connectivity test instance
 // can apply or delete policies in case of connectivity test concurrency > 1
-var policyApplyDeleteLock = sync.Mutex{}
+var policyApplyDeleteLock = lock.Mutex{}
 
 // applyPolicies applies all the Test's registered network policies.
 func (t *Test) applyPolicies(ctx context.Context) error {

--- a/connectivity/check/test.go
+++ b/connectivity/check/test.go
@@ -10,10 +10,14 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cloudflare/cfssl/cli/genkey"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
@@ -24,11 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium-cli/sysdump"
@@ -148,7 +147,7 @@ type Test struct {
 
 	// Buffer to store output until it's flushed by a failure.
 	// Unused when run in verbose or debug mode.
-	logMu  sync.RWMutex
+	logMu  lock.RWMutex
 	logBuf io.ReadWriter
 
 	// conditionFn is a function that returns true if the test needs to run,

--- a/connectivity/check/wait.go
+++ b/connectivity/check/wait.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,7 +48,7 @@ func WaitForDeployment(ctx context.Context, log Logger, client *k8s.Client, name
 		log.Debugf("[%s] Deployment %s/%s is not yet ready: %s", client.ClusterName(), namespace, name, err)
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for deployment %s/%s to become ready (last error: %w)",
 				namespace, name, err)
@@ -70,7 +71,7 @@ func WaitForDaemonSet(ctx context.Context, log Logger, client *k8s.Client, names
 		log.Debugf("[%s] DaemonSet %s/%s is not yet ready: %s", client.ClusterName(), namespace, name, err)
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for DaemonSet %s/%s to become ready (last error: %w)",
 				namespace, name, err)
@@ -102,7 +103,7 @@ func WaitForPodDNS(ctx context.Context, log Logger, src, dst Pod) error {
 			src.K8sClient.ClusterName(), target, src.Name(), dst.Name(), err, stdout.String())
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for lookup for %s from pod %s to server on pod %s to succeed (last error: %w)",
 				target, src.Name(), dst.Name(), err,
@@ -130,7 +131,7 @@ func WaitForCoreDNS(ctx context.Context, log Logger, client Pod) error {
 			client.K8sClient.ClusterName(), target, client.Name(), err, stdout.String())
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for lookup for %s from pod %s to succeed (last error: %w)",
 				target, client.Name(), err)
@@ -153,7 +154,7 @@ func WaitForServiceRetrieval(ctx context.Context, log Logger, client *k8s.Client
 		log.Debugf("[%s] Failed to retrieve Service %s/%s: %s", client.ClusterName(), namespace, name, err)
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return Service{}, fmt.Errorf("timeout reached waiting for service %s/%s to be retrieved (last error: %w)",
 				namespace, name, err)
@@ -196,7 +197,7 @@ func WaitForService(ctx context.Context, log Logger, client Pod, service Service
 			client.K8sClient.ClusterName(), service.Name(), err, stdout.String())
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for service %s (last error: %w)", service.Name(), err)
 		}
@@ -227,7 +228,7 @@ func WaitForServiceEndpoints(ctx context.Context, log Logger, agent Pod, service
 			agent.K8sClient.ClusterName(), service.Name(), agent.Name(), err)
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for service %s to appear in Cilium pod %s (last error: %w)",
 				service.Name(), agent.Name(), err)
@@ -307,7 +308,7 @@ func WaitForNodePorts(ctx context.Context, log Logger, client Pod, nodeIP string
 				client.K8sClient.ClusterName(), nodeIP, nodePort, service.Name(), err, stdout.String())
 
 			select {
-			case <-time.After(PollInterval):
+			case <-inctimer.After(PollInterval):
 			case <-ctx.Done():
 				return fmt.Errorf("timeout reached waiting for NodePort %s:%d (%s) (last error: %w)",
 					nodeIP, nodePort, service.Name(), err)
@@ -335,7 +336,7 @@ func WaitForIPCache(ctx context.Context, log Logger, agent Pod, pods []Pod) erro
 		log.Debugf("[%s] Error checking pod IPs in IPCache: %s", agent.K8sClient.ClusterName(), err)
 
 		select {
-		case <-time.After(PollInterval):
+		case <-inctimer.After(PollInterval):
 		case <-ctx.Done():
 			return fmt.Errorf("timeout reached waiting for pod IPs to be in IPCache of Cilium pod %s (last error: %w)",
 				agent.Name(), err)

--- a/connectivity/sniff/sniffer.go
+++ b/connectivity/sniff/sniffer.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/pkg/inctimer"
+
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/utils/lock"
 )
@@ -98,7 +100,7 @@ func Sniff(ctx context.Context, name string, target *check.Pod,
 			}
 
 			return nil, fmt.Errorf("Failed to execute tcpdump: %w", err)
-		case <-time.After(100 * time.Millisecond):
+		case <-inctimer.After(100 * time.Millisecond):
 			line, err := sniffer.stdout.ReadString('\n')
 			if err != nil && !errors.Is(err, io.EOF) {
 				return nil, fmt.Errorf("Failed to read kubectl exec's stdout: %w", err)

--- a/connectivity/tests/health.go
+++ b/connectivity/tests/health.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/pkg/inctimer"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/jsonpath"
@@ -44,7 +45,7 @@ func runHealthProbe(ctx context.Context, t *check.Test, pod *check.Pod) {
 
 	// Probe health status until it passes checks or timeout is reached.
 	for {
-		retryTimer := time.After(time.Second)
+		retryTimer := inctimer.After(time.Second)
 
 		if _, err := pod.K8sClient.GetPod(ctx, pod.Pod.Namespace, pod.Pod.Name, metav1.GetOptions{}); k8serrors.IsNotFound(err) {
 			t.Failf("cilium-health validation failed. Cilium Agent Pod %s/%s no longer exists", pod.Pod.Namespace, pod.Pod.Name)

--- a/status/status.go
+++ b/status/status.go
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"sync"
 	"text/tabwriter"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/lock"
 
 	"github.com/cilium/cilium-cli/defaults"
 )
@@ -115,7 +115,7 @@ type Status struct {
 	// For Helm mode only.
 	HelmChartVersion string `json:"helm_chart_version,omitempty"`
 
-	mutex *sync.Mutex
+	mutex *lock.Mutex
 }
 
 func newStatus() *Status {
@@ -127,7 +127,7 @@ func newStatus() *Status {
 		CiliumStatus:    CiliumStatusMap{},
 		CiliumEndpoints: CiliumEndpointsMap{},
 		Errors:          ErrorCountMapMap{},
-		mutex:           &sync.Mutex{},
+		mutex:           &lock.Mutex{},
 	}
 }
 

--- a/sysdump/sysdump_test.go
+++ b/sysdump/sysdump_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/safeio"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -184,7 +185,7 @@ func TestKVStoreTask(t *testing.T) {
 	})
 	fd, err := os.Open(path.Join(collector.sysdumpDir, "kvstore-heartbeat.json"))
 	assert.NoError(err)
-	data, err := io.ReadAll(fd)
+	data, err := safeio.ReadAllLimit(fd, safeio.KB)
 	assert.NoError(err)
 	assert.Equal([]byte("{}"), data)
 }

--- a/utils/runner/multierror.go
+++ b/utils/runner/multierror.go
@@ -6,6 +6,8 @@ package runner
 import (
 	"errors"
 	"sync"
+
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 // MultiError can be used to run multiple goroutines that
@@ -13,7 +15,7 @@ import (
 // return joined errors as a single one.
 type MultiError struct {
 	wg   sync.WaitGroup
-	lock sync.Mutex
+	lock lock.Mutex
 	err  error
 }
 

--- a/vendor/github.com/cilium/cilium/pkg/safeio/safeio.go
+++ b/vendor/github.com/cilium/cilium/pkg/safeio/safeio.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package safeio
+
+import (
+	"fmt"
+	"io"
+)
+
+// ErrLimitReached indicates that ReadAllLimit has
+// reached its limit before completing a full read
+// of the io.Reader.
+var ErrLimitReached = fmt.Errorf("read limit reached")
+
+// ByteSize expresses the size of bytes
+type ByteSize float64
+
+const (
+	_ = iota // ignore first value by assigning to blank identifier
+	// KB is a Kilobyte
+	KB ByteSize = 1 << (10 * iota)
+	// MB is a Megabyte
+	MB
+	// GB is a Gigabyte
+	GB
+	// TB is a Terabyte
+	TB
+	// PB is a Petabyte
+	PB
+	// EB is an Exabyte
+	EB
+	// ZB is a Zettabyte
+	ZB
+	// YB is a Yottabyte
+	YB
+)
+
+// String converts a ByteSize to a string
+func (b ByteSize) String() string {
+	switch {
+	case b >= YB:
+		return fmt.Sprintf("%.1fYB", b/YB)
+	case b >= ZB:
+		return fmt.Sprintf("%.1fZB", b/ZB)
+	case b >= EB:
+		return fmt.Sprintf("%.1fEB", b/EB)
+	case b >= PB:
+		return fmt.Sprintf("%.1fPB", b/PB)
+	case b >= TB:
+		return fmt.Sprintf("%.1fTB", b/TB)
+	case b >= GB:
+		return fmt.Sprintf("%.1fGB", b/GB)
+	case b >= MB:
+		return fmt.Sprintf("%.1fMB", b/MB)
+	case b >= KB:
+		return fmt.Sprintf("%.1fKB", b/KB)
+	}
+	return fmt.Sprintf("%.1fB", b)
+}
+
+// ReadAllLimit reads from r until an error, EOF, or after n bytes and returns
+// the data it read. A successful call returns err == nil, not err == EOF.
+// Because ReadAllLimit is defined to read from src until EOF it does not
+// treat an EOF from Read as an error to be reported. If the limit is reached
+// ReadAllLimit will return ErrLimitReached as an error.
+func ReadAllLimit(r io.Reader, n ByteSize) ([]byte, error) {
+	limit := int(n + 1)
+	buf, err := io.ReadAll(io.LimitReader(r, int64(limit)))
+	if err != nil {
+		return buf, err
+	}
+	if len(buf) >= limit {
+		return buf[:limit-1], ErrLimitReached
+	}
+	return buf, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,6 +211,7 @@ github.com/cilium/cilium/pkg/policy/types
 github.com/cilium/cilium/pkg/promise
 github.com/cilium/cilium/pkg/rate
 github.com/cilium/cilium/pkg/rate/metrics
+github.com/cilium/cilium/pkg/safeio
 github.com/cilium/cilium/pkg/safetime
 github.com/cilium/cilium/pkg/service/store
 github.com/cilium/cilium/pkg/slices


### PR DESCRIPTION
3 commits to fix various lint errors to get ready to be merged to cilium/cilium repo:

- Replace sync with github.com/cilium/cilium/pkg/lock
- Replace timer.After with inctimer.After
- Replace io.ReadAll with safeio.ReadAllLimit