### PR TITLE
connectivity: check disrupt client deployment if enabled.

### DIFF
--- a/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/deployment.go
+++ b/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/deployment.go
@@ -527,6 +527,15 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("unable to create deployment %s: %w", testConnDisruptClientDeployment, err)
 			}
+
+			// Wait for the client deployment to become ready, to catch any issues early if the
+			// clients are not able to connect to the server:
+			// See: https://github.com/cilium/test-connection-disruption/blob/main/cmd/client/main.go#L36-L44
+			err := WaitForDeployment(ctx, ct, ct.clients.src, ct.params.TestNamespace, testConnDisruptClientDeploymentName)
+			if err != nil {
+				ct.Failf("%s deployment is not ready: %s", testConnDisruptClientDeploymentName, err)
+			}
+
 		}
 	}
 


### PR DESCRIPTION
The disrupt test client Pods establish connections to the disrupt server clients. Only after the connections are established does the readiness probe become healthy.

Currently, we do not check if the clients have become healthy before proceeding.

This can lead to confusing CI failures, even if you do an early sanity check test (which asserts no pod restarts), there may not be any restarts to report right after doing [setup](https://github.com/cilium/test-connection-disruption/blob/main/cmd/client/main.go#L36-L44).

To improve this, this commit will now cause setup to wait for the deployment to become ready. Initial failures to connect will cause the setup step to fail fast rather than proceeding with subsequent upgrade tests.

This should also help differentiate disrupt connection issues that aren't related to any upgrade steps.