### PR TITLE
Improve network perf test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 # @cilium/sig-encryption         Encryption management
 # @cilium/sig-bgp                BGP integration
 # @cilium/sig-clustermesh        Clustermesh and external workloads
+# @cilium/sig-scalability        Scalability & performance of Cilium
 # @cilium/sig-hubble             Hubble integration
 # @cilium/sig-k8s                K8s integration, K8s CNI plugin
 # @cilium/vendor                 Vendoring, dependency management
@@ -52,6 +53,7 @@
 /connectivity/builder/no_ipsec_xfrm_errors.go @cilium/sig-encryption
 /connectivity/builder/node_to_node_encryption.go @cilium/sig-encryption
 /connectivity/builder/pod_to_pod_encryption.go @cilium/sig-encryption
+/connectivity/perf/** @cilium/sig-scalability
 /connectivity/tests/bgp.go @cilium/sig-bgp
 /connectivity/tests/clustermesh-endpointslice-sync.go @cilium/sig-clustermesh
 /connectivity/tests/egressgateway.go @cilium/egress-gateway
@@ -62,7 +64,6 @@
 /connectivity/tests/health.go @cilium/sig-agent
 /connectivity/tests/host.go @cilium/sig-agent
 /connectivity/tests/ipsec_xfrm.go @cilium/ipsec
-/connectivity/tests/perfpod.go @cilium/sig-datapath
 /connectivity/tests/pod.go @cilium/sig-agent
 /connectivity/tests/service.go @cilium/sig-lb
 /connectivity/tests/testloop.sh @jrajahalme

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -206,19 +206,19 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 		RunE: RunE(hooks),
 	}
 
-	cmd.Flags().DurationVar(&params.PerfDuration, "duration", 10*time.Second, "Duration for the Performance test to run")
-	cmd.Flags().IntVar(&params.PerfMessageSize, "msg-size", 1024, "Size of message to use in UDP test")
-	cmd.Flags().BoolVar(&params.PerfCRR, "crr", false, "Run CRR test")
-	cmd.Flags().BoolVar(&params.PerfRR, "rr", true, "Run RR test")
-	cmd.Flags().BoolVar(&params.PerfUDP, "udp", false, "Run UDP tests")
-	cmd.Flags().BoolVar(&params.PerfThroughput, "throughput", true, "Run throughput test")
-	cmd.Flags().BoolVar(&params.PerfMixed, "mixed", false, "Run pod-to-host and host-to-pod tests (only works if both host-net=true and pod-net=true)")
-	cmd.Flags().IntVar(&params.PerfSamples, "samples", 1, "Number of Performance samples to capture (how many times to run each test)")
-	cmd.Flags().BoolVar(&params.PerfHostNet, "host-net", true, "Test host network")
-	cmd.Flags().BoolVar(&params.PerfPodNet, "pod-net", true, "Test pod network")
+	cmd.Flags().DurationVar(&params.PerfParameters.Duration, "duration", 10*time.Second, "Duration for the Performance test to run")
+	cmd.Flags().IntVar(&params.PerfParameters.MessageSize, "msg-size", 1024, "Size of message to use in UDP test")
+	cmd.Flags().BoolVar(&params.PerfParameters.CRR, "crr", false, "Run CRR test")
+	cmd.Flags().BoolVar(&params.PerfParameters.RR, "rr", true, "Run RR test")
+	cmd.Flags().BoolVar(&params.PerfParameters.UDP, "udp", false, "Run UDP tests")
+	cmd.Flags().BoolVar(&params.PerfParameters.Throughput, "throughput", true, "Run throughput test")
+	cmd.Flags().BoolVar(&params.PerfParameters.Mixed, "mixed", false, "Run pod-to-host and host-to-pod tests (only works if both host-net=true and pod-net=true)")
+	cmd.Flags().IntVar(&params.PerfParameters.Samples, "samples", 1, "Number of Performance samples to capture (how many times to run each test)")
+	cmd.Flags().BoolVar(&params.PerfParameters.HostNet, "host-net", true, "Test host network")
+	cmd.Flags().BoolVar(&params.PerfParameters.PodNet, "pod-net", true, "Test pod network")
 
-	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
-	cmd.Flags().StringVar(&params.PerfReportDir, "report-dir", "", "Directory to save perf results in json format")
+	cmd.Flags().StringVar(&params.PerfParameters.Image, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
+	cmd.Flags().StringVar(&params.PerfParameters.ReportDir, "report-dir", "", "Directory to save perf results in json format")
 	registerCommonFlags(cmd.Flags())
 
 	return cmd

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -13,9 +13,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/cilium/cilium-cli/api"
 	"github.com/cilium/cilium-cli/connectivity"

--- a/cli/connectivity.go
+++ b/cli/connectivity.go
@@ -206,8 +206,14 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 	}
 
 	cmd.Flags().DurationVar(&params.PerfDuration, "duration", 10*time.Second, "Duration for the Performance test to run")
+	cmd.Flags().IntVar(&params.PerfMessageSize, "msg-size", 1024, "Size of message to use in UDP test")
+	cmd.Flags().BoolVar(&params.PerfCRR, "crr", false, "Run CRR test")
+	cmd.Flags().BoolVar(&params.PerfRR, "rr", true, "Run RR test")
+	cmd.Flags().BoolVar(&params.PerfUDP, "udp", false, "Run UDP tests")
+	cmd.Flags().BoolVar(&params.PerfThroughput, "throughput", true, "Run throughput test")
+	cmd.Flags().BoolVar(&params.PerfMixed, "mixed", false, "Run pod-to-host and host-to-pod tests (only works if both host-net=true and pod-net=true)")
 	cmd.Flags().IntVar(&params.PerfSamples, "samples", 1, "Number of Performance samples to capture (how many times to run each test)")
-	cmd.Flags().BoolVar(&params.PerfHostNet, "host-net", false, "Test host network")
+	cmd.Flags().BoolVar(&params.PerfHostNet, "host-net", true, "Test host network")
 	cmd.Flags().BoolVar(&params.PerfPodNet, "pod-net", true, "Test pod network")
 
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -19,46 +19,48 @@ import (
 	"github.com/cilium/cilium-cli/sysdump"
 )
 
+type PerfParameters struct {
+	ReportDir   string
+	Duration    time.Duration
+	HostNet     bool
+	PodNet      bool
+	Samples     int
+	MessageSize int
+	Mixed       bool
+	Throughput  bool
+	CRR         bool
+	RR          bool
+	UDP         bool
+	Image       string
+}
+
 type Parameters struct {
-	AssumeCiliumVersion   string
-	CiliumNamespace       string
-	TestNamespace         string
-	TestNamespaceIndex    int
-	TestConcurrency       int
-	SingleNode            bool
-	PrintFlows            bool
-	ForceDeploy           bool
-	Hubble                bool
-	HubbleServer          string
-	K8sLocalHostTest      bool
-	MultiCluster          string
-	RunTests              []*regexp.Regexp
-	SkipTests             []*regexp.Regexp
-	PostTestSleepDuration time.Duration
-	FlowValidation        string
-	AllFlows              bool
-	Writer                io.ReadWriter
-	Verbose               bool
-	Debug                 bool
-	Timestamp             bool
-	PauseOnFail           bool
-	SkipIPCacheCheck      bool
-	// Perf is not user-facing parameter, but it's used to run perf subcommand
-	// using connectivity test suite.
+	AssumeCiliumVersion    string
+	CiliumNamespace        string
+	TestNamespace          string
+	TestNamespaceIndex     int
+	TestConcurrency        int
+	SingleNode             bool
+	PrintFlows             bool
+	ForceDeploy            bool
+	Hubble                 bool
+	HubbleServer           string
+	K8sLocalHostTest       bool
+	MultiCluster           string
+	RunTests               []*regexp.Regexp
+	SkipTests              []*regexp.Regexp
+	PostTestSleepDuration  time.Duration
+	FlowValidation         string
+	AllFlows               bool
+	Writer                 io.ReadWriter
+	Verbose                bool
+	Debug                  bool
+	Timestamp              bool
+	PauseOnFail            bool
+	SkipIPCacheCheck       bool
 	Perf                   bool
-	PerfReportDir          string
-	PerfDuration           time.Duration
-	PerfHostNet            bool
-	PerfPodNet             bool
-	PerfSamples            int
-	PerfMessageSize        int
-	PerfMixed              bool
-	PerfThroughput         bool
-	PerfCRR                bool
-	PerfRR                 bool
-	PerfUDP                bool
+	PerfParameters         PerfParameters
 	CurlImage              string
-	PerformanceImage       string
 	JSONMockImage          string
 	TestConnDisruptImage   string
 	FRRImage               string

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -51,6 +51,12 @@ type Parameters struct {
 	PerfHostNet            bool
 	PerfPodNet             bool
 	PerfSamples            int
+	PerfMessageSize        int
+	PerfMixed              bool
+	PerfThroughput         bool
+	PerfCRR                bool
+	PerfRR                 bool
+	PerfUDP                bool
 	CurlImage              string
 	PerformanceImage       string
 	JSONMockImage          string

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -14,15 +14,16 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cilium/cilium/api/v1/observer"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/lock"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/api/v1/observer"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
 
 	"github.com/cilium/cilium-cli/connectivity/perf/common"
 	"github.com/cilium/cilium-cli/defaults"
@@ -538,8 +539,8 @@ func (ct *ConnectivityTest) report() error {
 			}
 		}
 		ct.Logf("%s", strings.Repeat("-", 85))
-		if ct.Params().PerfReportDir != "" {
-			common.ExportPerfSummaries(ct.PerfResults, ct.Params().PerfReportDir)
+		if ct.Params().PerfParameters.ReportDir != "" {
+			common.ExportPerfSummaries(ct.PerfResults, ct.Params().PerfParameters.ReportDir)
 		}
 	}
 

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -1053,7 +1053,7 @@ func (ct *ConnectivityTest) createClientPerfDeployment(ctx context.Context, name
 		Kind:      kindPerfName,
 		NamedPort: "http-80",
 		Port:      80,
-		Image:     ct.params.PerformanceImage,
+		Image:     ct.params.PerfParameters.Image,
 		Labels: map[string]string{
 			"client": "role",
 		},
@@ -1085,7 +1085,7 @@ func (ct *ConnectivityTest) createServerPerfDeployment(ctx context.Context, name
 		},
 		Annotations:                   ct.params.DeploymentAnnotations.Match(name),
 		Port:                          5001,
-		Image:                         ct.params.PerformanceImage,
+		Image:                         ct.params.PerfParameters.Image,
 		Command:                       []string{"/bin/bash", "-c", "netserver;sleep 10000000"},
 		NodeSelector:                  map[string]string{"kubernetes.io/hostname": nodeName},
 		HostNetwork:                   hostNetwork,
@@ -1126,7 +1126,7 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 		ct.Warn("Selected nodes have different zones, tweak nodeSelector if that's not what you intended")
 	}
 
-	if ct.params.PerfPodNet {
+	if ct.params.PerfParameters.PodNet {
 		if err = ct.createClientPerfDeployment(ctx, perfClientDeploymentName, firstNodeName, false); err != nil {
 			ct.Warnf("unable to create deployment: %w", err)
 		}
@@ -1139,7 +1139,7 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 		}
 	}
 
-	if ct.params.PerfHostNet {
+	if ct.params.PerfParameters.HostNet {
 		if err = ct.createClientPerfDeployment(ctx, perfClientHostNetDeploymentName, firstNodeName, true); err != nil {
 			ct.Warnf("unable to create deployment: %w", err)
 		}
@@ -1164,12 +1164,12 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 		}
 	} else if ct.params.TestNamespaceIndex == 0 {
 		srcList = []string{}
-		if ct.params.PerfPodNet {
+		if ct.params.PerfParameters.PodNet {
 			srcList = append(srcList, perfClientDeploymentName)
 			srcList = append(srcList, perfClientAcrossDeploymentName)
 			srcList = append(srcList, perfServerDeploymentName)
 		}
-		if ct.params.PerfHostNet {
+		if ct.params.PerfParameters.HostNet {
 			srcList = append(srcList, perfClientHostNetDeploymentName)
 			srcList = append(srcList, perfClientHostNetAcrossDeploymentName)
 			srcList = append(srcList, perfServerHostNetDeploymentName)

--- a/connectivity/perf/benchmarks/netperf/perfpod.go
+++ b/connectivity/perf/benchmarks/netperf/perfpod.go
@@ -109,8 +109,8 @@ func (s *netPerf) Run(ctx context.Context, t *check.Test) {
 	}
 }
 
-func buildExecCommand(test string, sip string, duration time.Duration, msgSize int, args []string) []string {
-	exec := []string{"/usr/local/bin/netperf", "-H", sip, "-l", duration.String(), "-t", test, "--", "-R", "1", "-m", fmt.Sprintf("%d", msgSize)}
+func buildExecCommand(test string, sip string, duration time.Duration, args []string) []string {
+	exec := []string{"/usr/local/bin/netperf", "-H", sip, "-l", duration.String(), "-t", test, "--", "-R", "1"}
 	exec = append(exec, args...)
 
 	return exec
@@ -134,7 +134,10 @@ func parseFloat(a *check.Action, value string) float64 {
 
 func netperf(ctx context.Context, sip string, perfTest common.PerfTests, a *check.Action) common.PerfResult {
 	args := []string{"-o", "MIN_LATENCY,MEAN_LATENCY,MAX_LATENCY,P50_LATENCY,P90_LATENCY,P99_LATENCY,TRANSACTION_RATE,THROUGHPUT,THROUGHPUT_UNITS"}
-	exec := buildExecCommand(perfTest.Test, sip, perfTest.Duration, perfTest.MsgSize, args)
+	if perfTest.Test == "UDP_STREAM" {
+		args = append(args, "-m", fmt.Sprintf("%d", perfTest.MsgSize))
+	}
+	exec := buildExecCommand(perfTest.Test, sip, perfTest.Duration, args)
 
 	a.ExecInPod(ctx, exec)
 	output := a.CmdOutput()

--- a/connectivity/perf/benchmarks/netperf/perfpod.go
+++ b/connectivity/perf/benchmarks/netperf/perfpod.go
@@ -93,7 +93,9 @@ func (s *netPerf) Run(ctx context.Context, t *check.Test) {
 				}
 
 				for _, test := range tests {
-					action := t.NewAction(s, netperfToolName, &c, server, features.IPFamilyV4)
+					testName := netperfToolName + "_" + test + "_" + scenarioName
+					action := t.NewAction(s, testName, &c, server, features.IPFamilyV4)
+
 					action.CollectFlows = false
 					action.Run(func(a *check.Action) {
 						k := common.PerfTests{

--- a/connectivity/perf/common/metrics.go
+++ b/connectivity/perf/common/metrics.go
@@ -99,6 +99,7 @@ type PerfTests struct {
 	SameNode bool
 	Scenario string
 	Sample   int
+	MsgSize  int
 	Duration time.Duration
 }
 

--- a/connectivity/perf/common/metrics.go
+++ b/connectivity/perf/common/metrics.go
@@ -7,11 +7,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	"golang.org/x/exp/maps"
 )
 
 // LatencyMetric captures latency metrics of network performance test
@@ -25,7 +26,7 @@ type LatencyMetric struct {
 }
 
 // toPerfData export LatencyMetric in a format compatible with perfdash scheme
-func (metric *LatencyMetric) toPerfData(labels map[string]string) dataItem {
+func (metric *LatencyMetric) toPerfData(labels map[string]string, prefix string) dataItem {
 	resLabels := map[string]string{
 		"metric": "Latency",
 	}
@@ -34,9 +35,9 @@ func (metric *LatencyMetric) toPerfData(labels map[string]string) dataItem {
 		Data: map[string]float64{
 			// Let's only export percentiles
 			// Max is skewing results and doesn't make much sense to keep track of
-			"Perc50": float64(metric.Perc50) / float64(time.Microsecond),
-			"Perc90": float64(metric.Perc90) / float64(time.Microsecond),
-			"Perc99": float64(metric.Perc99) / float64(time.Microsecond),
+			prefix + "_p50": float64(metric.Perc50) / float64(time.Microsecond),
+			prefix + "_p90": float64(metric.Perc90) / float64(time.Microsecond),
+			prefix + "_p99": float64(metric.Perc99) / float64(time.Microsecond),
 		},
 		Unit:   "us",
 		Labels: resLabels,
@@ -49,14 +50,14 @@ type TransactionRateMetric struct {
 }
 
 // ToPerfData export TransactionRateMetric in a format compatible with perfdash scheme
-func (metric *TransactionRateMetric) toPerfData(labels map[string]string) dataItem {
+func (metric *TransactionRateMetric) toPerfData(labels map[string]string, prefix string) dataItem {
 	resLabels := map[string]string{
 		"metric": "TransactionRate",
 	}
 	maps.Copy(resLabels, labels)
 	return dataItem{
 		Data: map[string]float64{
-			"Throughput": metric.TransactionRate,
+			prefix + "_throughput": metric.TransactionRate,
 		},
 		Unit:   "ops/s",
 		Labels: resLabels,
@@ -69,14 +70,14 @@ type ThroughputMetric struct {
 }
 
 // ToPerfData export ThroughputMetric in a format compatible with perfdash scheme
-func (metric *ThroughputMetric) toPerfData(labels map[string]string) dataItem {
+func (metric *ThroughputMetric) toPerfData(labels map[string]string, prefix string) dataItem {
 	resLabels := map[string]string{
 		"metric": "Throughput",
 	}
 	maps.Copy(resLabels, labels)
 	return dataItem{
 		Data: map[string]float64{
-			"Throughput": metric.Throughput / 1000000,
+			prefix + "_throughput": metric.Throughput / 1000000,
 		},
 		Unit:   "Mb/s",
 		Labels: resLabels,
@@ -137,29 +138,46 @@ func getLabelsForTest(summary PerfSummary) map[string]string {
 		node = "same-node"
 	}
 	return map[string]string{
-		"scenario":  summary.PerfTest.Scenario,
 		"node":      node,
-		"test_type": summary.PerfTest.Tool + "-" + summary.PerfTest.Test,
+		"test_type": summary.PerfTest.Tool,
 	}
 }
 
 // ExportPerfSummaries exports Perfsummary in a format compatible with perfdash
 // and saves results in reportDir directory
 func ExportPerfSummaries(summaries []PerfSummary, reportDir string) error {
-	data := []dataItem{}
+	data := map[string]dataItem{}
 	for _, summary := range summaries {
 		labels := getLabelsForTest(summary)
+		identifier := fmt.Sprintf("%s-%s", labels["node"], labels["test_type"])
 		if summary.Result.Latency != nil {
-			data = append(data, summary.Result.Latency.toPerfData(labels))
+			res := summary.Result.Latency.toPerfData(labels, summary.PerfTest.Test+"_"+summary.PerfTest.Scenario)
+			if _, ok := data[identifier+"lat"]; !ok {
+				data[identifier+"lat"] = res
+			} else {
+				maps.Copy(data[identifier+"lat"].Data, res.Data)
+			}
+
 		}
 		if summary.Result.TransactionRateMetric != nil {
-			data = append(data, summary.Result.TransactionRateMetric.toPerfData(labels))
+			res := summary.Result.TransactionRateMetric.toPerfData(labels, summary.PerfTest.Test+"_"+summary.PerfTest.Scenario)
+			if _, ok := data[identifier+"tr"]; !ok {
+				data[identifier+"tr"] = res
+			} else {
+				maps.Copy(data[identifier+"tr"].Data, res.Data)
+			}
+
 		}
 		if summary.Result.ThroughputMetric != nil {
-			data = append(data, summary.Result.ThroughputMetric.toPerfData(labels))
+			res := summary.Result.ThroughputMetric.toPerfData(labels, summary.PerfTest.Test+"_"+summary.PerfTest.Scenario)
+			if _, ok := data[identifier+"th"]; !ok {
+				data[identifier+"th"] = res
+			} else {
+				maps.Copy(data[identifier+"th"].Data, res.Data)
+			}
 		}
 	}
-	return exportSummary(perfData{Version: "v1", DataItems: data}, reportDir)
+	return exportSummary(perfData{Version: "v1", DataItems: maps.Values(data)}, reportDir)
 }
 
 func exportSummary(content perfData, reportDir string) error {


### PR DESCRIPTION
This PR contains various improvements to net perf testing - more details in commit messages.

Most notable improvement is that we no longer use fixed message size for TCP_STREAM test, which results in way more reasonable results as compared to the previous tests. 
First of all, we can finally saturate network throughput and also throughput between pods on the same node is way higher than throughput between pods running on different nodes. Example test results for native routing:
```
-------------------------------------------------------------------------------------
📋 Scenario        | Node       | Test            | Duration        | Throughput Mb/s 
-------------------------------------------------------------------------------------
📋 pod-to-pod      | same-node  | TCP_STREAM      | 10s             | 14257.07     
📋 host-to-host    | same-node  | TCP_STREAM      | 10s             | 25766.59     
📋 pod-to-pod      | other-node | TCP_STREAM      | 10s             | 9541.04      
📋 host-to-host    | other-node | TCP_STREAM      | 10s             | 9579.99      
-------------------------------------------------------------------------------------
```
Previously native throughput was showing sad 1500 Mb/s for the same Cilium configuration. 

How the new output looks like in perfdash:
![image](https://github.com/user-attachments/assets/01d714c6-5e49-469f-9331-216d95e22c82)
![image](https://github.com/user-attachments/assets/e64a30bb-d379-4a92-8877-c4917bc306cd)
Makes it much easier to compare host vs pod throughput / latency etc. 
