### PR TITLE
feat: Add support for impersonation --as and --as-group flags

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -23,7 +23,7 @@ func TestNamespaceContextValues(t *testing.T) {
 
 func TestK8sClientContextValues(t *testing.T) {
 	ctx := context.Background()
-	k8sClient, err := k8s.NewClient("", "", "")
+	k8sClient, err := k8s.NewClient("", "", "", "", []string{})
 	assert.NoError(t, err)
 	ctx = SetK8sClientContextValue(ctx, k8sClient)
 	result, ok := GetK8sClientContextValue(ctx)

--- a/cli/clustermesh.go
+++ b/cli/clustermesh.go
@@ -47,6 +47,8 @@ func newCmdClusterMeshStatus() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 
 			if params.Output == status.OutputJSON {
 				// Write status log messages to stderr to make sure they don't
@@ -114,6 +116,8 @@ func newCmdExternalWorkloadCreate() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 
 			if labels != "" {
 				params.Labels = parseLabels(labels)
@@ -149,6 +153,9 @@ func newCmdExternalWorkloadDelete() *cobra.Command {
 		Short: "Delete named external workloads",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
+
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.DeleteExternalWorkload(context.Background(), args); err != nil {
 				fatalf("Unable to remove external workloads: %s", err)
@@ -173,6 +180,8 @@ func newCmdExternalWorkloadInstall() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			var writer io.Writer
@@ -215,6 +224,8 @@ func newCmdExternalWorkloadStatus() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.ExternalWorkloadStatus(context.Background(), args); err != nil {
@@ -240,6 +251,8 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 			params.HelmReleaseName = helmReleaseName
 			ctx := context.Background()
 			params.EnableKVStoreMeshChanged = cmd.Flags().Changed("enable-kvstoremesh")
@@ -268,6 +281,8 @@ func newCmdClusterMeshDisableWithHelm() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 			params.HelmReleaseName = helmReleaseName
 			ctx := context.Background()
 			if err := clustermesh.DisableWithHelm(ctx, k8sClient, params); err != nil {
@@ -291,6 +306,8 @@ func newCmdClusterMeshConnectWithHelm() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 			params.HelmReleaseName = helmReleaseName
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.ConnectWithHelm(context.Background()); err != nil {
@@ -315,6 +332,8 @@ func newCmdClusterMeshDisconnectWithHelm() *cobra.Command {
 		Short: "Disconnect from a remote cluster",
 		Run: func(_ *cobra.Command, _ []string) {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroup
 			params.HelmReleaseName = helmReleaseName
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.DisconnectWithHelm(context.Background()); err != nil {

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -15,9 +15,11 @@ import (
 )
 
 var (
-	contextName     string
-	namespace       string
-	helmReleaseName string
+	contextName      string
+	namespace        string
+	impersonateAs    string
+	impersonateGroup []string
+	helmReleaseName  string
 
 	k8sClient *k8s.Client
 )
@@ -40,7 +42,7 @@ func NewCiliumCommand(hooks api.Hooks) *cobra.Command {
 				return nil
 			}
 
-			c, err := k8s.NewClient(contextName, "", namespace)
+			c, err := k8s.NewClient(contextName, "", namespace, impersonateAs, impersonateGroup)
 			if err != nil {
 				return fmt.Errorf("unable to create Kubernetes client: %w", err)
 			}
@@ -79,6 +81,8 @@ cilium connectivity test`,
 
 	cmd.PersistentFlags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
+	cmd.PersistentFlags().StringVar(&impersonateAs, "as", "", "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
+	cmd.PersistentFlags().StringArrayVar(&impersonateGroup, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
 	cmd.PersistentFlags().StringVar(&helmReleaseName, "helm-release-name", "cilium", "Helm release name")
 
 	cmd.AddCommand(

--- a/clustermesh/clustermesh.go
+++ b/clustermesh/clustermesh.go
@@ -107,6 +107,8 @@ type Parameters struct {
 	ConfigOverwrites     []string
 	Retries              int
 	Output               string
+	ImpersonateAs        string
+	ImpersonateGroups    []string
 
 	// EnableExternalWorkloads indicates whether externalWorkloads.enabled Helm value
 	// should be set to true. For Helm mode only.
@@ -490,7 +492,7 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 
 // getClientsForConnect returns a k8s.Client for the local and remote cluster, respectively
 func (k *K8sClusterMesh) getClientsForConnect() (*k8s.Client, *k8s.Client, error) {
-	remoteClient, err := k8s.NewClient(k.params.DestinationContext, "", k.params.Namespace)
+	remoteClient, err := k8s.NewClient(k.params.DestinationContext, "", k.params.Namespace, k.params.ImpersonateAs, k.params.ImpersonateGroups)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"unable to create Kubernetes client to access remote cluster %q: %w",

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -894,7 +894,7 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	if ct.params.MultiCluster != "" {
 		multiClusterClientLock.Lock()
 		defer multiClusterClientLock.Unlock()
-		dst, err := k8s.NewClient(ct.params.MultiCluster, "", ct.params.CiliumNamespace)
+		dst, err := k8s.NewClient(ct.params.MultiCluster, "", ct.params.CiliumNamespace, "", []string{})
 		if err != nil {
 			return fmt.Errorf("unable to create Kubernetes client for remote cluster %q: %w", ct.params.MultiCluster, err)
 		}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -65,7 +65,7 @@ type Client struct {
 	HelmActionConfig   *action.Configuration
 }
 
-func NewClient(contextName, kubeconfig, ciliumNamespace string) (*Client, error) {
+func NewClient(contextName, kubeconfig, ciliumNamespace, impersonateAs string, impersonateGroup []string) (*Client, error) {
 	// Register the Cilium types in the default scheme.
 	_ = ciliumv2.AddToScheme(scheme.Scheme)
 	_ = ciliumv2alpha1.AddToScheme(scheme.Scheme)
@@ -79,6 +79,13 @@ func NewClient(contextName, kubeconfig, ciliumNamespace string) (*Client, error)
 	config, err := rawKubeConfigLoader.ClientConfig()
 	if err != nil {
 		return nil, err
+	}
+
+	if impersonateAs != "" || len(impersonateGroup) > 0 {
+		config.Impersonate = rest.ImpersonationConfig{
+			UserName: impersonateAs,
+			Groups:   impersonateGroup,
+		}
 	}
 
 	rawConfig, err := rawKubeConfigLoader.RawConfig()


### PR DESCRIPTION
We use impersonation as cluster admins to elevate access to customer secrets and certain resources, and kubectl supports this with the --as or --as-group flags. Currently to use the cilium cli tool, we have to hand edit our kubeconfig to add `as: <user>` for our user, and then remember to remove it afterwords. Supporting impersonation directly in the Cilium cli tooling would make it much safer for us and align cilium with other kubectl flags.