### PR TITLE
connectivity: LRP with per packet LB

### DIFF
--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -248,6 +248,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		podToK8sOnControlplaneCidr{},
 		localRedirectPolicy{},
 		localRedirectPolicyWithNodeDNS{},
+		localRedirectPolicyPerPacketLB{},
 		noFragmentation{},
 		bgpControlPlane{},
 	}

--- a/connectivity/builder/local_redirect_policy_per_packet_lb.go
+++ b/connectivity/builder/local_redirect_policy_per_packet_lb.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/pkg/versioncheck"
+
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+type localRedirectPolicyPerPacketLB struct{}
+
+func (t localRedirectPolicyPerPacketLB) build(ct *check.ConnectivityTest, _ map[string]string) {
+	lrpFrontendIP := "169.254.169.254"
+	lrpFrontendIPSkipRedirect := "169.254.169.255"
+	newTest("local-redirect-policy-per-packet-lb", ct).
+		WithCondition(func() bool {
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
+		}).
+		WithCiliumLocalRedirectPolicy(check.CiliumLocalRedirectPolicyParams{
+			Policy:                  localRedirectPolicyYAML,
+			Name:                    "lrp-address-matcher",
+			FrontendIP:              lrpFrontendIP,
+			SkipRedirectFromBackend: false,
+		}).
+		WithCiliumLocalRedirectPolicy(check.CiliumLocalRedirectPolicyParams{
+			Policy:                  localRedirectPolicyYAML,
+			Name:                    "lrp-address-matcher-skip-redirect-from-backend",
+			FrontendIP:              lrpFrontendIPSkipRedirect,
+			SkipRedirectFromBackend: true,
+		}).
+		WithFeatureRequirements(features.RequireEnabled(features.LocalRedirectPolicy)).
+		WithFeatureRequirements(features.RequireEnabled(features.BPFLBSocketHostnsOnly)).
+		WithScenarios(
+			tests.LRP(false),
+			tests.LRP(true),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Scenario().Name() == "lrp-skip-redirect-from-backend" {
+				if a.Source().HasLabel("lrp", "backend") &&
+					a.Destination().Address(features.IPFamilyV4) == lrpFrontendIPSkipRedirect {
+					return check.ResultCurlTimeout, check.ResultNone
+				}
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/connectivity/check/features.go
+++ b/connectivity/check/features.go
@@ -169,6 +169,9 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 			if f.SocketLB != nil {
 				result[features.KPRSocketLB] = features.Status{Enabled: f.SocketLB.Enabled}
 			}
+			if f.BpfSocketLBHostnsOnly {
+				result[features.BPFLBSocketHostnsOnly] = features.Status{Enabled: f.BpfSocketLBHostnsOnly}
+			}
 		}
 	}
 	result[features.KPRMode] = features.Status{

--- a/utils/features/features.go
+++ b/utils/features/features.go
@@ -35,6 +35,8 @@ const (
 
 	BPFLBExternalClusterIP Feature = "bpf-lb-external-clusterip"
 
+	BPFLBSocketHostnsOnly Feature = "bpf-lb-sock-hostns-only"
+
 	HostPort Feature = "host-port"
 
 	NodeWithoutCilium Feature = "node-without-cilium"
@@ -314,6 +316,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[BPFLBExternalClusterIP] = Status{
 		Enabled: cm.Data[string(BPFLBExternalClusterIP)] == "true",
+	}
+
+	fs[BPFLBSocketHostnsOnly] = Status{
+		Enabled: cm.Data[string(BPFLBSocketHostnsOnly)] == "true",
 	}
 
 	fs[BGPControlPlane] = Status{

--- a/utils/features/features_test.go
+++ b/utils/features/features_test.go
@@ -143,6 +143,7 @@ func TestFeatureSet_extractFromConfigMap(t *testing.T) {
 		"enable-local-redirect-policy": "true",
 		"bpf-lb-external-clusterip":    "true",
 		"enable-bgp-control-plane":     "true",
+		"bpf-lb-sock-hostns-only":      "true",
 	}
 	fs.ExtractFromConfigMap(&cm)
 	assert.True(t, fs[IPv4].Enabled)
@@ -154,4 +155,5 @@ func TestFeatureSet_extractFromConfigMap(t *testing.T) {
 	assert.True(t, fs[BPFLBExternalClusterIP].Enabled)
 	assert.True(t, fs[BGPControlPlane].Enabled)
 	assert.Equal(t, "eni", fs[CiliumIPAMMode].Mode)
+	assert.True(t, fs[BPFLBSocketHostnsOnly].Enabled)
 }


### PR DESCRIPTION
This PR introduces LRP connectivity tests with per packet LB enabled.

Ref: https://github.com/cilium/cilium/pull/33721

```
Add local redirect policy connectivity tests with per packet LB.
```