### PR TITLE
Assign release-related files to cilium-cli-maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,24 @@
 # Code owners groups and a brief description of their areas:
-# @cilium/azure              Integration with Azure
-# @cilium/ci-structure       Continuous integration, testing
-# @cilium/cli                Commandline interfaces
-# @cilium/contributing       Developer documentation & tools
-# @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
-# @cilium/sig-encryption     Encryption management
-# @cilium/sig-bgp            BGP integration
-# @cilium/sig-clustermesh    Clustermesh and external workloads
-# @cilium/sig-hubble         Hubble integration
-# @cilium/sig-k8s            K8s integration, K8s CNI plugin
-# @cilium/vendor             Vendoring, dependency management
+# @cilium/azure                  Integration with Azure
+# @cilium/ci-structure           Continuous integration, testing
+# @cilium/cilium-cli-maintainers Release-related files
+# @cilium/cli                    Commandline interfaces
+# @cilium/contributing           Developer documentation & tools
+# @cilium/github-sec             GitHub security (handling of secrets, consequences of pull_request_target, etc.)
+# @cilium/sig-encryption         Encryption management
+# @cilium/sig-bgp                BGP integration
+# @cilium/sig-clustermesh        Clustermesh and external workloads
+# @cilium/sig-hubble             Hubble integration
+# @cilium/sig-k8s                K8s integration, K8s CNI plugin
+# @cilium/vendor                 Vendoring, dependency management
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/cli
 /CODEOWNERS @cilium/contributing
+/README.md @cilium/cilium-cli-maintainers
+/RELEASE.md @cilium/cilium-cli-maintainers
 /.github/ @cilium/contributing
 /.github/gcp-vm-startup.sh @cilium/ci-structure
 /.github/get-kubeconfig.sh @cilium/github-sec @cilium/ci-structure
@@ -74,4 +77,6 @@
 /k8s/ @cilium/sig-k8s
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor
+/stable-v0.14.txt @cilium/cilium-cli-maintainers
+/stable.txt @cilium/cilium-cli-maintainers
 /vendor/ @cilium/vendor


### PR DESCRIPTION
Assign release-related files that are mostly updated as a part of the release process to cilium-cli-maintainers:

    % git log --format='%an' README.md | sort | uniq -c | sort -nr | head -n 3
      58 Michi Mutsuzaki
      34 Tobias Klauser
       8 Thomas Graf

    % git log --format='%an' RELEASE.md | sort | uniq -c | sort -nr | head -n 3
      39 Michi Mutsuzaki
      21 Tobias Klauser
       1 Gilberto Bertin

    % git log --format='%an' stable-v0.14.txt | sort | uniq -c | sort -nr | head -n 3
       1 Michi Mutsuzaki

    % git log --format='%an' stable.txt | sort | uniq -c | sort -nr | head -n 3
      36 Michi Mutsuzaki
      27 Tobias Klauser
       1 Andrew Sauber