### PR TITLE
connectivity: Fix ineffective version check in BGP tests

### DIFF
--- a/connectivity/builder/bgp_control_plane.go
+++ b/connectivity/builder/bgp_control_plane.go
@@ -16,10 +16,7 @@ type bgpControlPlane struct{}
 func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("bgp-control-plane-v1", ct).
 		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
-		}).
-		WithCondition(func() bool {
-			return ct.Params().IncludeUnsafeTests
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
 		}).
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),
@@ -29,10 +26,7 @@ func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) 
 
 	newTest("bgp-control-plane-v2", ct).
 		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
-		}).
-		WithCondition(func() bool {
-			return ct.Params().IncludeUnsafeTests
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
 		}).
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),


### PR DESCRIPTION
Multiple `WithCondition` statements were causing that only the last one was effective, making version checks ineffective. This combines the conditions into a single `WithCondition` statement per test.