### PR TITLE
tests: lrp: add support for protocol differentiation

### DIFF
--- a/connectivity/check/peer.go
+++ b/connectivity/check/peer.go
@@ -499,9 +499,10 @@ func (he httpEndpoint) FlowFilters() []*flow.FlowFilter {
 }
 
 type LRPFrontend struct {
-	name string
-	ip   string
-	port string
+	name     string
+	ip       string
+	port     string
+	protocol string
 }
 
 func NewLRPFrontend(frontend ciliumv2.RedirectFrontend) *LRPFrontend {
@@ -509,7 +510,8 @@ func NewLRPFrontend(frontend ciliumv2.RedirectFrontend) *LRPFrontend {
 	if f := frontend.AddressMatcher; f != nil {
 		lf.ip = f.IP
 		lf.port = f.ToPorts[0].Port
-		lf.name = fmt.Sprintf("%s:%s", lf.ip, lf.port)
+		lf.protocol = string(f.ToPorts[0].Protocol)
+		lf.name = fmt.Sprintf("%s:%s/%s", lf.ip, lf.port, lf.protocol)
 
 		return &lf
 	}
@@ -539,6 +541,10 @@ func (l LRPFrontend) Port() uint32 {
 		return 0
 	}
 	return uint32(p)
+}
+
+func (l LRPFrontend) Protocol() string {
+	return l.protocol
 }
 
 func (l LRPFrontend) HasLabel(string, string) bool {

--- a/connectivity/tests/lrp.go
+++ b/connectivity/tests/lrp.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium-cli/defaults"
@@ -52,6 +53,9 @@ func (s lrp) Run(ctx context.Context, t *check.Test) {
 		policies = append(policies, policy)
 		frontend := check.NewLRPFrontend(spec.RedirectFrontend)
 		frontendStr := net.JoinHostPort(frontend.Address(features.IPFamilyV4), fmt.Sprint(frontend.Port()))
+		if versioncheck.MustCompile(">=1.17.0")(ct.CiliumVersion) {
+			frontendStr += fmt.Sprintf("/%s", frontend.Protocol())
+		}
 		lrpBackendsMap := make(map[string][]string)
 		// Check for LRP backend pods deployed on nodes in the cluster.
 		for _, pod := range t.Context().LrpBackendPods() {


### PR DESCRIPTION
update the logic used to wait for local redirect bpf entries as from
v1.16 we start supporting protocol differentiation for services, which
means the frontend string description will now include also the protocol