### PR TITLE
Pick up kindest/node:v1.21.10

### DIFF
--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: chart-testing
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.21.10
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -13,14 +13,14 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.21.10
   # Two extra nodes without Cilium to use for --external-ip and --external-other-ip.
   - role: worker
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.21.10
     labels:
       cilium.io/no-schedule: "true"
   - role: worker
-    image: kindest/node:v1.19.11
+    image: kindest/node:v1.21.10
     labels:
       cilium.io/no-schedule: "true"
 networking:


### PR DESCRIPTION
opened https://github.com/cilium/cilium-cli/issues/2720 to keep the kind node image up to date. need to figure out why nodes without cilium don't get ready with newer kind node images.

in the meantime let's do this to unblock https://github.com/cilium/cilium-cli/pull/2716.