### PR TITLE
connectivity: use TestNamespace and ExternalDeploymentPort params

### DIFF
--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -282,6 +282,7 @@ func renderTemplates(param check.Parameters) (map[string]string, error) {
 		"clientEgressL7TLSPolicyPortRangeYAML":             clientEgressL7TLSPolicyPortRangeYAML,
 		"clientEgressL7HTTPMatchheaderSecretYAML":          clientEgressL7HTTPMatchheaderSecretYAML,
 		"clientEgressL7HTTPMatchheaderSecretPortRangeYAML": clientEgressL7HTTPMatchheaderSecretPortRangeYAML,
+		"clientEgressL7HTTPExternalYAML":                   clientEgressL7HTTPExternalYAML,
 		"clientEgressNodeLocalDNSYAML":                     clientEgressNodeLocalDNSYAML,
 		"echoIngressFromCIDRYAML":                          echoIngressFromCIDRYAML,
 		"denyCIDRPolicyYAML":                               denyCIDRPolicyYAML,

--- a/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -21,14 +21,14 @@ var clientEgressL7HTTPExternalYAML string
 
 type egressGatewayWithL7Policy struct{}
 
-func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, _ map[string]string) {
+func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, templates map[string]string) {
 	newTest("egress-gateway-with-l7-policy", ct).
 		WithCondition(func() bool {
 			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
 		}).
 		WithCiliumPolicy(clientEgressICMPYAML).
-		WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML).  // DNS resolution only
-		WithCiliumPolicy(clientEgressL7HTTPExternalYAML). // L7 allow policy with HTTP introspection
+		WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML).               // DNS resolution only
+		WithCiliumPolicy(templates["clientEgressL7HTTPExternalYAML"]). // L7 allow policy with HTTP introspection
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
 			Name:            "cegp-sample-client",
 			PodSelectorKind: "client",

--- a/connectivity/builder/manifests/client-egress-l7-http-external-node.yaml
+++ b/connectivity/builder/manifests/client-egress-l7-http-external-node.yaml
@@ -15,10 +15,10 @@ spec:
       any:kind: client
   egress:
   - toFQDNs:
-    - matchName: "echo-external-node.cilium-test.svc.cluster.local"
+    - matchName: "echo-external-node.{{.TestNamespace}}.svc.cluster.local"
     toPorts:
     - ports:
-      - port: "8080"
+      - port: "{{.ExternalDeploymentPort}}"
         protocol: TCP
       rules:
         http:


### PR DESCRIPTION
in client-egress-l7-http-external-node CNP instead of the fixed values to accommodate the test namespace and external deployment port change.