### PR TITLE
connectivity: Support multiple conditions

### DIFF
--- a/connectivity/check/test_test.go
+++ b/connectivity/check/test_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cilium/cilium-cli/utils/features"
 )
 
@@ -51,4 +53,27 @@ func TestWithFeatureRequirements(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWithCondition(t *testing.T) {
+	mytest := NewTest("my-test", false, false)
+	assert.True(t, mytest.checkConditions())
+
+	mytest = NewTest("my-test", false, false).
+		WithCondition(func() bool { return true })
+	assert.True(t, mytest.checkConditions())
+
+	mytest = NewTest("my-test", false, false).
+		WithCondition(func() bool { return false })
+	assert.False(t, mytest.checkConditions())
+
+	mytest = NewTest("my-test", false, false).
+		WithCondition(func() bool { return true }).
+		WithCondition(func() bool { return false })
+	assert.False(t, mytest.checkConditions())
+
+	mytest = NewTest("my-test", false, false).
+		WithCondition(func() bool { return false }).
+		WithCondition(func() bool { return true })
+	assert.False(t, mytest.checkConditions())
 }


### PR DESCRIPTION
Save all the condition functions from WithCondition() instead on only remembering the one from the latest invocation. Run the test if and only if it satisfies all the conditions.

Fixes: #2713