### PR TITLE
{externalworkloads,multicluster}: Shorten cluster names

### DIFF
--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -50,8 +50,8 @@ jobs:
     steps:
       - name: Set cluster name
         run: |
-          echo "clusterName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
-          echo "vmName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "clusterName=${{ github.event.repository.name }}-${{ github.run_id }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "vmName=${{ github.event.repository.name }}-${{ github.run_id }}-vm${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -159,6 +159,7 @@ jobs:
           # Install Cilium in cluster
           cilium install \
             --version "${{ env.cilium_version }}" \
+            --set cluster.id=1 \
             --set cluster.name="${{ env.clusterName }}" \
             --set bpf.monitorAggregation=none \
             --datapath-mode=tunnel \

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -55,10 +55,10 @@ jobs:
       # Note: These names currently approach the limit of 40 characters
       - name: Set mode-specific names
         run: |
-          echo "clusterNameBase=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
-          echo "clusterName1=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-1" >> $GITHUB_ENV
-          echo "clusterName2=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-2" >> $GITHUB_ENV
-          echo "firewallRuleName=${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "clusterNameBase=${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "clusterName1=${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-1" >> $GITHUB_ENV
+          echo "clusterName2=${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-2" >> $GITHUB_ENV
+          echo "firewallRuleName=${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Install kubectl
         run: |


### PR DESCRIPTION
Shorten cluster names to avoid getting this error:

    Error: Unable to install Cilium: execution error at (cilium/templates/validate.yaml:100:5):
    The cluster name is invalid: must not be more than 32 characters.
    Configure 'upgradeCompatibility' to 1.15 or earlier to temporarily
    skip this check at your own risk

Ref: https://github.com/cilium/cilium/pull/33939

edit: added another commit to set cluster.id in externalworkloads.