### PR TITLE
connectivity test: Change allow-all-egress policy to allow all egress

### DIFF
--- a/connectivity/builder/manifests/allow-all-egress.yaml
+++ b/connectivity/builder/manifests/allow-all-egress.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   endpointSelector: {}
   egress:
-  - toEndpoints:
-    - {}
-  - toCIDR:
-    - 0.0.0.0/0
+  - toPorts:
+    - ports:
+      - port: "0"


### PR DESCRIPTION
Change allow-all-egress policy to allow traffic to all ports on all (supported) protocols to all destinations. This helps unmask bugs that woudl be otherwise masked by the default deny when nothing in the policy map matches.

This policy adds proto-only entries for TCP, UDP, and SCTP, wildcarding both the destination identity and the destination port.

Merging may need to be postponed until the surfaced bugs are fixed.
