### PR TITLE
fixed pernode cilium encrypt status output

### DIFF
--- a/encrypt/status.go
+++ b/encrypt/status.go
@@ -212,7 +212,12 @@ func expectedIPsecKeyCount(ciliumPods int, fs features.Set, perNodeKey bool) int
 }
 
 func printPerNodeStatus(nodeMap map[string]models.EncryptionStatus, ikProps ipsecKeyProps, format string) error {
+	var err error
 	for node, st := range nodeMap {
+		if err != nil {
+			break
+		}
+
 		if format == status.OutputJSON {
 			var ns any = st
 			if st.Mode == "IPsec" {
@@ -223,7 +228,8 @@ func printPerNodeStatus(nodeMap map[string]models.EncryptionStatus, ikProps ipse
 					IPsecKeyRotationInProgress: int64(ikProps.expectedCount) != st.Ipsec.KeysInUse,
 				}
 			}
-			return printJSONStatus(ns)
+			err = printJSONStatus(ns)
+			continue
 		}
 
 		builder := strings.Builder{}
@@ -244,10 +250,9 @@ func printPerNodeStatus(nodeMap map[string]models.EncryptionStatus, ikProps ipse
 				builder.WriteString(fmt.Sprintf("\t%s: %d\n", k, v))
 			}
 		}
-		_, err := fmt.Println(builder.String())
-		return err
+		_, err = fmt.Println(builder.String())
 	}
-	return nil
+	return err
 }
 
 func getClusterStatus(nodeMap map[string]models.EncryptionStatus, ikProps ipsecKeyProps) (clusterStatus, error) {


### PR DESCRIPTION
Running `cilium encryption status --per-node-details` should return the status of all the nodes.
However, the for loop returns after the 1st node status being displayed, whether errors arise or not.

**old** output (1st node):
```bash
Node: cilium-testing-control-plane
Encryption: Wireguard
```

**new** output (all available nodes):

```bash
Node: cilium-testing-worker2
Encryption: Wireguard

Node: cilium-testing-control-plane
Encryption: Wireguard

Node: cilium-testing-worker
Encryption: Wireguard
```