### PR TITLE
Add host-firewall-egress-to-fqdns test

### DIFF
--- a/connectivity/builder/builder.go
+++ b/connectivity/builder/builder.go
@@ -77,6 +77,9 @@ var (
 
 	//go:embed manifests/echo-ingress-from-cidr.yaml
 	echoIngressFromCIDRYAML string
+
+	//go:embed manifests/host-firewall-egress-to-fqdns.yaml
+	hostFirewallEgressToFQDNsPolicyYAML string
 )
 
 var (
@@ -259,6 +262,7 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 	tests := []testBuilder{
 		hostFirewallIngress{},
 		hostFirewallEgress{},
+		hostFirewallEgressToFqdns{},
 	}
 	return injectTests(tests, ct)
 }
@@ -286,6 +290,7 @@ func renderTemplates(param check.Parameters) (map[string]string, error) {
 		"clientEgressNodeLocalDNSYAML":                     clientEgressNodeLocalDNSYAML,
 		"echoIngressFromCIDRYAML":                          echoIngressFromCIDRYAML,
 		"denyCIDRPolicyYAML":                               denyCIDRPolicyYAML,
+		"hostFirewallEgressToFQDNsPolicyYAML":              hostFirewallEgressToFQDNsPolicyYAML,
 	}
 	if param.K8sLocalHostTest {
 		templates["clientEgressToCIDRCPHostPolicyYAML"] = clientEgressToCIDRCPHostPolicyYAML

--- a/connectivity/builder/host_firewall_egress_to_fqdns.go
+++ b/connectivity/builder/host_firewall_egress_to_fqdns.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium-cli/utils/features"
+)
+
+type hostFirewallEgressToFqdns struct{}
+
+func (t hostFirewallEgressToFqdns) build(ct *check.ConnectivityTest, templates map[string]string) {
+	// This policy only allows port 80 to domain-name, default one.one.one.one., DNS proxy enabled.
+	newTest("host-firewall-egress-to-fqdns", ct).
+		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.L7Proxy),
+			features.RequireEnabled(features.HostFirewall)).
+		WithCiliumClusterwidePolicy(templates["hostFirewallEgressToFQDNsPolicyYAML"]).
+		WithScenarios(
+			tests.HostToWorld(),
+			tests.HostToWorld2()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			extTarget := ct.Params().ExternalTarget
+			if a.Destination().Address(features.GetIPFamily(extTarget)) == extTarget {
+				return check.ResultDNSOK, check.ResultNone
+			}
+
+			return check.ResultDNSOKDropCurlTimeout, check.ResultNone
+		})
+}

--- a/connectivity/builder/manifests/host-firewall-egress-to-fqdns.yaml
+++ b/connectivity/builder/manifests/host-firewall-egress-to-fqdns.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: host-firewall-egress-to-fqdns-{{trimSuffix .ExternalTarget "."}}
+spec:
+  nodeSelector: {}
+  egress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+    toFQDNs:
+    - matchName: "{{.ExternalTarget}}"
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEntities:
+    - world
+  - toEntities:
+    - health
+    - kube-apiserver
+    - remote-node


### PR DESCRIPTION
This commit adds a connectivity test for host L7 DNS proxy capability added in https://github.com/cilium/cilium/pull/34024.