### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,9 @@
 # Code owners groups and a brief description of their areas:
-# @cilium/azure                  Integration with Azure
 # @cilium/ci-structure           Continuous integration, testing
 # @cilium/cilium-cli-maintainers Release-related files
 # @cilium/cli                    Commandline interfaces
 # @cilium/contributing           Developer documentation & tools
 # @cilium/github-sec             GitHub security (handling of secrets, consequences of pull_request_target, etc.)
-# @cilium/sig-encryption         Encryption management
-# @cilium/sig-bgp                BGP integration
-# @cilium/sig-clustermesh        Clustermesh and external workloads
-# @cilium/sig-hubble             Hubble integration
-# @cilium/sig-k8s                K8s integration, K8s CNI plugin
 # @cilium/vendor                 Vendoring, dependency management
 
 # The following filepaths should be sorted so that more specific paths occur
@@ -25,56 +19,7 @@
 /.github/kind-config*.yaml @cilium/ci-structure
 /.github/tools/ @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
-/bgp/ @cilium/sig-bgp
 /cmd/ @cilium/cli
-/clustermesh/ @cilium/sig-clustermesh
-/connectivity/ @cilium/ci-structure
-/connectivity/check/frr.go @cilium/sig-bgp
-/connectivity/check/ipcache.go @cilium/ipcache
-/connectivity/check/metrics*.go @cilium/metrics
-/connectivity/check/policy.go @cilium/sig-policy
-/connectivity/builder/** @cilium/ci-structure
-/connectivity/builder/all_ingress_deny_from_outside.go @cilium/sig-encryption
-/connectivity/builder/bgp_control_plane.go @cilium/sig-bgp
-/connectivity/builder/cluster_entity_multi_cluster.go @cilium/sig-clustermesh
-/connectivity/builder/dns_only.go @cilium/sig-clustermesh
-/connectivity/builder/echo_ingress.go @cilium/sig-servicemesh
-/connectivity/builder/echo_ingress_auth_always_fail.go @cilium/sig-servicemesh
-/connectivity/builder/echo_ingress_from_other_client_deny.go @cilium/sig-servicemesh
-/connectivity/builder/echo_ingress_from_outside.go @cilium/sig-servicemesh
-/connectivity/builder/echo_ingress_knp.go @cilium/sig-servicemesh
-/connectivity/builder/echo_ingress_l7.go @cilium/sig-servicemesh
-/connectivity/builder/echo_ingress_l7_named_port.go @cilium/sig-servicemesh
-/connectivity/builder/echo_ingress_mutual_auth_spiffe.go @cilium/sig-servicemesh
-/connectivity/builder/egress_gateway.go @cilium/egress-gateway
-/connectivity/builder/egress_gateway_excluded_cidrs.go @cilium/egress-gateway
-/connectivity/builder/egress_gateway_with_l7_policy.go @cilium/egress-gateway
-/connectivity/builder/no_ipsec_xfrm_errors.go @cilium/sig-encryption
-/connectivity/builder/node_to_node_encryption.go @cilium/sig-encryption
-/connectivity/builder/pod_to_pod_encryption.go @cilium/sig-encryption
-/connectivity/tests/bgp.go @cilium/sig-bgp
-/connectivity/tests/clustermesh-endpointslice-sync.go @cilium/sig-clustermesh
-/connectivity/tests/egressgateway.go @cilium/egress-gateway
-/connectivity/tests/encryption.go @cilium/sig-encryption
-/connectivity/tests/errors.go @cilium/sig-agent @cilium/sig-datapath
-/connectivity/tests/externalworkload.go @cilium/sig-clustermesh
-/connectivity/tests/from-cidr.go @cilium/sig-policy
-/connectivity/tests/health.go @cilium/sig-agent
-/connectivity/tests/host.go @cilium/sig-agent
-/connectivity/tests/ipsec_xfrm.go @cilium/ipsec
-/connectivity/tests/perfpod.go @cilium/sig-datapath
-/connectivity/tests/pod.go @cilium/sig-agent
-/connectivity/tests/service.go @cilium/sig-lb
-/connectivity/tests/testloop.sh @jrajahalme
-/connectivity/tests/to-cidr.go @cilium/sig-policy
-/connectivity/tests/upgrade.go @cilium/sig-datapath
-/connectivity/tests/world.go @cilium/proxy
-/encrypt/ @cilium/sig-encryption
-/hubble/ @cilium/sig-hubble
-/install/ @cilium/cli @cilium/helm
-/install/azure.go @cilium/azure
-/internal/cli/ @cilium/cli
-/k8s/ @cilium/sig-k8s
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor
 /stable-v0.14.txt @cilium/cilium-cli-maintainers


### PR DESCRIPTION
Most of the Go code will get deleted once cilium/cilium#34178 gets merged. Update CODEOWNERS first to avoid pulling in too many people for review when these files get deleted.