### PR TITLE
publish images: amd64/arm64 images containing cli only

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -14,7 +14,7 @@ on:
       - 'v*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  group: ${{ github.workflow }}-${{ gith-cliub.event.pull_request.number || github.event.after }}
   cancel-in-progress: true
 
 jobs:
@@ -25,8 +25,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: cilium-cli
+          - name: cilium-cli-ci
             dockerfile: ./Dockerfile
+            platforms: linux/amd64
+          - name: cilium-cli
+            dockerfile: ./Dockerfile-cli-only
+            platforms: linux/amd64,linux/arm64
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
@@ -65,16 +69,16 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
 
       - name: CI Image Releases digests
         if: ${{ github.event_name != 'pull_request_target' }}
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_main.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_main.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}:latest@${{ steps.docker_build_ci_main.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_main.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # PR updates
       - name: CI Build ${{ matrix.name }}
@@ -85,16 +89,16 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
-          platforms: linux/amd64
+          platforms: ${{ matrix.platforms }}
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
 
       - name: CI Image Releases digests
         if: ${{ github.event_name == 'pull_request_target' }}
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests
       - name: Upload artifact digests

--- a/Dockerfile-cli-only
+++ b/Dockerfile-cli-only
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.9@sha256:fe40cf4e92cd0c467be2cfc30657a680ae2398318afd50b0c80585784c604f28
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+FROM docker.io/library/golang:1.22.6-alpine3.19@sha256:1bad39361dd21f2f881ce10ff810e40e5be3eba89a0b61e762e05ec42f9bbaf2 AS builder
+WORKDIR /go/src/github.com/cilium/cilium-cli
+RUN apk add --no-cache git make ca-certificates
+COPY . .
+RUN make
+
+FROM scratch
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder /go/src/github.com/cilium/cilium-cli/cilium /usr/local/bin/cilium
+ENTRYPOINT []
+


### PR DESCRIPTION
There was no prebuilt image available for multiple architectures, this provides an image from scratch only containing cilium-cli binary.

This ensures that the image can be used directly as a standalone solution or included within other containers

example dockerfile
---
FROM quay.io/cilium/cilium-cli:tag as cilium
FROM exampleimage
COPY --from=cilium /usr/local/bin/cilium /usr/local/bin/cilium ---

Fixes: #2755