### PR TITLE
CODEOWNERS: Assign vendor/ to cilium-cli-maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,8 +20,8 @@
 /.github/tools/ @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /cmd/ @cilium/cli
-/go.sum @cilium/vendor
-/go.mod @cilium/vendor
+/go.sum @cilium/cilium-cli-maintainers
+/go.mod @cilium/cilium-cli-maintainers
 /stable-v0.14.txt @cilium/cilium-cli-maintainers
 /stable.txt @cilium/cilium-cli-maintainers
-/vendor/ @cilium/vendor
+/vendor/ @cilium/cilium-cli-maintainers


### PR DESCRIPTION
Most of the Go code has been moved to cilium/cilium repo [^1], and the only direct dependencies are cilium/cilium and google/gops at this point. I don't think it makes much sense to pull in the vendor team for reviewing new versions of cilium and / or gops. I'm imagining the new release process will look something like this:

- Renovate picks up a new cilium/cilium pre-release from main branch. Pre-releases happen roughly once a month.
- cilium-cli-maintainers team approves and merges the Renovate PR.
- cilium-cli-maintainers team cuts a new cilium-cli release.

[^1]: https://github.com/cilium/cilium/pull/34178