### PR TITLE
feat(clustermesh): Add --destination-contexts option for connecting multiple remote contexts

### DIFF
--- a/cli/clustermesh.go
+++ b/cli/clustermesh.go
@@ -322,13 +322,17 @@ func newCmdClusterMeshDisconnectWithHelm() *cobra.Command {
 			}
 		},
 	}
+	cmd.Flags().StringVar(&params.ConnectionMode, "connection-mode", "bidirectional", "Connection mode: unicast, bidirectional or mesh")
 	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
+	cmd.Flags().StringSliceVar(&params.DestinationContexts, "destination-contexts", []string{}, "Comma separated list of Kubernetes configuration contexts of destination cluster")
 
 	return cmd
 }
 
 func addCommonConnectFlags(cmd *cobra.Command, params *clustermesh.Parameters) {
+	cmd.Flags().StringVar(&params.ConnectionMode, "connection-mode", "bidirectional", "Connection mode: unicast, bidirectional or mesh")
 	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
+	cmd.Flags().StringSliceVar(&params.DestinationContexts, "destination-contexts", []string{}, "Comma separated list of Kubernetes configuration contexts of destination cluster")
 	cmd.Flags().StringSliceVar(&params.DestinationEndpoints, "destination-endpoint", []string{}, "IP of ClusterMesh service of destination cluster")
 	cmd.Flags().StringSliceVar(&params.SourceEndpoints, "source-endpoint", []string{}, "IP of ClusterMesh service of source cluster")
 }


### PR DESCRIPTION
Introduce the `--destination-contexts` option to enhance the flexibility of connecting multiple remote contexts.

This feature supports various connection modes (using the `--connection-mode` option):

* unicast: configures only the source context
* bidirectional (default value): configures the source context and its server in the destination contexts
* mesh: configures both the source and destination contexts, including clusters in both.