### PR TITLE
make: set set latest stable version based on stable.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,15 @@ GO_TAGS ?=
 TARGET=cilium
 INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
-VERSION=$(shell git describe --tags --always)
+CILIUM_VERSION=$(shell curl -s https://raw.githubusercontent.com/cilium/cilium/main/stable.txt)
+CLI_VERSION=$(shell git describe --tags --always)
 STRIP_DEBUG=-w -s
 ifdef DEBUG
 	STRIP_DEBUG=
 endif
-GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) -X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(VERSION)'
+GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) \
+		    -X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)' \
+		    -X 'github.com/cilium/cilium/cilium-cli/defaults.Version=$(CILIUM_VERSION)'
 
 TEST_TIMEOUT ?= 5s
 RELEASE_UID ?= $(shell id -u)


### PR DESCRIPTION
Follow-up change for https://github.com/cilium/cilium/pull/34666. We need to set the latest stable Cilium version based on stable.txt from the main Cilium repo as it isn't vendored.

> curl it, man.
> 
>   -- @michi-covalent