### PR TITLE
action: Run version command with --client flag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -114,4 +114,4 @@ runs:
     - name: Run Cilium CLI Version
       shell: bash
       run: |
-        ${{ inputs.binary-dir }}/${{ inputs.binary-name }} version
+        ${{ inputs.binary-dir }}/${{ inputs.binary-name }} version --client


### PR DESCRIPTION
Specify --client flag so that the command succeeds even if .kube/config does not exist.

Ref: https://github.com/cilium/cilium/pull/34914