### PR TITLE
Add help command to Makefile for improved usability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,22 @@ check:
 	docker run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION) golangci-lint run
 endif
 
-.PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags
+.PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags help
+
+help:
+	@echo "Available commands:"
+	@printf "  %-18s Build the Cilium binary.\n" $(TARGET)
+	@printf "  %-18s Create a release of the binary.\n" release
+	@printf "  %-18s Build binaries for local environment.\n" local-release
+	@printf "  %-18s Install the Cilium binary.\n" install
+	@printf "  %-18s Remove the binary and release files.\n" clean
+	@printf "  %-18s Run tests with race detection and coverage.\n" test
+	@printf "  %-18s Run benchmarks.\n" bench
+	@printf "  %-18s Run lint checks on the code.\n" check
+	@printf "  %-18s Remove generated tags and cscope files.\n" clean-tags
+	@printf "  %-18s Generate tags for the source code.\n" tags
+	@echo ""
+	@echo "Run 'make <command>' to execute a command."
+	@echo "Use 'make help' to see this help message."
 
 -include Makefile.override


### PR DESCRIPTION
Description
This pull request adds a help command to the Makefile, providing users with a clear overview of the available commands and their functionalities.

fixes: #2808 

Changes made:

Introduced a help target that outputs the following information in a neatly formatted manner:
```
Available commands:
  cilium             Build the Cilium binary.
  release            Create a release of the binary.
  local-release      Build binaries for local environment.
  install            Install the Cilium binary.
  clean              Remove the binary and release files.
  test               Run tests with race detection and coverage.
  bench              Run benchmarks.
  check              Run lint checks on the code.
  clean-tags         Remove generated tags and cscope files.
  tags               Generate tags for the source code.

Run 'make <command>' to execute a command.
Use 'make help' to see this help message.
```
This enhancement improves user experience by making it easier to find and understand the available commands in the Makefile.