### PR TITLE
multicluster: correctly specify the dst context to clustermes connect

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -239,7 +239,7 @@ jobs:
           $(kubectl --context "${{ steps.contexts.outputs.cluster2 }}" get svc -n kube-system clustermesh-apiserver -o jsonpath='{.metadata.annotations}')
 
           # Connect clusters
-          cilium --context "${{ steps.contexts.outputs.cluster1 }}" clustermesh connect --destination-context "${CONTEXT2}"
+          cilium --context "${{ steps.contexts.outputs.cluster1 }}" clustermesh connect --destination-context "${{ steps.contexts.outputs.cluster2 }}"
 
           # Wait for cluster mesh status to be ready
           cilium --context "${{ steps.contexts.outputs.cluster1 }}" clustermesh status --wait


### PR DESCRIPTION
Use the correct variable to specify the destination context for the clustermesh connect step, which is otherwise left empty:

>   cilium --context gke... clustermesh connect --destination-context ''

Although the workflow is currently working regardless (as the context referring to the second cluster is the default one), that no longer applies when pulling in the latest Cilium CLI changes, as --dst-context has been converted to possibly take a list of contexts.

Fixes: f2fba32482e0 ("multicluster: Run cilium-cli inside a container")