### PR TITLE
.github: support native hubble port-forwarding

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -158,7 +158,11 @@ jobs:
           # Port forward Relay
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
+          if ! [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]; then
+            # support for native port-forwarding
+            # TODO: remove kubectl version after 0.16.20 release
+            [[ $(pgrep -f "cilium.*hubble.*port-forward" | wc -l) == 1 ]]
+          fi
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=3 --all-flows --collect-sysdump-on-failure --external-target amazon.com. \

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -157,7 +157,11 @@ jobs:
           # Port forward Relay
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
+          if ! [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]; then
+            # support for native port-forwarding
+            # TODO: remove kubectl version after 0.16.20 release
+            [[ $(pgrep -f "cilium.*hubble.*port-forward" | wc -l) == 1 ]]
+          fi
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=3 --all-flows --collect-sysdump-on-failure --external-target amazon.com.

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -153,7 +153,11 @@ jobs:
           # Port forward Relay
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
+          if ! [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]; then
+            # support for native port-forwarding
+            # TODO: remove kubectl version after 0.16.20 release
+            [[ $(pgrep -f "cilium.*hubble.*port-forward" | wc -l) == 1 ]]
+          fi
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=5 --all-flows --collect-sysdump-on-failure --external-target google.com.

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -82,7 +82,11 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
+          if ! [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]; then
+            # support for native port-forwarding
+            # TODO: remove kubectl version after 0.16.20 release
+            [[ $(pgrep -f "cilium.*hubble.*port-forward" | wc -l) == 1 ]]
+          fi
 
       - name: Set up external targets
         id: external_targets
@@ -160,7 +164,11 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
+          if ! [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]; then
+            # support for native port-forwarding
+            # TODO: remove kubectl version after 0.16.20 release
+            [[ $(pgrep -f "cilium.*hubble.*port-forward" | wc -l) == 1 ]]
+          fi
 
       - name: Connectivity test
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -250,7 +250,11 @@ jobs:
           # Port forward Relay
           cilium --context "${{ steps.contexts.outputs.cluster1 }}" hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]
+          if ! [[ $(pgrep -f "kubectl.*port-forward.*hubble-relay" | wc -l) == 1 ]]; then
+            # support for native port-forwarding
+            # TODO: remove kubectl version after 0.16.20 release
+            [[ $(pgrep -f "cilium.*hubble.*port-forward" | wc -l) == 1 ]]
+          fi
 
           # Run connectivity test
           cilium --context "${{ steps.contexts.outputs.cluster1 }}" connectivity test --test-concurrency=5 \


### PR DESCRIPTION
Once 0.16.20 is merged, we can remove branching and support for the kubectl version.