### PR TITLE
.github: use netcat to check hubble port-forward success

### DIFF
--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -158,7 +158,7 @@ jobs:
           # Port forward Relay
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "^cilium.*hubble.*port-forward$" | wc -l) == 1 ]]
+          nc -nvz 127.0.0.1 4245
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=3 --all-flows --collect-sysdump-on-failure --external-target amazon.com. \

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -157,7 +157,7 @@ jobs:
           # Port forward Relay
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "^cilium.*hubble.*port-forward$" | wc -l) == 1 ]]
+          nc -nvz 127.0.0.1 4245
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=3 --all-flows --collect-sysdump-on-failure --external-target amazon.com.

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -153,8 +153,7 @@ jobs:
           # Port forward Relay
           cilium hubble port-forward&
           sleep 10s
-
-          [[ $(pgrep -f "^cilium.*hubble.*port-forward$" | wc -l) == 1 ]]
+          nc -nvz 127.0.0.1 4245
 
           # Run connectivity test
           cilium connectivity test --test-concurrency=5 --all-flows --collect-sysdump-on-failure --external-target google.com.

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -82,7 +82,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "^cilium.*hubble.*port-forward$" | wc -l) == 1 ]]
+          nc -nvz 127.0.0.1 4245
 
       - name: Set up external targets
         id: external_targets
@@ -160,7 +160,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "^cilium.*hubble.*port-forward$" | wc -l) == 1 ]]
+          nc -nvz 127.0.0.1 4245
 
       - name: Connectivity test
         run: |

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -250,7 +250,7 @@ jobs:
           # Port forward Relay
           cilium --context "${{ steps.contexts.outputs.cluster1 }}" hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "^cilium.*hubble.*port-forward$" | wc -l) == 1 ]]
+          nc -nvz 127.0.0.1 4245
 
           # Run connectivity test
           cilium --context "${{ steps.contexts.outputs.cluster1 }}" connectivity test --test-concurrency=5 \


### PR DESCRIPTION
Use more robust method for checking if hubble port-forward is successful using netcat.

Do note that the workflows use `on.pull_request_target` therefore the changes will not be reflected in this PR checks, but we've tested these on the isovalent CI with success.

CC @michi-covalent 

Will fix upcoming CI failure caused by: https://github.com/cilium/cilium/pull/35483