### PR TITLE
action: Explicitly set go-version

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -43,13 +43,10 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: 1.23.3
 
-      - name: Set up Go for root
-        run: |
-          sudo ln -sf `which go` `sudo which go` || true
-          sudo go version
-
-      - name: Build and install cilium CLI binary
-        run: sudo make install
+      - name: Install Cilium CLI
+        uses: ./
+        with:
+          local-path: '.'
 
       - name: Create kind cluster
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
@@ -234,13 +231,10 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: 1.23.3
 
-      - name: Set up Go for root
-        run: |
-          sudo ln -sf `which go` `sudo which go` || true
-          sudo go version
-
-      - name: Build and install cilium CLI binary
-        run: sudo make install
+      - name: Install Cilium CLI
+        uses: ./
+        with:
+          local-path: '.'
 
       - name: Create kind cluster 1
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
       uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       if: ${{ steps.build-cli.outputs.path != '' }}
       with:
-        go-version-file: '${{ steps.build-cli.outputs.go-mod-path }}'
+        go-version: '1.23.3'
         cache: true
         cache-dependency-path: '${{ steps.build-cli.outputs.go-sum-path }}'
 


### PR DESCRIPTION
Temporarily set go-version explicitly to avoid hitting this cache restore issue [^1]. We can revert this when Go 1.24 gets released.

Also modify kind.yaml to install Cilium CLI using the local action.

[^1]: https://github.com/actions/setup-go/issues/506