### PR TITLE
.github/workflows: add validation of renovate config

### DIFF
--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -1,0 +1,21 @@
+name: Validate Renovate configuration
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    name: Validate Renovate configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout configuration
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # this step uses latest renovate slim release
+      - name: Validate configuration
+        run: >
+          docker run --rm --entrypoint "renovate-config-validator"
+          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
+          ghcr.io/renovatebot/renovate:latest "/renovate.json5"


### PR DESCRIPTION
Add a GHA workflow to validate the renovate configuration when it is changed by a PR.

This was taken from the main cilium repository.