### PR TITLE
Dockerfile: drop syntax comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.12@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5
-
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
This is being updated by renovate for not much use. We don't use any fancy or deprecated Dockerfile syntax features so it should be fine to leave this unspecified.