### PR TITLE
renovate config migration remake

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:base",
+    "config:recommended",
     ":gitSignOff",
     "helpers:pinGitHubActionDigests",
   ],
@@ -44,7 +44,7 @@
     {
       groupName: "all github action dependencies",
       groupSlug: "all-github-action",
-      matchPaths: [
+      matchFileNames: [
         ".github/workflows/**",
         "action.yaml",
       ],
@@ -86,7 +86,7 @@
     {
       // Avoid updating patch releases of golang in go.mod
       enabled: "false",
-      matchFiles: [
+      matchFileNames: [
         "go.mod",
       ],
       matchDepNames: [
@@ -112,7 +112,7 @@
     {
       // Images that directly use docker.io/library/golang for building.
       groupName: "golang-images",
-      matchFiles: [
+      matchFileNames: [
         "Dockerfile",
         "Makefile",
       ],
@@ -144,8 +144,9 @@
       ],
     },
   ],
-  regexManagers: [
+  customManagers: [
     {
+      customType: "regex",
       fileMatch: [
         "^\\.github/workflows/[^/]+\\.yaml$",
         "^action.yaml$",
@@ -159,6 +160,7 @@
       ],
     },
     {
+      customType: "regex",
       fileMatch: [
         "^Makefile$",
       ],
@@ -171,6 +173,7 @@
       ],
     },
     {
+      customType: "regex",
       fileMatch: [
         "^go\\.mod$",
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -205,18 +205,6 @@
     },
     {
       "fileMatch": [
-        "^defaults/defaults.go$"
-      ],
-      // This regex manages image version strings in defaults/defaults.go
-      // similar to the examples shown here:
-      //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
-      "matchStrings": [
-        "\/\/ renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\"",
-        "\/\/ renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+Version = \"(?<currentValue>.*)\""
-      ]
-    },
-    {
-      "fileMatch": [
         "^go\\.mod$"
       ],
       "matchStrings": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -153,14 +153,6 @@
       ]
     },
     {
-      "matchPackageNames": [
-        "docker.io/library/busybox"
-      ],
-      "matchPaths": [
-        "Dockerfile"
-      ],
-    },
-    {
       "groupName": "Go",
       "matchDepNames": [
         "go",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,177 +1,182 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
     "config:base",
     ":gitSignOff",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
   ],
+
   // This ensures that the gitAuthor and gitSignOff fields match
-  "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
-  "includePaths": [
+  gitAuthor: "renovate[bot] <bot@renovateapp.com>",
+  includePaths: [
     ".github/workflows/**",
     "action.yaml",
     "defaults/defaults.go",
     "go.mod",
     "go.sum",
     "Dockerfile",
-    "Makefile"
+    "Makefile",
   ],
   postUpdateOptions: [
-    "gomodTidy"
+    "gomodTidy",
   ],
-  "pinDigests": true,
-  "ignorePresets": [":prHourlyLimit2"],
-  "separateMajorMinor": true,
-  "separateMultipleMajor": true,
-  "separateMinorPatch": true,
-  "pruneStaleBranches": true,
-  "baseBranches": [
-    "main"
+  pinDigests: true,
+  ignorePresets: [
+    ":prHourlyLimit2",
   ],
-  "vulnerabilityAlerts": {
-    "enabled": true
+  separateMajorMinor: true,
+  separateMultipleMajor: true,
+  separateMinorPatch: true,
+  pruneStaleBranches: true,
+  baseBranches: [
+    "main",
+  ],
+  vulnerabilityAlerts: {
+    enabled: true,
   },
-  "labels": [
+  labels: [
     "renovate/stop-updating",
     "kind/enhancement",
-    "priority/release-blocker"
+    "priority/release-blocker",
   ],
-  "stopUpdatingLabel": "renovate/stop-updating",
-  "packageRules": [
+  stopUpdatingLabel: "renovate/stop-updating",
+  packageRules: [
     {
-      "groupName": "all github action dependencies",
-      "groupSlug": "all-github-action",
-      "matchPaths": [
+      groupName: "all github action dependencies",
+      groupSlug: "all-github-action",
+      matchPaths: [
         ".github/workflows/**",
-        "action.yaml"
+        "action.yaml",
       ],
-      "matchUpdateTypes": [
+      matchUpdateTypes: [
         "major",
         "minor",
         "digest",
         "patch",
         "pin",
-        "pinDigest"
-      ]
+        "pinDigest",
+      ],
     },
     {
-      "groupName": "all go dependencies main",
-      "groupSlug": "all-go-deps-main",
-      "matchFiles": [
+      groupName: "all go dependencies main",
+      groupSlug: "all-go-deps-main",
+      matchFiles: [
         "go.mod",
-        "go.sum"
+        "go.sum",
       ],
-      "postUpdateOptions": [
+      postUpdateOptions: [
         // update source import paths on major updates
         "gomodUpdateImportPaths",
       ],
-      "matchUpdateTypes": [
+      matchUpdateTypes: [
         "major",
         "minor",
         "digest",
         "patch",
         "pin",
-        "pinDigest"
+        "pinDigest",
       ],
       matchBaseBranches: [
-        "main"
+        "main",
       ],
-      "schedule": [
-        "on friday"
+      schedule: [
+        "on friday",
       ],
     },
     {
       // Avoid updating patch releases of golang in go.mod
-      "enabled": "false",
-      "matchFiles": [
+      enabled: "false",
+      matchFiles: [
         "go.mod",
       ],
-      "matchDepNames": [
-        "go"
+      matchDepNames: [
+        "go",
       ],
-      "matchDatasources": [
-        "golang-version"
+      matchDatasources: [
+        "golang-version",
       ],
-      "matchUpdateTypes": [
-        "patch"
+      matchUpdateTypes: [
+        "patch",
       ],
       matchBaseBranches: [
         "main",
-      ]
+      ],
     },
     {
       // Allow github.com/cilium/cilium to upgrade to prerelease versions.
-      "ignoreUnstable": false,
-      "matchPackageNames": [
+      ignoreUnstable: false,
+      matchPackageNames: [
         "github.com/cilium/cilium",
       ],
     },
     {
       // Images that directly use docker.io/library/golang for building.
-      "groupName": "golang-images",
-      "matchFiles": [
+      groupName: "golang-images",
+      matchFiles: [
         "Dockerfile",
-        "Makefile"
-      ]
+        "Makefile",
+      ],
     },
     {
-      "groupName": "Go",
-      "matchDepNames": [
+      groupName: "Go",
+      matchDepNames: [
         "go",
-        "docker.io/library/golang"
+        "docker.io/library/golang",
       ],
-      "schedule": [
-        "on friday"
-      ]
+      schedule: [
+        "on friday",
+      ],
     },
     {
       // Group golangci-lint updates to overrule grouping of version updates in the GHA files.
       // Without this, golangci-lint updates are not in sync for GHA files and other usages.
-      "groupName": "golangci-lint",
-      "matchDepNames": [
-        "golangci/golangci-lint"
-      ]
+      groupName: "golangci-lint",
+      matchDepNames: [
+        "golangci/golangci-lint",
+      ],
     },
     {
       // Group cilium updates to overrule grouping of version updates in the GHA files.
       // Without this, cilium updates are not in sync for GHA files and other usages.
-      "groupName": "cilium",
-      "matchDepNames": [
-        "cilium/cilium"
-      ]
-    }
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": [
-        "^\\.github/workflows/[^/]+\\.yaml$",
-	"^action.yaml$"
+      groupName: "cilium",
+      matchDepNames: [
+        "cilium/cilium",
       ],
+    },
+  ],
+  regexManagers: [
+    {
+      fileMatch: [
+        "^\\.github/workflows/[^/]+\\.yaml$",
+        "^action.yaml$",
+      ],
+
       // This regex manages version strings in GitHub actions workflow files,
       // similar to the examples shown here:
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)"
-      ]
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)",
+      ],
     },
     {
-      "fileMatch": [
-        "^Makefile$"
+      fileMatch: [
+        "^Makefile$",
       ],
+
       // This regex manages version strings in the Makefile,
       // similar to the examples shown here:
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = (?<currentValue>.*)\\s+.+_SHA = (?<currentDigest>sha256:[a-f0-9]+)"
-      ]
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = (?<currentValue>.*)\\s+.+_SHA = (?<currentDigest>sha256:[a-f0-9]+)",
+      ],
     },
     {
-      "fileMatch": [
-        "^go\\.mod$"
+      fileMatch: [
+        "^go\\.mod$",
       ],
-      "matchStrings": [
-        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)"
-      ]
+      matchStrings: [
+        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)",
+      ],
     },
-  ]
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,184 +1,184 @@
 {
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    "config:recommended",
-    ":gitSignOff",
-    "helpers:pinGitHubActionDigests",
+    'config:recommended',
+    ':gitSignOff',
+    'helpers:pinGitHubActionDigests',
   ],
 
   // This ensures that the gitAuthor and gitSignOff fields match
-  gitAuthor: "renovate[bot] <bot@renovateapp.com>",
+  gitAuthor: 'renovate[bot] <bot@renovateapp.com>',
   includePaths: [
-    ".github/workflows/**",
-    "action.yaml",
-    "defaults/defaults.go",
-    "go.mod",
-    "go.sum",
-    "Dockerfile",
-    "Makefile",
+    '.github/workflows/**',
+    'action.yaml',
+    'defaults/defaults.go',
+    'go.mod',
+    'go.sum',
+    'Dockerfile',
+    'Makefile',
   ],
   postUpdateOptions: [
-    "gomodTidy",
+    'gomodTidy',
   ],
   pinDigests: true,
   ignorePresets: [
-    ":prHourlyLimit2",
+    ':prHourlyLimit2',
   ],
   separateMajorMinor: true,
   separateMultipleMajor: true,
   separateMinorPatch: true,
   pruneStaleBranches: true,
   baseBranches: [
-    "main",
+    'main',
   ],
   vulnerabilityAlerts: {
     enabled: true,
   },
   labels: [
-    "renovate/stop-updating",
-    "kind/enhancement",
-    "priority/release-blocker",
+    'renovate/stop-updating',
+    'kind/enhancement',
+    'priority/release-blocker',
   ],
-  stopUpdatingLabel: "renovate/stop-updating",
+  stopUpdatingLabel: 'renovate/stop-updating',
   packageRules: [
     {
-      groupName: "all github action dependencies",
-      groupSlug: "all-github-action",
+      groupName: 'all github action dependencies',
+      groupSlug: 'all-github-action',
       matchFileNames: [
-        ".github/workflows/**",
-        "action.yaml",
+        '.github/workflows/**',
+        'action.yaml',
       ],
       matchUpdateTypes: [
-        "major",
-        "minor",
-        "digest",
-        "patch",
-        "pin",
-        "pinDigest",
+        'major',
+        'minor',
+        'digest',
+        'patch',
+        'pin',
+        'pinDigest',
       ],
     },
     {
-      groupName: "all go dependencies main",
-      groupSlug: "all-go-deps-main",
+      groupName: 'all go dependencies main',
+      groupSlug: 'all-go-deps-main',
       matchFiles: [
-        "go.mod",
-        "go.sum",
+        'go.mod',
+        'go.sum',
       ],
       postUpdateOptions: [
         // update source import paths on major updates
-        "gomodUpdateImportPaths",
+        'gomodUpdateImportPaths',
       ],
       matchUpdateTypes: [
-        "major",
-        "minor",
-        "digest",
-        "patch",
-        "pin",
-        "pinDigest",
+        'major',
+        'minor',
+        'digest',
+        'patch',
+        'pin',
+        'pinDigest',
       ],
       matchBaseBranches: [
-        "main",
+        'main',
       ],
       schedule: [
-        "on friday",
+        'on friday',
       ],
     },
     {
       // Avoid updating patch releases of golang in go.mod
-      enabled: "false",
+      enabled: 'false',
       matchFileNames: [
-        "go.mod",
+        'go.mod',
       ],
       matchDepNames: [
-        "go",
+        'go',
       ],
       matchDatasources: [
-        "golang-version",
+        'golang-version',
       ],
       matchUpdateTypes: [
-        "patch",
+        'patch',
       ],
       matchBaseBranches: [
-        "main",
+        'main',
       ],
     },
     {
       // Allow github.com/cilium/cilium to upgrade to prerelease versions.
       ignoreUnstable: false,
       matchPackageNames: [
-        "github.com/cilium/cilium",
+        'github.com/cilium/cilium',
       ],
     },
     {
       // Images that directly use docker.io/library/golang for building.
-      groupName: "golang-images",
+      groupName: 'golang-images',
       matchFileNames: [
-        "Dockerfile",
-        "Makefile",
+        'Dockerfile',
+        'Makefile',
       ],
     },
     {
-      groupName: "Go",
+      groupName: 'Go',
       matchDepNames: [
-        "go",
-        "docker.io/library/golang",
+        'go',
+        'docker.io/library/golang',
       ],
       schedule: [
-        "on friday",
+        'on friday',
       ],
     },
     {
       // Group golangci-lint updates to overrule grouping of version updates in the GHA files.
       // Without this, golangci-lint updates are not in sync for GHA files and other usages.
-      groupName: "golangci-lint",
+      groupName: 'golangci-lint',
       matchDepNames: [
-        "golangci/golangci-lint",
+        'golangci/golangci-lint',
       ],
     },
     {
       // Group cilium updates to overrule grouping of version updates in the GHA files.
       // Without this, cilium updates are not in sync for GHA files and other usages.
-      groupName: "cilium",
+      groupName: 'cilium',
       matchDepNames: [
-        "cilium/cilium",
+        'cilium/cilium',
       ],
     },
   ],
   customManagers: [
     {
-      customType: "regex",
+      customType: 'regex',
       fileMatch: [
-        "^\\.github/workflows/[^/]+\\.yaml$",
-        "^action.yaml$",
+        '^\\.github/workflows/[^/]+\\.yaml$',
+        '^action.yaml$',
       ],
 
       // This regex manages version strings in GitHub actions workflow files,
       // similar to the examples shown here:
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
       matchStrings: [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)",
+        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)',
       ],
     },
     {
-      customType: "regex",
+      customType: 'regex',
       fileMatch: [
-        "^Makefile$",
+        '^Makefile$',
       ],
 
       // This regex manages version strings in the Makefile,
       // similar to the examples shown here:
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
       matchStrings: [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = (?<currentValue>.*)\\s+.+_SHA = (?<currentDigest>sha256:[a-f0-9]+)",
+        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = (?<currentValue>.*)\\s+.+_SHA = (?<currentDigest>sha256:[a-f0-9]+)',
       ],
     },
     {
-      customType: "regex",
+      customType: 'regex',
       fileMatch: [
-        "^go\\.mod$",
+        '^go\\.mod$',
       ],
       matchStrings: [
-        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)",
+        '// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)',
       ],
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,44 +100,6 @@
       ]
     },
     {
-      "enabled": false,
-      "matchPackageNames": [
-        // All of these packages are maintained on a Cilium fork. Thus, we don't
-        // want to update them automatically.
-        "go.universe.tf/metallb",
-        "github.com/cilium/metallb",
-        "github.com/miekg/dns",
-        "github.com/cilium/dns",
-        "sigs.k8s.io/controller-tools",
-        "github.com/cilium/controller-tools",
-        // We update this dependency manually together with envoy proxy updates
-        "github.com/cilium/proxy",
-        // We need v1.0.6-0.20210604193023-d5e0c0615ace from pflag, but
-        // renovate wants to downgrade to 1.0.5. Can be removed if pflag ever
-        // tags a new release.
-        "github.com/spf13/pflag",
-        // v0.0.0-20230801115018-d63ba01acd4b causes this complilation error:
-        //
-        // # github.com/cilium/cilium/pkg/hive/cell
-        // Error: vendor/github.com/cilium/cilium/pkg/hive/cell/health.go:194:23:
-        // type func(a Status, b Status) bool of func(a, b Status) bool {…} does not match inferred
-        // type func(a Status, b Status) int for func(a E, b E) int
-        "golang.org/x/exp",
-	// This package is not versioned leading to "empty" updates every week.
-	// Update it manually once newly introduces tetragon CRDs are required.
-	"github.com/cilium/tetragon/pkg/k8s",
-        // Do not update GoBGP until https://github.com/osrg/gobgp/issues/2777
-        // is resolved and a new version is released.
-        // Ref: https://github.com/cilium/cilium/pull/31123
-        "github.com/osrg/gobgp/v3",
-      ],
-      "matchPackagePatterns": [
-        // k8s dependencies will be updated manually in lockstep.
-        "k8s.io/*",
-        "sigs.k8s.io/*"
-      ]
-    },
-    {
       // Allow github.com/cilium/cilium to upgrade to prerelease versions.
       "ignoreUnstable": false,
       "matchPackageNames": [


### PR DESCRIPTION
This is mostly the same as https://github.com/cilium/cilium-cli/pull/2913 but done by hand and split into understandable commits.

I've also taken the liberty of dropping a few unused things from the config, that's the first couple of commits.
