### PR TITLE
Remove v0.15.22 from the release list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ binary releases.
 | Release                                                                | Maintained | Compatible Cilium Versions |
 |------------------------------------------------------------------------|------------|----------------------------|
 | [v0.16.24](https://github.com/cilium/cilium-cli/releases/tag/v0.16.24) | Yes        | Cilium 1.15 and newer      |
-| [v0.15.22](https://github.com/cilium/cilium-cli/releases/tag/v0.15.22) | Yes        | Cilium 1.14 (*)            |
-
-Note:
-- [v0.15.22](https://github.com/cilium/cilium-cli/releases/tag/v0.15.22) can
-  still be used for Cilium 1.15 and newer if Gateway API support is not enabled.
 
 ## Capabilities
 


### PR DESCRIPTION
Cilium v1.14 has gone end of life.