### PR TITLE
ci: avoid using deprecated tls.secretsBackend flag

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -140,7 +140,8 @@ jobs:
             --datapath-mode=aks-byocni \
             --wait=false \
             --set loadBalancer.l7.backend=envoy \
-            --set tls.secretsBackend=k8s \
+            --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+            --set=tls.secretSync.enabled=true \
             --set bpf.monitorAggregation=none \
             --set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
 

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -142,7 +142,8 @@ jobs:
             --set bpf.monitorAggregation=none \
             --datapath-mode=tunnel \
             --set loadBalancer.l7.backend=envoy \
-            --set tls.secretsBackend=k8s \
+            --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+            --set=tls.secretSync.enabled=true \
             --set ipam.mode=cluster-pool
 
           # Enable Relay

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -141,7 +141,8 @@ jobs:
             --set cluster.name="${{ env.clusterName }}" \
             --wait=false \
             --set loadBalancer.l7.backend=envoy \
-            --set tls.secretsBackend=k8s \
+            --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+            --set=tls.secretSync.enabled=true \
             --set bpf.monitorAggregation=none
 
           # Enable Relay

--- a/.github/workflows/externalworkloads.yaml
+++ b/.github/workflows/externalworkloads.yaml
@@ -165,7 +165,8 @@ jobs:
             --datapath-mode=tunnel \
             --set kubeProxyReplacement=true \
             --set loadBalancer.l7.backend=envoy \
-            --set tls.secretsBackend=k8s \
+            --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+            --set=tls.secretSync.enabled=true \
             --set ipv4NativeRoutingCIDR="${{ steps.cluster.outputs.cluster_cidr }}"
 
           # Enable Relay

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -140,7 +140,8 @@ jobs:
           --set cluster.name="${{ env.clusterName }}" \
           --set bpf.monitorAggregation=none \
           --set loadBalancer.l7.backend=envoy \
-          --set tls.secretsBackend=k8s \
+          --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+          --set=tls.secretSync.enabled=true \
           --set hubble.eventQueueSize=65536
 
           # Enable Relay

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -65,7 +65,8 @@ jobs:
             --set bpf.monitorAggregation=none \
             --set cni.chainingMode=portmap \
             --set loadBalancer.l7.backend=envoy \
-            --set tls.secretsBackend=k8s \
+            --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+            --set=tls.secretSync.enabled=true \
             --set prometheus.enabled=true \
             --set localRedirectPolicy=true \
             --set socketLB.enabled=true

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -190,7 +190,8 @@ jobs:
             --version "${{ env.cilium_version }}" \
             --context "${{ steps.contexts.outputs.cluster1 }}" \
             --set loadBalancer.l7.backend=envoy \
-            --set tls.secretsBackend=k8s \
+            --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+            --set=tls.secretSync.enabled=true \
             --set cluster.name="${{ env.clusterName1 }}" \
             --set cluster.id=1 \
             --set bpf.monitorAggregation=none \
@@ -209,7 +210,8 @@ jobs:
             --version "${{ env.cilium_version }}" \
             --context "${{ steps.contexts.outputs.cluster2 }}" \
             --set loadBalancer.l7.backend=envoy \
-            --set tls.secretsBackend=k8s \
+            --set=tls.readSecretsOnlyFromSecretsNamespace=true \
+            --set=tls.secretSync.enabled=true \
             --set cluster.name="${{ env.clusterName2 }}" \
             --set cluster.id=2 \
             --set bpf.monitorAggregation=none \


### PR DESCRIPTION
This is a prerequisite for using Cilium 1.17 in CI.

Follow https://github.com/cilium/cilium/pull/37428