### PR TITLE
.github: Pass through GITHUB_WORKFLOW_REF

### DIFF
--- a/.github/tools/cilium.sh
+++ b/.github/tools/cilium.sh
@@ -12,4 +12,5 @@ docker run \
   -v ~/.aws:/root/.aws \
   -v ~/.azure:/root/.azure \
   -v ~/.config/gcloud:/root/.config/gcloud \
+  -e GITHUB_WORKFLOW_REF="$GITHUB_WORKFLOW_REF" \
   "$CILIUM_CLI_IMAGE_REPO":"$CILIUM_CLI_IMAGE_TAG" cilium "$@"


### PR DESCRIPTION
GITHUB_WORKFLOW_REF will be used in future in CI runs via GitHub actions
to identify the workflow where the CLI is running, in order to better
attribute code owners during failures. Pass it through as part of the
GitHub actions scripting.
