### PR TITLE
Always update github.com/cilium/cilium from main

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,32 +58,6 @@
       ],
     },
     {
-      groupName: 'all go dependencies main',
-      groupSlug: 'all-go-deps-main',
-      matchFiles: [
-        'go.mod',
-        'go.sum',
-      ],
-      postUpdateOptions: [
-        // update source import paths on major updates
-        'gomodUpdateImportPaths',
-      ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-        'digest',
-        'patch',
-        'pin',
-        'pinDigest',
-      ],
-      matchBaseBranches: [
-        'main',
-      ],
-      schedule: [
-        'on friday',
-      ],
-    },
-    {
       // Avoid updating patch releases of golang in go.mod
       enabled: 'false',
       matchFileNames: [
@@ -100,13 +74,6 @@
       ],
       matchBaseBranches: [
         'main',
-      ],
-    },
-    {
-      // Allow github.com/cilium/cilium to upgrade to prerelease versions.
-      ignoreUnstable: false,
-      matchPackageNames: [
-        'github.com/cilium/cilium',
       ],
     },
     {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,28 +21,37 @@ used in the commands throughout the documenat to allow copy-pasting.
 
     export RELEASE=v0.17.1
 
-## Update local checkout
+## Create release preparation branch and PR
 
 Update your local checkout to the latest state:
 
     git checkout main
     git pull origin main
 
-### Update the README.md
+Create the release branch:
+
+    git checkout -b pr/prepare-$RELEASE
+
+Update `github.com/cilium/cilium` to the latest version:
+
+    go get github.com/cilium/cilium@main
+    go mod tidy && go mod vendor
+    git add go.mod go.sum vendor
 
 Update the *Releases* section of the `README.md` which lists all currently
 supported releases in a table. The version in this table needs to be updated to
 match the new release `$RELEASE`. Also bump `$RELEASE` in the section above, so
 it can be copy-pasted when preparing the next release.
 
-### Create release preparation branch and open PR
-
-    git checkout -b pr/prepare-$RELEASE
     git add README.md RELEASE.md
     git commit -s -m "Prepare for $RELEASE release"
+
+Push the branch to the upstream repository:
+
     git push origin pr/prepare-$RELEASE
 
-Then open a pull request against `main` branch. Wait for the PR to be reviewed and merged.
+Then open a pull request against `main` branch. Wait for the PR to be reviewed
+and merged.
 
 ## Tag a release
 


### PR DESCRIPTION
Currently, renovate will try to update to the latest patch release, i.e. 1.17.1 at the moment but the stable branches on github.com/cilium/cilium don't contain the cilium-cli/ directory, thus breaking the build on update PRs, see e.g. https://github.com/cilium/cilium-cli/pull/2948

Instead, we should always be vendoring the latest version from main. Drop the renovate configuration accordingly and instead update the github.com/cilium/cilium dependency upon release of a new cilium-cli version.