### PR TITLE
renovate: clean up configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,14 +11,8 @@
   includePaths: [
     '.github/workflows/**',
     'action.yaml',
-    'defaults/defaults.go',
-    'go.mod',
-    'go.sum',
     'Dockerfile',
     'Makefile',
-  ],
-  postUpdateOptions: [
-    'gomodTidy',
   ],
   pinDigests: true,
   ignorePresets: [
@@ -55,25 +49,6 @@
         'patch',
         'pin',
         'pinDigest',
-      ],
-    },
-    {
-      // Avoid updating patch releases of golang in go.mod
-      enabled: 'false',
-      matchFileNames: [
-        'go.mod',
-      ],
-      matchDepNames: [
-        'go',
-      ],
-      matchDatasources: [
-        'golang-version',
-      ],
-      matchUpdateTypes: [
-        'patch',
-      ],
-      matchBaseBranches: [
-        'main',
       ],
     },
     {
@@ -137,15 +112,6 @@
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
       matchStrings: [
         '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = (?<currentValue>.*)\\s+.+_SHA = (?<currentDigest>sha256:[a-f0-9]+)',
-      ],
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^go\\.mod$',
-      ],
-      matchStrings: [
-        '// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)',
       ],
     },
   ],

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/cilium/cilium-cli
 
-// renovate: datasource=golang-version depName=go
 go 1.23.0
 
 // Replace directives from github.com/cilium/cilium. Keep in sync when updating Cilium!


### PR DESCRIPTION
The only direct dependency in go.mod is github.com/cilium/cilium which is updated manually before release (see
https://github.com/cilium/cilium-cli/pull/2951).

The Go version in go.mod is already excluded from being updated by renovate and because there are no other modules to update anymore we can omit go.mod from being updated by renovate altogether.

Also remove some leftover configuration that no longer applies as a result of the merge of cilium-cli into github.com/cilium/cilium.