### PR TITLE
action: Clean up the logic to handle go-mod-directory

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,10 +13,11 @@ inputs:
     default: '*/cilium-cli'
   go-mod-directory:
     description: >
-      Override the directory that contains go.mod when building the Cilium CLI
+      Specify the directory that contains go.mod when building the Cilium CLI
       from the source. By default, This action assumes that go.mod is in the
-      directory specified in the local-path parameter. Set this parameter to '.'
-      if go.mod is in the top-level directory.
+      top-level directory.
+    required: true
+    default: '.'
   binary-dir:
     description: 'Directory to store Cilium CLI executable'
     required: true
@@ -46,22 +47,15 @@ runs:
       run: |
         CLI_PATH=$(find . -iwholename '${{ inputs.local-path }}' -type d -not -path './.git/*' -not -path './vendor/*' | sort | tail -n 1)
         echo path="${CLI_PATH}" >> $GITHUB_OUTPUT
-        if [[ -z "${{ inputs.go-mod-directory }}" ]]; then
-          echo go-mod-path="${CLI_PATH}/go.mod" >> $GITHUB_OUTPUT
-          echo go-sum-path="${CLI_PATH}/go.sum" >> $GITHUB_OUTPUT
-        else
-          echo go-mod-path="${{ inputs.go-mod-directory }}/go.mod" >> $GITHUB_OUTPUT
-          echo go-sum-path="${{ inputs.go-mod-directory }}/go.sum" >> $GITHUB_OUTPUT
-        fi
+        echo go-mod-path="${{ inputs.go-mod-directory }}/go.mod" >> $GITHUB_OUTPUT
 
     - name: Setup Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       if: ${{ steps.build-cli.outputs.path != '' }}
       with:
-        # renovate: datasource=golang-version depName=go
-        go-version: 1.24.0
+        go-version-file: '${{ steps.build-cli.outputs.go-mod-path }}'
         cache: true
-        cache-dependency-path: '${{ steps.build-cli.outputs.go-sum-path }}'
+        cache-dependency-path: '**/go.sum'
 
     - name: Build Cilium CLI from source
       if: ${{ steps.build-cli.outputs.path != '' }}


### PR DESCRIPTION
- Partially revert commit cc1a61d40 [^1] since Cilium updated the Go version to 1.24 in main branch [^2].
- Change the default go-mod-directory to the top-level directory to match the current code structure in cilium/cilium where go.mod file is only in the top-level directory.
- Set setup-go cache-dependency-path parameter to '**/go.sum' so that caching works regardless of how go-mod-directory parameter is set.

[^1]: https://github.com/cilium/cilium-cli/pull/2871
[^2]: https://github.com/cilium/cilium/pull/37852