### PR TITLE
Prepare for v0.18.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ binary releases.
 
 | Release                                                                | Maintained | Compatible Cilium Versions |
 |------------------------------------------------------------------------|------------|----------------------------|
-| [v0.17.0](https://github.com/cilium/cilium-cli/releases/tag/v0.17.0)   | Yes        | Cilium 1.15 and newer      |
+| [v0.18.0](https://github.com/cilium/cilium-cli/releases/tag/v0.18.0)   | Yes        | Cilium 1.15 and newer      |
 
 ## Capabilities
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ table](https://github.com/cilium/cilium-cli#releases) for the most recent suppor
 Set `RELEASE` environment variable to the new version. This variable will be
 used in the commands throughout the documenat to allow copy-pasting.
 
-    export RELEASE=v0.17.1
+    export RELEASE=v0.18.1
 
 ## Create release preparation branch and PR
 


### PR DESCRIPTION
Bumping up the minor version to indicate that there is a behavior change in cilium-cli GitHub Action [^1].

[^1]: https://github.com/cilium/cilium-cli/pull/2956