### PR TITLE
Simplify Dockerfile and clean up docker image workflow

### DIFF
--- a/.github/workflows/aks-byocni.yaml
+++ b/.github/workflows/aks-byocni.yaml
@@ -40,7 +40,6 @@ env:
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.16.8
-  kubectl_version: v1.23.6
 
 jobs:
   installation-and-connectivity:
@@ -51,14 +50,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install kubectl
-        run: |
-          curl -sLO "https://dl.k8s.io/release/${{ env.kubectl_version }}/bin/linux/amd64/kubectl"
-          curl -sLO "https://dl.k8s.io/${{ env.kubectl_version }}/bin/linux/amd64/kubectl.sha256"
-          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-          kubectl version --client
 
       - name: Login to Azure
         uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
@@ -127,11 +118,18 @@ jobs:
             --resource-group ${{ steps.vars.outputs.name }} \
             --name ${{ steps.vars.outputs.name }}
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: cilium/cilium/.github/actions/get-cloud-kubeconfig@0abd5b89da23b808820baea119314b9b416bdf2a
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: ./
         with:
           skip-build: 'true'
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Run test
         run: |

--- a/.github/workflows/eks-tunnel.yaml
+++ b/.github/workflows/eks-tunnel.yaml
@@ -30,7 +30,6 @@ env:
   eksctl_version: v0.147.0
   # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.16.8
-  kubectl_version: v1.23.6
 
 jobs:
   installation-and-connectivity:
@@ -48,14 +47,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install kubectl
-        run: |
-          curl -sLO "https://dl.k8s.io/release/${{ env.kubectl_version }}/bin/linux/amd64/kubectl"
-          curl -sLO "https://dl.k8s.io/${{ env.kubectl_version }}/bin/linux/amd64/kubectl.sha256"
-          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-          kubectl version --client
 
       - name: Install eksctl CLI
         run: |
@@ -125,11 +116,18 @@ jobs:
 
           eksctl create cluster -f ./eks-config.yaml
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: cilium/cilium/.github/actions/get-cloud-kubeconfig@0abd5b89da23b808820baea119314b9b416bdf2a
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: ./
         with:
           skip-build: 'true'
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Install Cilium and run tests
         timeout-minutes: 30

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -30,7 +30,6 @@ env:
   eksctl_version: v0.147.0
   # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.16.8
-  kubectl_version: v1.23.6
 
 jobs:
   installation-and-connectivity:
@@ -48,14 +47,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install kubectl
-        run: |
-          curl -sLO "https://dl.k8s.io/release/${{ env.kubectl_version }}/bin/linux/amd64/kubectl"
-          curl -sLO "https://dl.k8s.io/${{ env.kubectl_version }}/bin/linux/amd64/kubectl.sha256"
-          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-          kubectl version --client
 
       - name: Install eksctl CLI
         run: |
@@ -126,11 +117,18 @@ jobs:
 
           eksctl create cluster -f ./eks-config.yaml
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: cilium/cilium/.github/actions/get-cloud-kubeconfig@0abd5b89da23b808820baea119314b9b416bdf2a
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: ./
         with:
           skip-build: 'true'
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Install Cilium and run tests
         timeout-minutes: 30

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -37,7 +37,6 @@ env:
   zone: us-west2-a
   # renovate: datasource=github-releases depName=cilium/cilium
   cilium_version: v1.16.8
-  kubectl_version: v1.23.6
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:
@@ -53,14 +52,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install kubectl
-        run: |
-          curl -sLO "https://dl.k8s.io/release/${{ env.kubectl_version }}/bin/linux/amd64/kubectl"
-          curl -sLO "https://dl.k8s.io/${{ env.kubectl_version }}/bin/linux/amd64/kubectl.sha256"
-          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-          kubectl version --client
 
       - name: Set up gcloud credentials
         id: 'auth'
@@ -127,11 +118,18 @@ jobs:
         run: |
           gcloud container clusters get-credentials ${{ env.clusterName }} --zone ${{ env.zone }}
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: cilium/cilium/.github/actions/get-cloud-kubeconfig@0abd5b89da23b808820baea119314b9b416bdf2a
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: ./
         with:
           skip-build: 'true'
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Run test
         run: |
@@ -142,7 +140,8 @@ jobs:
           --set loadBalancer.l7.backend=envoy \
           --set=tls.readSecretsOnlyFromSecretsNamespace=true \
           --set=tls.secretSync.enabled=true \
-          --set hubble.eventQueueSize=65536
+          --set hubble.eventQueueSize=65536 \
+          --set ipv4NativeRoutingCIDR=${{ steps.cluster.outputs.cluster_cidr }}
 
           # Enable Relay
           cilium hubble enable

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -20,20 +20,23 @@ concurrency:
 jobs:
   build-and-push-prs:
     if: ${{ github.repository == 'cilium/cilium-cli' }}
-    environment: ci
+    environment: ${{ github.ref_type == 'tag' && 'release' || 'ci' }}
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - name: cilium-cli-ci
-            dockerfile: ./Dockerfile
-            platforms: linux/amd64
 
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Login to quay.io for release
+        if: ${{ github.ref_type == 'tag' }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RELEASE_USERNAME }}
+          password: ${{ secrets.QUAY_RELEASE_TOKEN }}
+
       - name: Login to quay.io for CI
+        if: ${{ github.ref_type != 'tag' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: quay.io
@@ -45,10 +48,14 @@ jobs:
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
             echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "repo_tags=quay.io/${{ github.repository_owner }}/cilium-cli-ci:${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref_type }}" == "tag" ]; then
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "repo_tags=quay.io/${{ github.repository_owner }}/cilium-cli:latest,quay.io/${{ github.repository_owner }}/cilium-cli:${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "repo=cilium-cli-ci" >> $GITHUB_OUTPUT
+            echo "repo_tags=quay.io/${{ github.repository_owner }}/cilium-cli-ci:latest,quay.io/${{ github.repository_owner }}/cilium-cli-ci:${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout Source Code
@@ -56,77 +63,11 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
-      # main branch or tag pushes
-      - name: CI Build ${{ matrix.name }}
-        if: ${{ github.event_name != 'pull_request_target' }}
+      - name: Docker Build
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        id: docker_build_ci_main
+        id: docker_build
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.name }}
-          platforms: ${{ matrix.platforms }}
+          platforms: linux/arm64,linux/amd64
           push: true
-          tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-
-      - name: CI Image Releases digests
-        if: ${{ github.event_name != 'pull_request_target' }}
-        shell: bash
-        run: |
-          mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}:latest@${{ steps.docker_build_ci_main.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_main.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
-
-      # PR updates
-      - name: CI Build ${{ matrix.name }}
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        id: docker_build_ci_pr
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.name }}
-          platforms: ${{ matrix.platforms }}
-          push: true
-          tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-
-      - name: CI Image Releases digests
-        if: ${{ github.event_name == 'pull_request_target' }}
-        shell: bash
-        run: |
-          mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
-
-      # Upload artifact digests
-      - name: Upload artifact digests
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: image-digest ${{ matrix.name }}
-          path: image-digest
-          retention-days: 1
-
-  image-digests:
-    if: ${{ github.repository == 'cilium/cilium-cli' }}
-    name: Display Digests
-    runs-on: ubuntu-24.04
-    needs: [build-and-push-prs]
-    steps:
-      - name: Downloading Image Digests
-        shell: bash
-        run: |
-          mkdir -p image-digest/
-
-      - name: Download digests of all images built
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-        with:
-          path: image-digest/
-          pattern: "*image-digest *"
-
-      - name: Image Digests Output
-        shell: bash
-        run: |
-          cd image-digest/
-          find -type f | sort | xargs -d '\n' cat
+          tags: ${{ steps.tag.outputs.repo_tags }}


### PR DESCRIPTION
- Make the same change as https://github.com/cilium/cilium/pull/37970 to remove cloud provider CLIs. This way we can use the same Dockerfile for CI and releases.
- Get rid of the step to install kubectl. Let's just use the one that comes in the actions runner.
- Clean up images.yaml workflow a bit. Remove the steps for generating image digest files since we don't currently use them.
- Handle the release environment so that images get pushed to the release repo quay.io/cilium/cilium-cli on tag pushes.