### PR TITLE
action: Add kubeconfig-mount-path input

### DIFF
--- a/.github/tools/cilium.sh
+++ b/.github/tools/cilium.sh
@@ -5,13 +5,11 @@ set -ex
 CILIUM_CLI_IMAGE_REPO=${CILIUM_CLI_IMAGE_REPO:-quay.io/cilium/cilium-cli-ci}
 CILIUM_CLI_IMAGE_TAG=${CILIUM_CLI_IMAGE_TAG:-latest}
 KUBECONFIG=${KUBECONFIG:-~/.kube/config}
+KUBECONFIG_MOUNT_PATH=${KUBECONFIG_MOUNT_PATH:-/root/.kube/config}
 
 docker run \
   --network host \
-  -v "$KUBECONFIG":/root/.kube/config \
+  -v "$KUBECONFIG":"$KUBECONFIG_MOUNT_PATH" \
   -v "$(pwd)":/root/app \
-  -v ~/.aws:/root/.aws \
-  -v ~/.azure:/root/.azure \
-  -v ~/.config/gcloud:/root/.config/gcloud \
   -e GITHUB_WORKFLOW_REF="$GITHUB_WORKFLOW_REF" \
   "$CILIUM_CLI_IMAGE_REPO":"$CILIUM_CLI_IMAGE_TAG" cilium "$@"

--- a/action.yaml
+++ b/action.yaml
@@ -41,6 +41,9 @@ inputs:
     description: >
       Kubeconfig to be used by cilium-cli in docker
     default: '~/.kube/config'
+  kubeconfig-mount-path:
+    description: 'Path to mount kubeconfig inside the cilium-cli container'
+    default: '/root/.kube/config'
 runs:
   using: "composite"
   steps:
@@ -118,6 +121,7 @@ runs:
         export CILIUM_CLI_IMAGE_REPO=${{ inputs.image-repo }}
         export CILIUM_CLI_IMAGE_TAG=${{ inputs.image-tag }}
         export KUBECONFIG=${{ inputs.kubeconfig }}
+        export KUBECONFIG_MOUNT_PATH=${{ inputs.kubeconfig-mount-path }}
         cat ${{ github.action_path }}/.github/tools/cilium.sh | envsubst > /tmp/cilium
         sudo install /tmp/cilium ${{ inputs.binary-dir }}/${{ inputs.binary-name }}
 


### PR DESCRIPTION
Parameterize the mount path for kubeconfig to make it easier to migrate to distroless nonroot image. Also delete unused volume mounts.