### PR TITLE
Dockerfile: do not specify syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.15@sha256:9857836c9ee4268391bb5b09f9f157f3c91bb15821bb77969642813b0d00518d
-
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
We no longer use the syntax directive in Cilium upstream Dockerfile, they were removed by commit cilium/cilium@005f900c4060 ("docker: Do not specify syntax"). Drop it in the cilium-cli Dockerfile as well and avoid noisy renovatebot PRs updating the synatx version.