### PR TITLE
renovate: try to group dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,9 +18,13 @@
   ignorePresets: [
     ':prHourlyLimit2',
   ],
-  separateMajorMinor: true,
+  // We don't want to separate major and minor upgrades in separate PRs since
+  // we can upgrade them together in a single PR.
+  separateMajorMinor: false,
+  // We don't want to separate minor patch upgrades in separate PRs since
+  // we can upgrade them together in a single PR.
+  separateMinorPatch: false,
   separateMultipleMajor: true,
-  separateMinorPatch: true,
   pruneStaleBranches: true,
   baseBranches: [
     'main',
@@ -49,14 +53,6 @@
         'patch',
         'pin',
         'pinDigest',
-      ],
-    },
-    {
-      // Images that directly use docker.io/library/golang for building.
-      groupName: 'golang-images',
-      matchFileNames: [
-        'Dockerfile',
-        'Makefile',
       ],
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TEST_TIMEOUT ?= 5s
 RELEASE_UID ?= $(shell id -u)
 RELEASE_GID ?= $(shell id -g)
 
-# renovate: datasource=docker depName=go
+# renovate: datasource=docker depName=golang
 GO_IMAGE_VERSION = 1.25.3-alpine3.21
 GO_IMAGE_SHA = sha256:0c9f3e09a50a6c11714dbc37a6134fd0c474690030ed07d23a61755afd3a812f
 


### PR DESCRIPTION
Don't separate updates and remove grouping for golang-images. This should hopefully lead to a single PR per Go update (as was the intention in commit fd4c98b82a42 ("Makefile: fix renovate depname for GO_IMAGE_* updates").

Also revert the referenced commit since it caused the Go version in the Makefile no longer being updated:

    Renovate failed to look up the following dependencies: Failed to look up docker package go.
    Files affected: Makefile

It should now be covered by to Go group.