### PR TITLE
doc: fixed latest binary installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ BINDIR=~/.local/bin make install
 
 Alternatively, to install the latest binary release:
 
+### linux
+
 ```
 CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
 CLI_ARCH=amd64
@@ -28,6 +30,18 @@ curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/d
 sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
 sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
 rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+```
+
+### macOS
+
+```
+CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
+CLI_ARCH=amd64
+if [ "$(uname -m)" = "arm64" ]; then CLI_ARCH=arm64; fi
+curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}
+shasum -a 256 -c cilium-darwin-${CLI_ARCH}.tar.gz.sha256sum
+sudo tar xzvfC cilium-darwin-${CLI_ARCH}.tar.gz /usr/local/bin
+rm cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}
 ```
 
 See https://github.com/cilium/cilium-cli/releases for supported `GOOS`/`GOARCH`


### PR DESCRIPTION
The one here was causing this error
```bash
❯ sha256sum --check cilium-${GOOS}-${GOARCH}.tar.gz.sha256sum
sha256sum: cilium--.tar.gz.sha256sum: no properly formatted SHA256 checksum lines found

❯ sudo tar -C /usr/local/bin -xzvf cilium-${GOOS}-${GOARCH}.tar.gz
rm cilium-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting no
```

replaced with the one from the docs, which works