### PR TITLE
ci: add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,14 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: read
+
 name: Release
 
 jobs:
   build:
-    name: Create Release ${{ github.event_name == 'pull_request' && '(dry-run)' }}
+    name: Build Release Artifacts
     if: github.repository == 'cilium/cilium-cli'
     runs-on: ubuntu-24.04
     steps:
@@ -28,8 +31,28 @@ jobs:
       - name: Generate the artifacts
         run: make release
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-artifacts
+          path: release/*
+          retention-days: 1
+
+  release:
+    name: Create Release
+    if: github.repository == 'cilium/cilium-cli' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts
+          path: release
+
       - name: Create Release
-        if: github.event_name == 'push'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This allows the release workflow to create releases. Otherwise it will fail with:

    Creating new GitHub release for tag v0.19.3...
    GitHub release failed with status: 403
    {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release","status":"403"}

as seen on https://github.com/cilium/cilium-cli/actions/runs/25797138861/job/75777197322