### PR TITLE
renovate: add dependency cooldown, don't pin digests for cilium/cilium GitHub actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,6 +45,12 @@
       minimumReleaseAge: "5 days"
     },
     {
+      // Do not pin digests for cilium/cilium GitHub actions and reusable workflows.
+      matchManagers: [ "github-actions" ],
+      matchPackageNames: [ "cilium/cilium" ],
+      pinDigests: false
+    },
+    {
       groupName: 'all github action dependencies',
       groupSlug: 'all-github-action',
       matchFileNames: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,11 @@
   stopUpdatingLabel: 'renovate/stop-updating',
   packageRules: [
     {
+      // Dependency cooldown: skip versions published less than 5 days ago
+      matchUpdateTypes: ["major", "minor", "patch"],
+      minimumReleaseAge: "5 days"
+    },
+    {
       groupName: 'all github action dependencies',
       groupSlug: 'all-github-action',
       matchFileNames: [


### PR DESCRIPTION
Follow corresponding cilium/cilium upstream changes.

See commits for details.