### PR TITLE
ci: pin cilium/cilium actions to v1.19.4, avoid digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,10 +45,12 @@
       minimumReleaseAge: "5 days"
     },
     {
-      // Do not pin digests for cilium/cilium GitHub actions and reusable workflows.
+      // Do not update digests for cilium/cilium GitHub actions and reusable workflows.
+      // Version updates are handled by the cilium group rule below.
       matchManagers: [ "github-actions" ],
       matchPackageNames: [ "cilium/cilium" ],
-      pinDigests: false
+      matchUpdateTypes: [ "digest", "pinDigest" ],
+      enabled: false
     },
     {
       groupName: 'all github action dependencies',

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 50
     steps:
       - name: Cleanup Disk space in runner
-        uses: cilium/cilium/.github/actions/disk-cleanup@b72d04bf22d6426f8194356d9bc3f785339a11b7 # main
+        uses: cilium/cilium/.github/actions/disk-cleanup@95e477fdcfd35d438b135f4d981ee20ce3016ac3 # v1.19.4
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: Cleanup Disk space in runner
-        uses: cilium/cilium/.github/actions/disk-cleanup@b72d04bf22d6426f8194356d9bc3f785339a11b7 # main
+        uses: cilium/cilium/.github/actions/disk-cleanup@95e477fdcfd35d438b135f4d981ee20ce3016ac3 # v1.19.4
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Cleanup Disk space in runner
-        uses: cilium/cilium/.github/actions/disk-cleanup@b72d04bf22d6426f8194356d9bc3f785339a11b7 # main
+        uses: cilium/cilium/.github/actions/disk-cleanup@95e477fdcfd35d438b135f4d981ee20ce3016ac3 # v1.19.4
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Commit d46dbc7de48d ("renovate: do not pin digests for cilium/cilium GitHub actions") changed the renovate config to avoid bumping digests for cilium/cilium GitHub actions. However, this did not work as intended[^1]. Instead, pin the action to a stable branch matching cilium_version in the action, so renovate would track it as a version update rather than a digest update and it would be grouped with the existing cilium package rule.

[^1]: https://github.com/cilium/cilium-cli/pull/3239#pullrequestreview-4327107625

Also do not let renvoate update digests for cilium/cilium GitHub actions. Version updates are handled by the renovate config cilium group.