### PR TITLE
go.mod, vendor: update replace directives to match cilium's go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,15 @@ module github.com/cilium/cilium-cli
 go 1.26.0
 
 // Replace directives from github.com/cilium/cilium. Keep in sync when updating Cilium!
-// Copied from https://github.com/cilium/cilium/blob/v1.19.0-pre.3/go.mod#L331-L337
+// Copied from https://github.com/cilium/cilium/blob/99375b2ef599f3cd9082aef88972bbfa124b2ead/go.mod#L338-L344
 
 // Using private fork of controller-tools. See commit msg for more context
 // as to why we are using a private fork.
-replace sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
+replace sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.21.0-1
 
 // Using private fork of gobgp. See commit msg for more context as to why we
 // are using a private fork.
-replace github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
+replace github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6
 
 require github.com/cilium/cilium v1.20.0-pre.2.0.20260520131253-99375b2ef599
 

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/cilium/cilium v1.20.0-pre.2.0.20260520131253-99375b2ef599 h1:beJbk2xS
 github.com/cilium/cilium v1.20.0-pre.2.0.20260520131253-99375b2ef599/go.mod h1:uwy7wd4QE0azIYogQjMa2kV5SxPMzfFzDnZJKTwP3Mk=
 github.com/cilium/ebpf v0.21.0 h1:4dpx1J/B/1apeTmWBH5BkVLayHTkFrMovVPnHEk+l3k=
 github.com/cilium/ebpf v0.21.0/go.mod h1:1kHKv6Kvh5a6TePP5vvvoMa1bclRyzUXELSs272fmIQ=
-github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674 h1:RPXlDz/YCj2qscehc5oVFwHgUTDQGYHIgTxlN65F8R8=
-github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
+github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6 h1:JiuFG0n56b113TIYlP5Hdj+F2egjK3kZsskF3RQ5hBE=
+github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
 github.com/cilium/hive v1.0.1 h1:5PZpis3yw1ywfTnDVQ8AB7k/esVVeoE0cnWVyZDCxE0=
 github.com/cilium/hive v1.0.1/go.mod h1:NY1wD3TQ4sya7zkhkB4QX6eIZ4FjwZPG+lnUB2IH5Xs=
 github.com/cilium/proxy v0.0.0-20260508102643-7c2f6580d32e h1:cYDQ14gFlagSSdv/bGvorajxP6LLQON2P8O55f8yZDM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -979,7 +979,7 @@ github.com/opencontainers/go-digest
 ## explicit; go 1.18
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/osrg/gobgp/v3 v3.37.0 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
+# github.com/osrg/gobgp/v3 v3.37.0 => github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6
 ## explicit; go 1.23.0
 github.com/osrg/gobgp/v3/pkg/packet/bgp
 # github.com/pelletier/go-toml v1.9.5
@@ -2119,5 +2119,5 @@ sigs.k8s.io/structured-merge-diff/v6/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
 sigs.k8s.io/yaml/kyaml
-# sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
-# github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
+# sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.21.0-1
+# github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6


### PR DESCRIPTION
Update the replace directives to match the version in the go.mod of github.com/cilium/cilium at the version currently used, see https://github.com/cilium/cilium/blob/99375b2ef599f3cd9082aef88972bbfa124b2ead/go.mod#L338-L344