### PR TITLE
ci: fix unquoted expression in images-dev shell condition

### DIFF
--- a/.github/workflows/images-dev.yaml
+++ b/.github/workflows/images-dev.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
+          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
             echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
             echo "repo_tags=quay.io/${{ github.repository_owner }}/cilium-cli-ci:${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
In `images-dev.yaml`, the "Getting image tag" step does:

```bash
if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
```

On push-to-main events `github.event.pull_request.head.sha` is empty, so bash sees `[ != "" ]` and spits out `[: !=: unary operator expected` every single time. CI doesn't break (the `if` condition evaluates false, so the else branch runs correctly), but the error is noisy in the logs.

Fix: wrap the expression in quotes so bash sees `[ "" != "" ]` instead.

**Reproduce:** check any recent run of the `Dev Image CI Build` workflow triggered by a push to main - the "Getting image tag" step log will have the error.