### PR TITLE
ci: fix unquoted expression in images-dev shell condition

### DIFF
--- a/.github/workflows/images-dev.yaml
+++ b/.github/workflows/images-dev.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
+          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
             echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
             echo "repo_tags=quay.io/${{ github.repository_owner }}/cilium-cli-ci:${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
`images-dev.yaml` "Getting image tag" step runs this on push-to-main events:

    if [ ${{ github.event.pull_request.head.sha }} != "" ]; then

`github.event.pull_request.head.sha` is empty on push events, so bash sees `[ != "" ]` and logs `[: !=: unary operator expected` on every merge to main. CI still passes (else branch runs fine), but the error shows up in every run.

Fix: quote the expression so bash sees `[ "" != "" ]` instead.

To reproduce: check the "Getting image tag" step in any `Dev Image CI Build` run triggered by a push to main.