### PR TITLE
docs: support macOS checksum verification in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
-sha256sum --check cilium-${GOOS}-${GOARCH}.tar.gz.sha256sum
+if [ "${GOOS}" = "darwin" ]; then
+  shasum -a 256 -c cilium-${GOOS}-${GOARCH}.tar.gz.sha256sum
+else
+  sha256sum --check cilium-${GOOS}-${GOARCH}.tar.gz.sha256sum
+fi
 sudo tar -C /usr/local/bin -xzvf cilium-${GOOS}-${GOARCH}.tar.gz
 rm cilium-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
 ```


### PR DESCRIPTION
Problem
The README install snippet uses `sha256sum --check` for every OS.
On a regular Mac that command is missing, so the install falls over there.

Fix
Use `shasum -a 256 -c` when `GOOS=darwin`, keep `sha256sum --check` elsewhere.

Repro
1. On macOS, run the README install snippet.
2. It downloads `cilium-darwin-*.tar.gz` just fine.
3. The checksum step fails because `sha256sum` is not there.

Related: #3087, #3007.