### PR TITLE
README.md: Update compatible Cilium versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ binary releases.
 
 | Release                                                              | Maintained | Compatible Cilium Versions |
 |----------------------------------------------------------------------|------------|----------------------------|
-| [v0.19.7](https://github.com/cilium/cilium-cli/releases/tag/v0.19.7) | Yes        | Cilium 1.16 and newer      |
+| [v0.19.7](https://github.com/cilium/cilium-cli/releases/tag/v0.19.7) | Yes        | Cilium 1.17 and newer      |
 
 ## Capabilities
 


### PR DESCRIPTION
Cilium 1.20 has been released [^1].

[^1]: https://github.com/cilium/cilium/releases/tag/v1.20.0